### PR TITLE
Edge-to-edge support

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetDialog.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetDialog.kt
@@ -22,6 +22,10 @@ class TrueSheetDialog(private val reactContext: ThemedReactContext, private val 
   private var sheetView: ViewGroup
   private var windowAnimation: Int = 0
 
+  override fun getEdgeToEdgeEnabled(): Boolean {
+    return if (Utils.EDGE_TO_EDGE) true else super.getEdgeToEdgeEnabled()
+  }
+
   /**
    * Specify whether the sheet background is dimmed.
    * Set to `false` to allow interaction with the background components.

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetDialog.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetDialog.kt
@@ -22,10 +22,6 @@ class TrueSheetDialog(private val reactContext: ThemedReactContext, private val 
   private var sheetView: ViewGroup
   private var windowAnimation: Int = 0
 
-  override fun getEdgeToEdgeEnabled(): Boolean {
-    return if (Utils.EDGE_TO_EDGE) true else super.getEdgeToEdgeEnabled()
-  }
-
   /**
    * Specify whether the sheet background is dimmed.
    * Set to `false` to allow interaction with the background components.
@@ -72,6 +68,25 @@ class TrueSheetDialog(private val reactContext: ThemedReactContext, private val 
 
     // Update the usable sheet height
     maxScreenHeight = Utils.screenHeight(reactContext)
+  }
+
+  override fun getEdgeToEdgeEnabled(): Boolean {
+    return if (Utils.EDGE_TO_EDGE) true else super.getEdgeToEdgeEnabled()
+  }
+
+  override fun onStart() {
+    super.onStart()
+
+    if (Utils.EDGE_TO_EDGE) {
+      window?.apply {
+        setFlags(
+          WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+          WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+        )
+
+        decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+      }
+    }
   }
 
   /**

--- a/android/src/main/java/com/lodev09/truesheet/core/Utils.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/Utils.kt
@@ -11,6 +11,14 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.PixelUtil
 
 object Utils {
+  // Detect `react-native-edge-to-edge` (https://github.com/zoontek/react-native-edge-to-edge)
+  val EDGE_TO_EDGE = try {
+    Class.forName("com.zoontek.rnedgetoedge.EdgeToEdgePackage")
+    true
+  } catch (exception: ClassNotFoundException) {
+    false
+  }
+
   @SuppressLint("DiscouragedApi")
   private fun getIdentifierHeight(context: ReactContext, name: String): Int =
     context.resources.getDimensionPixelSize(
@@ -29,6 +37,11 @@ object Utils {
     }
 
     val screenHeight = displayMetrics.heightPixels
+
+    if (EDGE_TO_EDGE) {
+      return screenHeight
+    }
+
     val statusBarHeight = getIdentifierHeight(context, "status_bar_height")
     val hasNavigationBar = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
       context.getSystemService(WindowManager::class.java)

--- a/android/src/main/java/com/lodev09/truesheet/core/Utils.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/Utils.kt
@@ -54,16 +54,16 @@ object Utils {
       0
     }
 
-    if (EDGE_TO_EDGE) {
+    return if (EDGE_TO_EDGE) {
       // getRealMetrics includes navigation bar height
       // windowManager.defaultDisplay.getMetrics isn't
-      return when (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      when (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         true -> screenHeight
         false -> screenHeight + navigationBarHeight
       }
+    } else {
+      screenHeight - statusBarHeight - navigationBarHeight
     }
-
-    return screenHeight - statusBarHeight - navigationBarHeight
   }
 
   fun toDIP(value: Int): Float = PixelUtil.toDIPFromPixel(value.toFloat())

--- a/android/src/main/java/com/lodev09/truesheet/core/Utils.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/Utils.kt
@@ -38,10 +38,6 @@ object Utils {
 
     val screenHeight = displayMetrics.heightPixels
 
-    if (EDGE_TO_EDGE) {
-      return screenHeight
-    }
-
     val statusBarHeight = getIdentifierHeight(context, "status_bar_height")
     val hasNavigationBar = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
       context.getSystemService(WindowManager::class.java)
@@ -56,6 +52,15 @@ object Utils {
       getIdentifierHeight(context, "navigation_bar_height")
     } else {
       0
+    }
+
+    if (EDGE_TO_EDGE) {
+      // getRealMetrics includes navigation bar height
+      // windowManager.defaultDisplay.getMetrics isn't
+      return when (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        true -> screenHeight
+        false -> screenHeight + navigationBarHeight
+      }
     }
 
     return screenHeight - statusBarHeight - navigationBarHeight


### PR DESCRIPTION
@lodev09 Hi 👋

Following https://github.com/lodev09/react-native-true-sheet/issues/72

I had to use `decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION` to ignore insets applied on the `BottomSheetDialog` internal `bottomSheet` `FrameLayout` ([related issue](https://github.com/material-components/material-components-android/issues/3389)). The alternative would be to fork and remove all the things we don't want, but…meh 😄.

Tested on Android 6 to 15

https://github.com/user-attachments/assets/629995a6-07c6-4736-9bd9-9f4f5294df60

