### PR TITLE
feat(ios): support 2-level deep scroll view detection

### DIFF
--- a/docs/docs/guides/scrolling/scrolling.mdx
+++ b/docs/docs/guides/scrolling/scrolling.mdx
@@ -39,6 +39,17 @@ By default, `scrollable` is `false`. Set it to `true` to enable automatic Scroll
 
 On iOS, `scrollable` automatically pins scroll views (including `ScrollView` and `FlatList`) to fit within the sheet's available space. The ScrollView's top edge will be pinned below any top sibling views, and its left, right, and bottom edges will be pinned to the container.
 
+The scroll view detection supports up to 2 levels deep in the view hierarchy, so you can wrap your `ScrollView` or `FlatList` in a container `View` if needed:
+
+```tsx
+<TrueSheet scrollable>
+  <View style={{ flex: 1 }}>
+    <View>{/* Header content */}</View>
+    <FlatList nestedScrollEnabled data={data} renderItem={renderItem} />
+  </View>
+</TrueSheet>
+```
+
 ### Android
 
 On Android, `scrollable` ensures the scroll view fills the available sheet space. You must also enable `nestedScrollEnabled` on your `ScrollView` or `FlatList` for scrolling to work properly.

--- a/example/src/components/sheets/FlatListSheet.tsx
+++ b/example/src/components/sheets/FlatListSheet.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, type Ref } from 'react';
-import { StyleSheet, FlatList } from 'react-native';
+import { StyleSheet, FlatList, View } from 'react-native';
 import { TrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
 
 import { DARK, DARK_GRAY, SPACING, times } from '../../utils';
@@ -36,24 +36,26 @@ export const FlatListSheet = forwardRef((props: FlatListSheetProps, ref: Ref<Tru
       onDidPresent={() => console.log(`Sheet FlatList presented!`)}
       {...props}
     >
-      <DemoContent />
-      <FlatList
-        nestedScrollEnabled
-        data={times(10, (i) => i)}
-        contentContainerStyle={styles.content}
-        indicatorStyle="black"
-        ItemSeparatorComponent={Spacer}
-        // scrollIndicatorInsets={{ top: TOP_INSET }}
-        // Broken on Android ;(
-        // refreshControl={
-        //   <RefreshControl
-        //     refreshing={isRefreshing}
-        //     tintColor="white"
-        //     onRefresh={handleRefresh}
-        //   />
-        // }
-        renderItem={({ item }) => <DemoContent color={DARK_GRAY} text={`Item #${item}`} />}
-      />
+      <View style={styles.wrapper}>
+        <DemoContent />
+        <FlatList
+          nestedScrollEnabled
+          data={times(10, (i) => i)}
+          contentContainerStyle={styles.content}
+          indicatorStyle="black"
+          ItemSeparatorComponent={Spacer}
+          // scrollIndicatorInsets={{ top: TOP_INSET }}
+          // Broken on Android ;(
+          // refreshControl={
+          //   <RefreshControl
+          //     refreshing={isRefreshing}
+          //     tintColor="white"
+          //     onRefresh={handleRefresh}
+          //   />
+          // }
+          renderItem={({ item }) => <DemoContent color={DARK_GRAY} text={`Item #${item}`} />}
+        />
+      </View>
     </TrueSheet>
   );
 });
@@ -61,6 +63,9 @@ export const FlatListSheet = forwardRef((props: FlatListSheetProps, ref: Ref<Tru
 FlatListSheet.displayName = 'FlatListSheet';
 
 const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+  },
   content: {
     padding: SPACING,
     paddingTop: SPACING,


### PR DESCRIPTION
## Summary

On iOS, the scroll view detection for `scrollable` prop now supports finding `ScrollView` or `FlatList` up to 2 levels deep in the view hierarchy.

This allows wrapping your scroll view in a container `View` if needed:

```tsx
<TrueSheet scrollable>
  <View style={{ flex: 1 }}>
    <View>{/* Header content */}</View>
    <FlatList nestedScrollEnabled data={data} renderItem={renderItem} />
  </View>
</TrueSheet>
```

## Changes

- Refactored `findScrollView:` in `TrueSheetContentView.mm` to search 2 levels deep
- Extracted `findScrollViewInSubviews:` helper method for cleaner code
- Updated example `FlatListSheet` to test nested scroll view
- Updated scrolling documentation