### PR TITLE
fix(ios): support presenting react-navigation modals from nested sheets

### DIFF
--- a/example/src/components/sheets/BasicSheet.tsx
+++ b/example/src/components/sheets/BasicSheet.tsx
@@ -7,6 +7,7 @@ import { DemoContent } from '../DemoContent';
 import { Footer } from '../Footer';
 import { Button } from '../Button';
 import { Spacer } from '../Spacer';
+import { useAppNavigation } from '../../hooks';
 
 interface BasicSheetProps extends TrueSheetProps {}
 
@@ -14,6 +15,7 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
   const sheetRef = useRef<TrueSheet>(null);
   const childSheet = useRef<TrueSheet>(null);
   const [contentCount, setContentCount] = useState(0);
+  const navigation = useAppNavigation();
 
   const resize = async (index: number) => {
     await sheetRef.current?.resize(index);
@@ -108,6 +110,7 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
       <Spacer />
       <Button text="Present Child Sheet" onPress={presentChild} />
       <Button text="Present PromptSheet" onPress={presentPromptSheet} />
+      <Button text="Navigate to Modal" onPress={() => navigation.navigate('ModalStack')} />
       <Spacer />
       <Button text="Dismiss" onPress={dismiss} />
 

--- a/example/src/screens/ModalScreen.tsx
+++ b/example/src/screens/ModalScreen.tsx
@@ -4,13 +4,12 @@ import type { TrueSheet } from '@lodev09/react-native-true-sheet';
 
 import { BLUE, GAP, LIGHT_GRAY, SPACING } from '../utils';
 import { Button, Spacer } from '../components';
-import { BasicSheet, PromptSheet, ScrollViewSheet } from '../components/sheets';
+import { PromptSheet, FlatListSheet } from '../components/sheets';
 import { useAppNavigation } from '../hooks';
 
 export const ModalScreen = () => {
-  const basicSheet = useRef<TrueSheet>(null);
   const promptSheet = useRef<TrueSheet>(null);
-  const scrollViewSheet = useRef<TrueSheet>(null);
+  const flatlistSheet = useRef<TrueSheet>(null);
 
   const navigation = useAppNavigation();
 
@@ -23,16 +22,14 @@ export const ModalScreen = () => {
         </Text>
       </View>
 
-      <Button text="TrueSheet View" onPress={() => basicSheet.current?.present()} />
       <Button text="TrueSheet Prompt" onPress={() => promptSheet.current?.present()} />
-      <Button text="TrueSheet ScrollView" onPress={() => scrollViewSheet.current?.present()} />
+      <Button text="TrueSheet FlatList" onPress={() => flatlistSheet.current?.present()} />
       <Spacer />
       <Button text="Navigate Test" onPress={() => navigation.navigate('Test')} />
       <Button text="Dimiss Modal" onPress={() => navigation.goBack()} />
 
-      <BasicSheet ref={basicSheet} />
       <PromptSheet ref={promptSheet} />
-      <ScrollViewSheet ref={scrollViewSheet} />
+      <FlatListSheet ref={flatlistSheet} />
     </View>
   );
 };

--- a/example/src/screens/TestScreen.tsx
+++ b/example/src/screens/TestScreen.tsx
@@ -4,22 +4,21 @@ import type { TrueSheet } from '@lodev09/react-native-true-sheet';
 
 import { BLUE, GAP, SPACING } from '../utils';
 import { Button } from '../components';
-import { BasicSheet, PromptSheet, ScrollViewSheet } from '../components/sheets';
+import { BasicSheet, PromptSheet, FlatListSheet } from '../components/sheets';
 
 export const TestScreen = () => {
   const basicSheet = useRef<TrueSheet>(null);
   const promptSheet = useRef<TrueSheet>(null);
-  const scrollViewSheet = useRef<TrueSheet>(null);
+  const flatListSheet = useRef<TrueSheet>(null);
 
   return (
     <View style={styles.content}>
-      <Button text="TrueSheet View" onPress={() => basicSheet.current?.present()} />
       <Button text="TrueSheet Prompt" onPress={() => promptSheet.current?.present()} />
-      <Button text="TrueSheet ScrollView" onPress={() => scrollViewSheet.current?.present()} />
+      <Button text="TrueSheet FlatList" onPress={() => flatListSheet.current?.present()} />
 
       <BasicSheet ref={basicSheet} />
       <PromptSheet ref={promptSheet} />
-      <ScrollViewSheet ref={scrollViewSheet} />
+      <FlatListSheet ref={flatListSheet} />
     </View>
   );
 };

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -759,8 +759,14 @@
 }
 
 - (UIViewController *)newPresentingViewController {
-  // Allow react-native-screens to present modals on top of the sheet's content
-  return self;
+  // Find the topmost TrueSheetViewController in the chain
+  // This handles cases where this sheet is presenting another sheet (child sheet)
+  UIViewController *topmost = self;
+  while (topmost.presentedViewController != nil && !topmost.presentedViewController.isBeingDismissed &&
+         [topmost.presentedViewController isKindOfClass:[TrueSheetViewController class]]) {
+    topmost = topmost.presentedViewController;
+  }
+  return topmost;
 }
 #endif
 


### PR DESCRIPTION
## Summary

Fixes an issue where presenting a react-navigation modal from within a TrueSheet that has a child sheet presented would fail with the error:

```
Attempt to present <RNSScreen> on <TrueSheetViewController> which is already presenting <TrueSheetViewController>
```

## Changes

- Updated `newPresentingViewController` in `TrueSheetViewController.mm` to traverse the presentation chain and return the topmost `TrueSheetViewController`, allowing react-navigation to present modals from the correct view controller.

## Test

1. Present a TrueSheet (BasicSheet)
2. Present a child sheet from within it
3. Tap "Navigate to Modal" from the child sheet
4. Modal should present correctly
5. Dismiss the modal - should work correctly