### PR TITLE
fix(iOS): null checks in getTrueSheetView

### DIFF
--- a/ios/TrueSheetViewManager.swift
+++ b/ios/TrueSheetViewManager.swift
@@ -24,9 +24,11 @@ class TrueSheetViewManager: RCTViewManager {
 
   // MARK: - Private
 
-  private func getTrueSheetView(_ tag: NSNumber) -> TrueSheetView {
+  private func getTrueSheetView(_ tag: NSNumber) -> TrueSheetView? {
+    guard let uiManager = bridge?.uiManager else { return nil }
+    guard let viewForTag = uiManager.view(forReactTag: tag) else { return nil }
     // swiftlint:disable force_cast
-    return bridge.uiManager.view(forReactTag: tag) as! TrueSheetView
+    return viewForTag as! TrueSheetView
     // swiftlint:enable force_cast
   }
 
@@ -35,12 +37,12 @@ class TrueSheetViewManager: RCTViewManager {
   @objc
   func present(_ tag: NSNumber, index: Int, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
     let trueSheetView = getTrueSheetView(tag)
-    trueSheetView.present(at: index, promise: Promise(resolver: resolve, rejecter: reject))
+    trueSheetView?.present(at: index, promise: Promise(resolver: resolve, rejecter: reject))
   }
 
   @objc
   func dismiss(_ tag: NSNumber, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
     let trueSheetView = getTrueSheetView(tag)
-    trueSheetView.dismiss(promise: Promise(resolver: resolve, rejecter: reject))
+    trueSheetView?.dismiss(promise: Promise(resolver: resolve, rejecter: reject))
   }
 }


### PR DESCRIPTION
Similarly to https://github.com/lodev09/react-native-true-sheet/pull/35

This PR fixes a crash in onDismiss caused by nil values during app reloads in release builds. Both bridge and the view can be null and this is now handled in `getTrueSheetView`. In our case it looks like there is a race condition and `onDismiss` was called on a non existent sheet.