### PR TITLE
Fix android back button press when dismissible false

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.graphics.drawable.ShapeDrawable
 import android.graphics.drawable.shapes.RoundRectShape
 import android.util.TypedValue
+import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
@@ -250,6 +251,15 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
       setCancelable(dismissible)
       behavior.isHideable = dismissible
       behavior.isDraggable = draggable
+
+      setOnKeyListener { _, keyCode, event ->
+        if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP && !dismissible) {
+          reactContext.currentActivity?.onBackPressed()
+          true
+        } else {
+          false
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Add back button handling to dialog.

To test: 

- Add a Sheet with `dismissible={false}`
- Try to use back button on Android
- Back button should work


Not a android dev expert so, you might want to change some things. But i've tried it and it work for me.