### PR TITLE
fix(android): support react native 0.77

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -107,6 +107,9 @@ class TrueSheetViewManager : ViewGroupManager<TrueSheetView>() {
     for (i in 0 until minOf(sizes.size(), 3)) {
       when (sizes.getType(i)) {
         ReadableType.Number -> result.add(sizes.getDouble(i))
+        // React Native < 0.77 used String for getString, but 0.77
+        // changed it to String?. Suppress the error for older APIs.
+        @Suppress("UNNECESSARY_SAFE_CALL")
         ReadableType.String -> sizes.getString(i)?.let { result.add(it) }
         else -> Log.d(TAG, "Invalid type")
       }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -107,7 +107,7 @@ class TrueSheetViewManager : ViewGroupManager<TrueSheetView>() {
     for (i in 0 until minOf(sizes.size(), 3)) {
       when (sizes.getType(i)) {
         ReadableType.Number -> result.add(sizes.getDouble(i))
-        ReadableType.String -> result.add(sizes.getString(i) as String)
+        ReadableType.String -> sizes.getString(i)?.let { result.add(it) }
         else -> Log.d(TAG, "Invalid type")
       }
     }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -107,7 +107,7 @@ class TrueSheetViewManager : ViewGroupManager<TrueSheetView>() {
     for (i in 0 until minOf(sizes.size(), 3)) {
       when (sizes.getType(i)) {
         ReadableType.Number -> result.add(sizes.getDouble(i))
-        ReadableType.String -> result.add(sizes.getString(i))
+        ReadableType.String -> result.add(sizes.getString(i) as String)
         else -> Log.d(TAG, "Invalid type")
       }
     }


### PR DESCRIPTION
Thanks for this great library!

Due to [this change in React Native core](https://github.com/facebook/react-native/commit/145c72f8163048f0eee30d5ce850911f5dad865c#diff-cab6c32d3e05344091c804ea93e8a220dabdd75ec2a258aaf4bde7751c13f844R31) `getString` now returns `String?`. Since the `when` condition checks that the current value is a string, I think it's fine to type cast the result as a `String`. I tested it locally and it resolves the error.

Alternatively, we could go the route of only adding the value if it exists using:

```kotlin
	ReadableType.String -> sizes.getString(i)?.let { result.add(it) }
```