### PR TITLE
fix(ios): simplify emitted position for consistent values

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -203,9 +203,9 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     eventDispatcher?.dispatchEvent(DragEndEvent(surfaceId, id, index, position, detent))
   }
 
-  override fun viewControllerDidChangePosition(index: Float, position: Float, detent: Float, transitioning: Boolean) {
+  override fun viewControllerDidChangePosition(index: Float, position: Float, detent: Float, realtime: Boolean) {
     val surfaceId = UIManagerHelper.getSurfaceId(this)
-    eventDispatcher?.dispatchEvent(PositionChangeEvent(surfaceId, id, index, position, detent, transitioning))
+    eventDispatcher?.dispatchEvent(PositionChangeEvent(surfaceId, id, index, position, detent, realtime))
   }
 
   override fun viewControllerDidChangeSize(width: Int, height: Int) {

--- a/android/src/main/java/com/lodev09/truesheet/events/TrueSheetStateEvents.kt
+++ b/android/src/main/java/com/lodev09/truesheet/events/TrueSheetStateEvents.kt
@@ -28,7 +28,7 @@ class DetentChangeEvent(surfaceId: Int, viewId: Int, private val index: Int, pri
 
 /**
  * Fired continuously for position updates during drag and animation
- * Payload: { index: number, position: number, detent: number, transitioning: boolean }
+ * Payload: { index: number, position: number, detent: number, realtime: boolean }
  */
 class PositionChangeEvent(
   surfaceId: Int,
@@ -36,7 +36,7 @@ class PositionChangeEvent(
   private val index: Float,
   private val position: Float,
   private val detent: Float,
-  private val transitioning: Boolean = false
+  private val realtime: Boolean = false
 ) : Event<PositionChangeEvent>(surfaceId, viewId) {
 
   override fun getEventName(): String = EVENT_NAME
@@ -46,7 +46,7 @@ class PositionChangeEvent(
       putDouble("index", index.toDouble())
       putDouble("position", position.toDouble())
       putDouble("detent", detent.toDouble())
-      putBoolean("transitioning", transitioning)
+      putBoolean("realtime", realtime)
     }
 
   companion object {

--- a/docs/docs/reference/02-events.mdx
+++ b/docs/docs/reference/02-events.mdx
@@ -100,7 +100,7 @@ Comes with [`PositionChangeEventPayload`](/reference/types#positionchangeeventpa
 
 This is called continuously when the sheet's position changes during drag operations or transitions. This event fires more frequently than `onDragChange` and provides real-time position updates.
 
-The `transitioning` property indicates whether the sheet is currently presenting or dismissing. On iOS, when `transitioning` is `true`, the position should be animated (ReanimatedTrueSheet handles this automatically).
+The `realtime` property indicates whether the position value is real-time (e.g., during drag or animation tracking). When `realtime` is `false`, the position should be animated in JS (ReanimatedTrueSheet handles this automatically).
 
 :::tip
 Use this event when you need smooth, continuous position tracking for animations or visual feedback. For less frequent updates during dragging, use `onDragChange` instead.

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -78,7 +78,7 @@ Blur tint that is mapped into native values in IOS.
   index: 1.5,
   position: 123.5,
   detent: 0.5,
-  transitioning: false
+  realtime: true
 }
 ```
 
@@ -87,4 +87,4 @@ Blur tint that is mapped into native values in IOS.
 | index | `number` | The interpolated detent index. Continuous value that smoothly transitions between detents (e.g., `0.5` means halfway between detent 0 and 1). |
 | position | `number` | The Y position of the sheet relative to the screen. |
 | detent | `number` | The detent value (0-1) for the nearest detent index. |
-| transitioning | `boolean` | Whether the sheet is currently transitioning (presenting or dismissing). When `true`, position updates are animated on iOS. |
+| realtime | `boolean` | Whether the position is a real-time value (e.g., during drag or animation tracking). When `false`, position should be animated in JS. |

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2646,7 +2646,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNTrueSheet (3.0.0-beta.13):
+  - RNTrueSheet (3.0.0-beta.14):
     - boost
     - DoubleConversion
     - fast_float
@@ -3095,7 +3095,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: e1cf8ef3f11045536eed6bd4f132b003ef5f9a5f
   RNReanimated: ac06da53579693ab451941ef89f5a55afeab0dd9
   RNScreens: d821082c6dd1cb397cc0c98b026eeafaa68be479
-  RNTrueSheet: c0d1fa3899a4fc1c68fb2e832a50400456ebcb48
+  RNTrueSheet: 03216b7cbbfbbff0d7786c00bd319c2af8403ea1
   RNWorklets: ab618bf7d1c7fd2cb793b9f0f39c3e29274b3ebf
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb

--- a/example/src/screens/MapScreen.tsx
+++ b/example/src/screens/MapScreen.tsx
@@ -156,7 +156,7 @@ export const MapScreen = () => {
         <Button text="Navigate to Modal" onPress={() => navigation.navigate('ModalStack')} />
         <Spacer />
         <Button text="Expand" onPress={() => sheetRef.current?.resize(2)} />
-        <Button text="Collapse" onPress={() => sheetRef.current?.dismiss()} />
+        <Button text="Collapse" onPress={() => sheetRef.current?.resize(0)} />
         <BasicSheet ref={basicSheet} />
         <PromptSheet ref={promptSheet} />
         <ScrollViewSheet ref={scrollViewSheet} />

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -417,12 +417,8 @@ using namespace facebook::react;
 - (void)viewControllerDidChangePosition:(CGFloat)index
                                position:(CGFloat)position
                                  detent:(CGFloat)detent
-                          transitioning:(BOOL)transitioning {
-  [TrueSheetStateEvents emitPositionChange:_eventEmitter
-                                     index:index
-                                  position:position
-                                    detent:detent
-                             transitioning:transitioning];
+                               realtime:(BOOL)realtime {
+  [TrueSheetStateEvents emitPositionChange:_eventEmitter index:index position:position detent:detent realtime:realtime];
 }
 
 - (void)viewControllerDidChangeSize:(CGSize)size {

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewControllerDidChangePosition:(CGFloat)index
                                position:(CGFloat)position
                                  detent:(CGFloat)detent
-                          transitioning:(BOOL)transitioning;
+                               realtime:(BOOL)realtime;
 - (void)viewControllerDidChangeSize:(CGSize)size;
 - (void)viewControllerWillFocus;
 - (void)viewControllerDidFocus;

--- a/ios/events/TrueSheetStateEvents.h
+++ b/ios/events/TrueSheetStateEvents.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
                      index:(CGFloat)index
                   position:(CGFloat)position
                     detent:(CGFloat)detent
-             transitioning:(BOOL)transitioning;
+                  realtime:(BOOL)realtime;
 
 @end
 

--- a/ios/events/TrueSheetStateEvents.mm
+++ b/ios/events/TrueSheetStateEvents.mm
@@ -31,7 +31,7 @@
                      index:(CGFloat)index
                   position:(CGFloat)position
                     detent:(CGFloat)detent
-             transitioning:(BOOL)transitioning {
+                  realtime:(BOOL)realtime {
   if (!eventEmitter)
     return;
 
@@ -40,7 +40,7 @@
   event.index = static_cast<double>(index);
   event.position = static_cast<double>(position);
   event.detent = static_cast<double>(detent);
-  event.transitioning = static_cast<bool>(transitioning);
+  event.realtime = static_cast<bool>(realtime);
   emitter->onPositionChange(event);
 }
 

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -18,10 +18,10 @@ export interface DetentInfoEventPayload {
 
 export interface PositionChangeEventPayload extends DetentInfoEventPayload {
   /**
-   * Workaround for cases where we can't get real-time position from native.
-   * When true, manually animate the position in JS.
+   * Indicates whether the position value is real-time (e.g., during drag or animation tracking).
+   * When false, the position should be animated in JS.
    */
-  transitioning: boolean;
+  realtime: boolean;
 }
 
 export type MountEvent = NativeSyntheticEvent<null>;

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -18,7 +18,7 @@ export interface PositionChangeEventPayload {
   index: Double;
   position: Double;
   detent: Double;
-  transitioning: boolean;
+  realtime: boolean;
 }
 
 export interface NativeProps extends ViewProps {

--- a/src/reanimated/ReanimatedTrueSheet.tsx
+++ b/src/reanimated/ReanimatedTrueSheet.tsx
@@ -78,8 +78,12 @@ export const ReanimatedTrueSheet = forwardRef<TrueSheet, ReanimatedTrueSheetProp
     // Update detent directly (discrete value, not animated)
     detent.value = payload.detent;
 
-    if (payload.transitioning) {
-      // Animate position and index when transitioning
+    if (payload.realtime) {
+      // Update directly when we have real-time values (during drag or animation tracking)
+      animatedPosition.value = payload.position;
+      animatedIndex.value = payload.index;
+    } else {
+      // Animate position and index when not real-time
       if (Platform.OS === 'android') {
         animatedPosition.value = withTiming(payload.position, TIMING_CONFIG);
         animatedIndex.value = withTiming(payload.index, TIMING_CONFIG);
@@ -87,10 +91,6 @@ export const ReanimatedTrueSheet = forwardRef<TrueSheet, ReanimatedTrueSheetProp
         animatedPosition.value = withSpring(payload.position, SPRING_CONFIG);
         animatedIndex.value = withSpring(payload.index, SPRING_CONFIG);
       }
-    } else {
-      // Update directly during drag
-      animatedPosition.value = payload.position;
-      animatedIndex.value = payload.index;
     }
 
     onPositionChange?.({ nativeEvent: payload } as PositionChangeEvent);


### PR DESCRIPTION
## Summary

This PR simplifies the iOS position emission logic and renames `transitioning` to `realtime` with reversed boolean logic for clarity.

### Changes

**iOS Position Tracking Simplification:**
- Remove `_lastTransitionPosition` and `_isTrackingPositionFromLayout` tracking variables
- Simplify position change emission in `viewDidLayoutSubviews`
- Add delay before setting `_isDragging = NO` after gesture ends to prevent duplicate emissions
- Use epsilon comparison (`0.01`) for floating point position comparisons
- Simplify `trackTransitionPosition:` to only emit when there's actual position change

**Rename `transitioning` → `realtime` (reversed logic):**
- **Old**: `transitioning: true` = animate in JS, `transitioning: false` = real-time value
- **New**: `realtime: true` = real-time value (use directly), `realtime: false` = animate in JS

### Files Updated

- iOS: TrueSheetViewController, TrueSheetView, TrueSheetStateEvents
- Android: TrueSheetViewController, TrueSheetView, TrueSheetStateEvents  
- TypeScript: TrueSheet.types.ts, TrueSheetViewNativeComponent.ts, ReanimatedTrueSheet.tsx
- Docs: events.mdx, types.mdx

### Breaking Change

The `transitioning` property in `PositionChangeEventPayload` has been renamed to `realtime` with reversed boolean logic.