### PR TITLE
feat: add draggable prop to disable sheet dragging

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -273,6 +273,10 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     viewController.dismissible = dismissible
   }
 
+  fun setDraggable(draggable: Boolean) {
+    viewController.draggable = draggable
+  }
+
   fun setGrabber(grabber: Boolean) {
     viewController.grabber = grabber
   }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -153,6 +153,12 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
       }
     }
 
+  var draggable: Boolean = true
+    set(value) {
+      field = value
+      behavior?.isDraggable = value
+    }
+
   // ====================================================================
   // MARK: - Computed Properties
   // ====================================================================
@@ -234,6 +240,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
       setCanceledOnTouchOutside(dismissible)
       setCancelable(dismissible)
       behavior.isHideable = dismissible
+      behavior.isDraggable = draggable
     }
   }
 
@@ -515,7 +522,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
       bottomSheet.removeView(it)
     }
 
-    if (!grabber) return
+    if (!grabber || !draggable) return
 
     val grabberView = View(reactContext).apply {
       tag = GRABBER_TAG

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -114,6 +114,11 @@ class TrueSheetViewManager :
     view.setDismissible(dismissible)
   }
 
+  @ReactProp(name = "draggable", defaultBoolean = true)
+  override fun setDraggable(view: TrueSheetView, draggable: Boolean) {
+    view.setDraggable(draggable)
+  }
+
   @ReactProp(name = "dimmed", defaultBoolean = true)
   override fun setDimmed(view: TrueSheetView, dimmed: Boolean) {
     view.setDimmed(dimmed)

--- a/docs/docs/guides/resizing/resizing.mdx
+++ b/docs/docs/guides/resizing/resizing.mdx
@@ -48,6 +48,10 @@ TrueSheet.resize('resizing-sheet', 1)
 `detents` can only support up to 3 detents. **_collapsed_**, **_half-expanded_**, and **_expanded_**.
 :::
 
+:::tip
+If you want to disable user dragging and only allow programmatic resizing, set [`draggable={false}`](/reference/configuration#draggable).
+:::
+
 
 ### Listening to Detent Change
 

--- a/docs/docs/migration.mdx
+++ b/docs/docs/migration.mdx
@@ -323,6 +323,22 @@ This ensures proper scrolling behavior on both iOS and Android when using `Scrol
 
 See the [Header guide](/guides/header) for more details.
 
+### 7. Draggable Control
+
+Version 3 introduces the `draggable` prop to disable user dragging entirely. When set to `false`, the sheet becomes static and can only be resized programmatically using the [`resize`](/reference/methods#resize) method.
+
+```tsx
+<TrueSheet draggable={false} detents={[0.5, 1]}>
+  <Button title="Expand" onPress={() => sheet.current?.resize(1)} />
+</TrueSheet>
+```
+
+:::info
+When `draggable` is `false`, the grabber is automatically hidden.
+:::
+
+See the [Configuration reference](/reference/configuration#draggable) for more details.
+
 ## Step-by-Step Migration
 
 1. **Enable New Architecture** in your React Native app (see above)

--- a/docs/docs/reference/01-configuration.mdx
+++ b/docs/docs/reference/01-configuration.mdx
@@ -93,6 +93,18 @@ If set to `false`, the sheet will prevent interactive dismissal via dragging or 
 | - | - | - | - |
 | `boolean` | `true` | ✅ | ✅ |
 
+## `draggable`
+
+If set to `false`, the sheet will disable dragging to resize. The sheet can only be resized programmatically using the [`resize`](/reference/methods#resize) method.
+
+| Type | Default | 🍎 | 🤖 |
+| - | - | - | - |
+| `boolean` | `true` | ✅ | ✅ |
+
+:::info
+When `draggable` is `false`, the [`grabber`](#grabber) is automatically hidden.
+:::
+
 ## `dimmed`
 
 Specify whether the sheet background is dimmed. Set to `false` to allow interaction with the background components.

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -132,6 +132,7 @@ using namespace facebook::react;
   _controller.grabber = newProps.grabber;
   _controller.pageSizing = newProps.pageSizing;
   _controller.modalInPresentation = !newProps.dismissible;
+  _controller.draggable = newProps.draggable;
   _controller.dimmed = newProps.dimmed;
 
   if (newProps.dimmedDetentIndex >= 0) {
@@ -187,6 +188,7 @@ using namespace facebook::react;
       [self->_controller setupSheetDetents];
       [self->_controller applyActiveDetent];
     }];
+    [_controller updateDraggable];
   } else if (_initialDetentIndex >= 0) {
     [self presentAtIndex:_initialDetentIndex animated:_initialDetentAnimated completion:nil];
   }

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -52,6 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) UIColor *backgroundColor;
 @property (nonatomic, strong, nullable) NSNumber *cornerRadius;
 @property (nonatomic, assign) BOOL grabber;
+@property (nonatomic, assign) BOOL draggable;
 @property (nonatomic, assign) BOOL dimmed;
 @property (nonatomic, strong, nullable) NSNumber *dimmedDetentIndex;
 @property (nonatomic, copy, nullable) NSString *blurTint;
@@ -64,6 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setupActiveDetentWithIndex:(NSInteger)index;
 - (void)setupSheetDetents;
 - (void)setupSheetProps;
+- (void)updateDraggable;
 - (NSInteger)currentDetentIndex;
 - (CGFloat)currentPosition;
 - (CGFloat)bottomInset;

--- a/ios/utils/GestureUtil.h
+++ b/ios/utils/GestureUtil.h
@@ -20,6 +20,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)attachPanGestureHandler:(UIView *)view target:(id)target selector:(SEL)selector;
 
+/**
+ * Enables or disables all pan gesture recognizers on a view
+ * @param view The view whose pan gesture recognizers to enable/disable
+ * @param enabled Whether the pan gestures should be enabled
+ */
++ (void)setPanGesturesEnabled:(BOOL)enabled forView:(UIView *)view;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/utils/GestureUtil.mm
+++ b/ios/utils/GestureUtil.mm
@@ -23,4 +23,16 @@
   }
 }
 
++ (void)setPanGesturesEnabled:(BOOL)enabled forView:(UIView *)view {
+  if (!view) {
+    return;
+  }
+
+  for (UIGestureRecognizer *recognizer in view.gestureRecognizers ?: @[]) {
+    if ([recognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
+      recognizer.enabled = enabled;
+    }
+  }
+}
+
 @end

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -337,6 +337,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
       detents = [0.5, 1],
       backgroundColor,
       dismissible = true,
+      draggable = true,
       grabber = true,
       dimmed = true,
       initialDetentIndex = -1,
@@ -395,6 +396,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
         initialDetentIndex={initialDetentIndex}
         initialDetentAnimated={initialDetentAnimated}
         dismissible={dismissible}
+        draggable={draggable}
         maxHeight={maxHeight}
         edgeToEdgeFullScreen={edgeToEdgeFullScreen}
         scrollable={scrollable}

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -161,6 +161,14 @@ export interface TrueSheetProps extends ViewProps {
   dismissible?: boolean;
 
   /**
+   * Enables or disables dragging the sheet to resize it.
+   * When disabled, the sheet becomes static and can only be resized programmatically.
+   *
+   * @default true
+   */
+  draggable?: boolean;
+
+  /**
    * Main sheet background color.
    * Uses system default when not provided.
    */

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -39,6 +39,7 @@ export interface NativeProps extends ViewProps {
   // Boolean properties - match defaults from TrueSheet.types.ts
   grabber?: WithDefault<boolean, true>;
   dismissible?: WithDefault<boolean, true>;
+  draggable?: WithDefault<boolean, true>;
   dimmed?: WithDefault<boolean, true>;
   initialDetentAnimated?: WithDefault<boolean, true>;
   edgeToEdgeFullScreen?: WithDefault<boolean, false>;


### PR DESCRIPTION
## Summary

Adds a new `draggable` prop that allows disabling sheet dragging entirely. When set to `false`, the sheet becomes static and can only be resized programmatically.

## Changes

### TypeScript
- Added `draggable` prop to native component spec
- Added `draggable` prop type with JSDoc documentation
- Pass prop to native component

### iOS
- Added `draggable` property to `TrueSheetViewController`
- Added `updateDraggable` method for real-time prop updates
- Added `setPanGesturesEnabled:forView:` utility method in `GestureUtil`
- Grabber is automatically hidden when `draggable={false}`

### Android
- Added `draggable` property to `TrueSheetViewController` that sets `behavior.isDraggable`
- Added `setDraggable()` method to `TrueSheetView`
- Added `@ReactProp` for draggable in ViewManager
- Grabber is automatically hidden when `draggable={false}`

### Documentation
- Added `draggable` prop to configuration reference
- Added tip in resizing guide about programmatic-only resizing
- Added "Draggable Control" section in migration guide

## Usage

```tsx
<TrueSheet draggable={false} detents={[0.5, 1]}>
  <Button title="Expand" onPress={() => sheet.current?.resize(1)} />
</TrueSheet>
```

Closes #246