### PR TITLE
Make android sheet reactive to height changes

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetDialog.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetDialog.kt
@@ -52,6 +52,28 @@ class TrueSheetDialog(private val reactContext: ThemedReactContext, private val 
   var maxScreenHeight = 0
 
   var contentHeight = 0
+    set(value) {
+      val oldValue = field
+      field = value
+      
+      // If height changed and using auto size, reconfigure
+      if (oldValue != value && sizes.size == 1 && sizes[0] == "auto" && isShowing) {        
+        // Force a layout update
+        sheetContainerView?.let { container ->
+          val params = container.layoutParams
+          params.height = value + footerHeight
+          container.layoutParams = params
+        }
+        
+        configure()
+        
+        // Force expanded state to ensure proper height
+        behavior.apply {
+          maxHeight = value + footerHeight
+          state = BottomSheetBehavior.STATE_EXPANDED
+        }
+      }
+    }
   var footerHeight = 0
   var maxSheetHeight: Int? = null
 


### PR DESCRIPTION
This PR fixes an issue with dynamic content height updates when using the 'auto' size option on Android.

It fixes the #191 issue.

## Issue
When using a TrueSheet with `sizes={['auto']}` and dynamically updating the content (e.g., conditional rendering after a delay), the sheet wouldn't resize properly on Android, even though it worked correctly on iOS.

## Solution
Enhanced the content height handling in `TrueSheetDialog.kt` to properly update the sheet's dimensions when content changes:
1. Added a setter for `contentHeight` that detects changes
2. When using 'auto' size, directly updates the container's layout params
3. Forces the behavior to reconfigure with the new height
4. Ensures the sheet expands to the new height by setting the proper state

## Testing
To test this fix:
1. Create a sheet with `sizes={['auto']}`
2. Add conditional content that renders after a delay
3. Verify the sheet properly resizes when the content appears

Before this fix, the sheet would remain at its initial height. After the fix, it properly expands to fit the new content.

## Preview

**Before**

<video src="https://github.com/user-attachments/assets/19246b54-3973-469b-8eb1-851802363ea5" width="200"></video>

**After**

<video src="https://github.com/user-attachments/assets/2880a358-c643-4cd3-a3a5-7bf5349a037a" width="200"></video>