### PR TITLE
feat(android): add native grabber following M3 specs

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -113,13 +113,13 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
   }
 
   /**
-   * showOrUpdate will display the Dialog. It is called by the manager once all properties are set
-   * because we need to know all of them before creating the Dialog. It is also smart during updates
-   * if the changed properties can be applied directly to the Dialog or require the recreation of a
-   * new Dialog.
+   * Finalizes property updates when the sheet is presented.
+   * Called by the manager once all properties are set.
    */
-  fun showOrUpdate() {
+  fun finalizeUpdates() {
     if (viewController.isPresented) {
+      viewController.setupBackground()
+      viewController.setupGrabber()
       updateSheetIfNeeded()
       viewController.setStateForDetentIndex(viewController.currentDetentIndex)
     }
@@ -190,7 +190,7 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
   }
 
   override fun onHostResume() {
-    showOrUpdate()
+    finalizeUpdates()
   }
 
   override fun onHostPause() {
@@ -303,13 +303,11 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
   fun setCornerRadius(radius: Float) {
     if (viewController.sheetCornerRadius == radius) return
     viewController.sheetCornerRadius = radius
-    viewController.setupBackground()
   }
 
   fun setSheetBackgroundColor(color: Int) {
     if (viewController.sheetBackgroundColor == color) return
     viewController.sheetBackgroundColor = color
-    viewController.setupBackground()
   }
 
   fun setSoftInputMode(mode: Int) {
@@ -320,7 +318,9 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     viewController.dismissible = dismissible
   }
 
-  fun setGrabber(grabber: Boolean) {}
+  fun setGrabber(grabber: Boolean) {
+    viewController.grabber = grabber
+  }
 
   fun setDetents(newDetents: MutableList<Double>) {
     viewController.detents = newDetents

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -37,7 +37,7 @@ class TrueSheetViewManager :
 
   override fun onAfterUpdateTransaction(view: TrueSheetView) {
     super.onAfterUpdateTransaction(view)
-    view.showOrUpdate()
+    view.finalizeUpdates()
   }
 
   override fun addEventEmitters(reactContext: ThemedReactContext, view: TrueSheetView) {

--- a/docs/docs/migration.mdx
+++ b/docs/docs/migration.mdx
@@ -92,6 +92,24 @@ Several props have been renamed for better clarity:
 
 The following props have been removed in v3:
 
+#### `grabberProps` (Android)
+
+The `grabberProps` prop has been removed. The grabber is now rendered **natively** on both iOS and Android following Material Design 3 specifications. Use the `grabber` boolean prop to show or hide the native grabber.
+
+**Migration:**
+
+```tsx
+// ❌ v2
+<TrueSheet grabberProps={{ color: 'red', width: 40 }}>
+  {/* ... */}
+</TrueSheet>
+
+// ✅ v3 - grabber is native, use boolean to show/hide
+<TrueSheet grabber={true}>
+  {/* ... */}
+</TrueSheet>
+```
+
 #### `scrollRef` (iOS)
 
 The `scrollRef` prop has been removed. Scroll views are now **automatically detected** on iOS. Use the new `fitScrollView` prop to enable automatic ScrollView pinning.
@@ -334,6 +352,7 @@ See the [Header guide](/guides/header) for more details.
    - Replace `dimmedIndex` with `dimmedDetentIndex`
    - Remove `scrollRef` prop (iOS - now auto-detected)
    - Remove `contentContainerStyle` prop (no longer needed)
+   - Remove `grabberProps` prop (grabber is now native on both platforms)
    - Change detent percentage strings to fractional numbers (e.g., `"50%"` → `0.5`)
 
 6. **Test your app:**

--- a/docs/docs/reference/01-props.mdx
+++ b/docs/docs/reference/01-props.mdx
@@ -147,21 +147,15 @@ Set to `pan` if you're working with `FlatList` with a `TextInput`.
 
 ### `grabber`
 
-Shows a grabber (or handle). Native on IOS and styled `View` on Android.
+Shows a native grabber (or drag handle) on the sheet.
 
 | Type | Default | 🍎 | 🤖 |
 | - | - | - | - |
 | `boolean` | `true` | ✅ | ✅ |
 
-
-
-### `grabberProps`
-
-Overrides the grabber props for android.
-
-| Type | Default | 🍎 | 🤖 |
-| - | - | - | - |
-| [`TrueSheetGrabberProps`](/reference/types#truesheetgrabberprops) | `true` |  | ✅ |
+:::info
+iOS uses the native `UISheetPresentationController` grabber, while Android renders a native view following [Material Design 3 specifications](https://m3.material.io/components/bottom-sheets/specs) (32×4dp, centered, with the standard drag handle color).
+:::
 
 ### `header`
 

--- a/docs/docs/reference/03-types.mdx
+++ b/docs/docs/reference/03-types.mdx
@@ -17,18 +17,6 @@ keywords: [bottom sheet types, bottom sheet typescript, bottom sheet definitions
 | `"auto"` | Auto resize based on content height. | **_16+_** | ✅ |
 | `number` | Fractional height (0-1) representing percentage of screen height. | ✅ | ✅ |
 
-## `TrueSheetGrabberProps`
-
-Grabber props to be used for android grabber or handle.
-
-| Prop | Type | Default | Description |
-| - | - | - | - |
-| visible | `boolean` | `true` | Is grabber visible. |
-| color | `ColorValue` | `"rgba(73,69,79,0.4)"` | Grabber color according to M3 specs. |
-| height | `number` | `4` | Grabber height according to M3 specs. |
-| width | `number` | `32` | Grabber width according to M3 specs. |
-| topOffset | `number` | `0` | Grabber top position offset. |
-
 ## `BlurTint`
 
 Blur tint that is mapped into native values in IOS.

--- a/example/src/components/sheets/BasicSheet.tsx
+++ b/example/src/components/sheets/BasicSheet.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useRef, useState, type Ref, useImperativeHandle } from 'rea
 import { StyleSheet } from 'react-native';
 import { TrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
 
-import { DARK, DARK_BLUE, FOOTER_HEIGHT, GAP, GRABBER_COLOR, SPACING } from '../../utils';
+import { DARK, DARK_BLUE, FOOTER_HEIGHT, GAP, SPACING } from '../../utils';
 import { DemoContent } from '../DemoContent';
 import { Footer } from '../Footer';
 import { Button } from '../Button';
@@ -54,7 +54,6 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
       detents={['auto', 0.8, 1]}
       ref={sheetRef}
       style={styles.content}
-      grabberProps={{ color: GRABBER_COLOR }}
       onDragChange={(e) =>
         console.log(
           `drag changed at index: ${e.nativeEvent.index}, position: ${e.nativeEvent.position}`

--- a/example/src/components/sheets/GestureSheet.tsx
+++ b/example/src/components/sheets/GestureSheet.tsx
@@ -4,7 +4,7 @@ import { TrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet
 import Animated, { useAnimatedStyle, useSharedValue, withDecay } from 'react-native-reanimated';
 import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
 
-import { DARK, DARK_GRAY, FOOTER_HEIGHT, GAP, GRABBER_COLOR, SPACING, times } from '../../utils';
+import { DARK, DARK_GRAY, FOOTER_HEIGHT, GAP, SPACING, times } from '../../utils';
 import { Footer } from '../Footer';
 import { Button } from '../Button';
 import { DemoContent } from '../DemoContent';
@@ -51,7 +51,6 @@ export const GestureSheet = forwardRef((props: GestureSheetProps, ref: Ref<TrueS
       style={styles.content}
       blurTint="dark"
       backgroundColor={DARK}
-      grabberProps={{ color: GRABBER_COLOR }}
       onDidDismiss={() => console.log('Gesture sheet dismissed!')}
       onDidPresent={(e) =>
         console.log(

--- a/example/src/components/sheets/PromptSheet.tsx
+++ b/example/src/components/sheets/PromptSheet.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useRef, type Ref, useImperativeHandle, useState } from 'rea
 import { StyleSheet } from 'react-native';
 import { TrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
 
-import { DARK, DARK_BLUE, FOOTER_HEIGHT, GAP, GRABBER_COLOR, SPACING } from '../../utils';
+import { DARK, DARK_BLUE, FOOTER_HEIGHT, GAP, SPACING } from '../../utils';
 import { DemoContent } from '../DemoContent';
 import { Input } from '../Input';
 import { Button } from '../Button';
@@ -41,7 +41,6 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
       style={styles.content}
       blurTint="dark"
       backgroundColor={DARK}
-      grabberProps={{ color: GRABBER_COLOR }}
       onDidDismiss={handleDismiss}
       onDidPresent={(e) =>
         console.log(

--- a/example/src/utils/constants.ts
+++ b/example/src/utils/constants.ts
@@ -3,7 +3,6 @@ export const GAP = 12;
 export const INPUT_HEIGHT = SPACING * 3;
 export const FOOTER_HEIGHT = SPACING * 4;
 export const BORDER_RADIUS = 4;
-export const GRABBER_COLOR = 'rgba(121, 135, 160, 0.5)';
 
 export const DARK = '#282e37';
 export const GRAY = '#b2bac8';

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -1,8 +1,6 @@
 import type { ComponentType, ReactElement } from 'react';
 import type { ColorValue, NativeSyntheticEvent, ViewProps } from 'react-native';
 
-import type { TrueSheetGrabberProps } from './TrueSheetGrabber';
-
 export interface DetentInfoEventPayload {
   /**
    * The index position from the provided `detents`.
@@ -167,19 +165,14 @@ export interface TrueSheetProps extends ViewProps {
   cornerRadius?: number;
 
   /**
-   * Shows native grabber (or handle) on IOS.
+   * Shows a native grabber (or drag handle) on the sheet.
    *
-   * @platform ios
+   * iOS uses the native `UISheetPresentationController` grabber.
+   * Android renders a native view following Material Design 3 specifications.
+   *
    * @default true
    */
   grabber?: boolean;
-
-  /**
-   * Grabber props to be used for android grabber or handle.
-   *
-   * @platform android
-   */
-  grabberProps?: TrueSheetGrabberProps;
 
   /**
    * Controls the sheet presentation style on iPad.


### PR DESCRIPTION
## Summary

Add native grabber (drag handle) to Android following Material Design 3 specifications, matching iOS native grabber behavior.

## Changes

- Add native grabber view to `TrueSheetViewController` with M3 specs:
  - Width: 32dp
  - Height: 4dp
  - Color: #49454F with 0.4 alpha
  - Corner radius: 2dp
  - Top margin: 16dp
- Remove `grabberProps` prop (grabber is now native on both platforms)
- Refactor `setupBackground` to use `bottomSheetView` instead of `sheetContainer`
- Rename `showOrUpdate` to `finalizeUpdates`
- Update documentation and migration guide

## Breaking Changes

- Removed `grabberProps` prop - the grabber is now rendered natively on both iOS and Android
- Use `grabber={true|false}` to show/hide the native grabber