### PR TITLE
feat: add `dimmedAlpha` prop on iOS

### DIFF
--- a/ios/TrueSheetView.swift
+++ b/ios/TrueSheetView.swift
@@ -211,19 +211,22 @@ class TrueSheetView: UIView, RCTInvalidating, TrueSheetViewControllerDelegate {
   }
 
   func viewControllerDidAppear() {
-    // Add this sheet's opacity to the stack
-    TrueSheetView.sheetOpacityStack.append(dimmedAlpha)
-
-    // Dim root view controller
-    UIView.animate(withDuration: 0.3) {
-      if let rootViewController = UIApplication.shared.windows.first?.rootViewController {
-        rootViewController.view.alpha = self.dimmedAlpha
+    // Only apply dimming if the sheet has dimmed property set to true
+    if viewController.dimmed {
+      // Add this sheet's opacity to the stack
+      TrueSheetView.sheetOpacityStack.append(dimmedAlpha)
+      
+      // Dim root view controller
+      UIView.animate(withDuration: 0.3) {
+        if let rootViewController = UIApplication.shared.windows.first?.rootViewController {
+          rootViewController.view.alpha = self.dimmedAlpha
+        }
       }
     }
   }
 
   func viewControllerWillDisappear() {
-    if viewController.isBeingDismissed {
+    if viewController.isBeingDismissed && viewController.dimmed {
       // Remove the topmost opacity value (which should be this sheet's)
       if !TrueSheetView.sheetOpacityStack.isEmpty {
         TrueSheetView.sheetOpacityStack.removeLast()

--- a/ios/TrueSheetView.swift
+++ b/ios/TrueSheetView.swift
@@ -25,6 +25,7 @@ class TrueSheetView: UIView, RCTInvalidating, TrueSheetViewControllerDelegate {
 
   @objc var initialIndex: NSNumber = -1
   @objc var initialIndexAnimated = true
+  @objc var dimmedAlpha: CGFloat = 0.75
 
   // MARK: - Private properties
 
@@ -202,6 +203,18 @@ class TrueSheetView: UIView, RCTInvalidating, TrueSheetViewControllerDelegate {
     // Add constraints to fix weirdness and support ScrollView
     contentView.pinTo(view: containerView, constraints: nil)
     scrollView.pinTo(view: contentView, constraints: nil)
+
+    if viewController.dimmed {
+      UIView.animate(withDuration: 0.3) {
+        self.viewController.presentingViewController?.view.alpha = self.dimmedAlpha
+      }
+    }
+  }
+
+  func viewControllerWillDisappear() {
+    UIView.animate(withDuration: 0.3) {
+      self.viewController.presentingViewController?.view.alpha = 1
+    }
   }
 
   func viewControllerDidDismiss() {

--- a/ios/TrueSheetViewController.swift
+++ b/ios/TrueSheetViewController.swift
@@ -20,6 +20,7 @@ protocol TrueSheetViewControllerDelegate: AnyObject {
   func viewControllerDidDismiss()
   func viewControllerDidChangeSize(_ sizeInfo: SizeInfo?)
   func viewControllerWillAppear()
+  func viewControllerDidAppear()
   func viewControllerWillDisappear()
   func viewControllerKeyboardWillShow(_ keyboardHeight: CGFloat)
   func viewControllerKeyboardWillHide()
@@ -143,6 +144,11 @@ class TrueSheetViewController: UIViewController, UISheetPresentationControllerDe
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     delegate?.viewControllerWillAppear()
+  }
+
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    delegate?.viewControllerDidAppear()
   }
 
   override func viewWillDisappear(_ animated: Bool) {

--- a/ios/TrueSheetViewController.swift
+++ b/ios/TrueSheetViewController.swift
@@ -20,6 +20,7 @@ protocol TrueSheetViewControllerDelegate: AnyObject {
   func viewControllerDidDismiss()
   func viewControllerDidChangeSize(_ sizeInfo: SizeInfo?)
   func viewControllerWillAppear()
+  func viewControllerWillDisappear()
   func viewControllerKeyboardWillShow(_ keyboardHeight: CGFloat)
   func viewControllerKeyboardWillHide()
   func viewControllerDidDrag(_ state: UIPanGestureRecognizer.State, _ height: CGFloat)
@@ -142,6 +143,11 @@ class TrueSheetViewController: UIViewController, UISheetPresentationControllerDe
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     delegate?.viewControllerWillAppear()
+  }
+
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    delegate?.viewControllerWillDisappear()
   }
 
   override func viewDidDisappear(_ animated: Bool) {

--- a/ios/TrueSheetViewManager.m
+++ b/ios/TrueSheetViewManager.m
@@ -45,6 +45,7 @@ RCT_EXPORT_VIEW_PROPERTY(dimmed, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(dimmedIndex, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(initialIndex, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(initialIndexAnimated, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(dimmedAlpha, CGFloat)
 
 // Internal properties
 RCT_EXPORT_VIEW_PROPERTY(contentHeight, NSNumber)

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -251,6 +251,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
       keyboardMode = 'resize',
       initialIndex,
       dimmedIndex,
+      dimmedAlpha = 0.75,
       grabberProps,
       blurTint,
       cornerRadius,
@@ -276,6 +277,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
         grabber={grabber}
         dimmed={dimmed}
         dimmedIndex={dimmedIndex}
+        dimmedAlpha={dimmedAlpha}
         edgeToEdge={edgeToEdge}
         initialIndex={initialIndex}
         initialIndexAnimated={initialIndexAnimated}

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -167,6 +167,13 @@ export interface TrueSheetProps extends ViewProps {
   dimmedIndex?: number
 
   /**
+   * The alpha value of the dimmed background.
+   *
+   * @default 0.75
+   */
+  dimmedAlpha?: number
+
+  /**
    * Prevents interactive dismissal of the Sheet.
    *
    * @default true


### PR DESCRIPTION
* Allow customisable dim alpha for the root view on iOS through `dimmedAlpha` prop
* Supports stacked sheets
* Respects `dimmed` prop

Requested in #78 and also find it useful for my own use case

Happy to add to docs if this looks good

https://github.com/user-attachments/assets/e851c7c9-be21-490c-958f-9fd7db60b077

