### PR TITLE
fix: make react-native-reanimated truly optional

### DIFF
--- a/docs/blog/2025/release-3-0.mdx
+++ b/docs/blog/2025/release-3-0.mdx
@@ -94,7 +94,7 @@ import {
   ReanimatedTrueSheetProvider,
   ReanimatedTrueSheet,
   useReanimatedTrueSheet,
-} from '@lodev09/react-native-true-sheet'
+} from '@lodev09/react-native-true-sheet/reanimated'
 import Animated, { useAnimatedStyle, interpolate } from 'react-native-reanimated'
 
 const App = () => (

--- a/docs/docs/guides/dimming/dimming.mdx
+++ b/docs/docs/guides/dimming/dimming.mdx
@@ -59,7 +59,7 @@ Learn more about Reanimated integration in the [Reanimated guide](/guides/reanim
 :::
 
 ```tsx {2-3,7,9-11,14-21}
-import { ReanimatedTrueSheet, ReanimatedTrueSheetProvider, useReanimatedTrueSheet } from '@lodev09/react-native-true-sheet'
+import { ReanimatedTrueSheet, ReanimatedTrueSheetProvider, useReanimatedTrueSheet } from '@lodev09/react-native-true-sheet/reanimated'
 import Animated, { useAnimatedStyle } from 'react-native-reanimated'
 import { StyleSheet } from 'react-native'
 

--- a/docs/docs/guides/reanimated/reanimated.mdx
+++ b/docs/docs/guides/reanimated/reanimated.mdx
@@ -22,7 +22,7 @@ import reanimated from './reanimated.gif'
 Manages shared values for Reanimated integration.
 
 ```tsx
-import { ReanimatedTrueSheetProvider } from '@lodev09/react-native-true-sheet'
+import { ReanimatedTrueSheetProvider } from '@lodev09/react-native-true-sheet/reanimated'
 
 function App() {
   return (
@@ -38,7 +38,8 @@ function App() {
 Animated sheet component that syncs position automatically with all props from [`TrueSheet`](/reference/configuration).
 
 ```tsx
-import { ReanimatedTrueSheet } from '@lodev09/react-native-true-sheet'
+import { type TrueSheet } from '@lodev09/react-native-true-sheet'
+import { ReanimatedTrueSheet } from '@lodev09/react-native-true-sheet/reanimated'
 
 function MyScreen() {
   const sheetRef = useRef<TrueSheet>(null)
@@ -64,7 +65,7 @@ Note that the `onPositionChange` prop event now runs on the UI thread (worklet).
 Use the `useReanimatedTrueSheet` hook to access the sheet's animated values.
 
 ```tsx
-import { useReanimatedTrueSheet } from '@lodev09/react-native-true-sheet'
+import { useReanimatedTrueSheet } from '@lodev09/react-native-true-sheet/reanimated'
 import Animated, { useAnimatedStyle, interpolate } from 'react-native-reanimated'
 
 function MyComponent() {

--- a/docs/docs/migration.mdx
+++ b/docs/docs/migration.mdx
@@ -292,7 +292,7 @@ import {
   ReanimatedTrueSheetProvider,
   ReanimatedTrueSheet,
   useReanimatedTrueSheet,
-} from '@lodev09/react-native-true-sheet'
+} from '@lodev09/react-native-true-sheet/reanimated'
 import Animated, { useAnimatedStyle } from 'react-native-reanimated'
 
 // 1. Wrap your app with the provider

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,7 +3,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import { MapScreen, NavigationScreen, TestScreen, ModalScreen } from './screens';
 import type { AppStackParamList, ModalStackParamList } from './types';
-import { ReanimatedTrueSheetProvider } from '@lodev09/react-native-true-sheet';
+import { ReanimatedTrueSheetProvider } from '@lodev09/react-native-true-sheet/reanimated';
 
 const DEFAULT_NAVIGATION: keyof AppStackParamList = 'Map';
 

--- a/example/src/components/ReanimatedExample.tsx
+++ b/example/src/components/ReanimatedExample.tsx
@@ -1,10 +1,10 @@
 import { useRef } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { type TrueSheet } from '@lodev09/react-native-true-sheet';
 import {
   ReanimatedTrueSheet,
   useReanimatedTrueSheet,
-  type TrueSheet,
-} from '@lodev09/react-native-true-sheet';
+} from '@lodev09/react-native-true-sheet/reanimated';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 

--- a/example/src/screens/MapScreen.tsx
+++ b/example/src/screens/MapScreen.tsx
@@ -6,15 +6,20 @@ import {
   TouchableOpacity,
   useWindowDimensions,
   View,
+  type LayoutChangeEvent,
   type StyleProp,
   type ViewStyle,
 } from 'react-native';
 import {
   TrueSheet,
+  type WillPresentEvent,
+  type DidPresentEvent,
+  type DetentChangeEvent,
+} from '@lodev09/react-native-true-sheet';
+import {
   ReanimatedTrueSheet,
   useReanimatedTrueSheet,
-  type WillPresentEvent,
-} from '@lodev09/react-native-true-sheet';
+} from '@lodev09/react-native-true-sheet/reanimated';
 import MapView from 'react-native-maps';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 
@@ -98,7 +103,7 @@ export const MapScreen = () => {
         edgeToEdgeFullScreen
         style={styles.content}
         backgroundColor={Platform.select({ android: DARK })}
-        onLayout={(e) => {
+        onLayout={(e: LayoutChangeEvent) => {
           console.log(
             `sheet layout width: ${e.nativeEvent.layout.width}, height: ${e.nativeEvent.layout.height}`
           );
@@ -114,7 +119,7 @@ export const MapScreen = () => {
         //   const { detent, position, index } = e.nativeEvent;
         //   console.log(`position change index: ${index}, detent: ${detent}, position: ${position}`);
         // }}
-        onDidPresent={(e) => {
+        onDidPresent={(e: DidPresentEvent) => {
           console.log(
             `did present index: ${e.nativeEvent.index}, detent: ${e.nativeEvent.detent}, position: ${e.nativeEvent.position}`
           );
@@ -135,7 +140,7 @@ export const MapScreen = () => {
           // sheetRef.current?.present(1)
           console.log('sheet is ready!');
         }}
-        onDetentChange={(e) => {
+        onDetentChange={(e: DetentChangeEvent) => {
           console.log(
             `detent changed to index: ${e.nativeEvent.index}, detent: ${e.nativeEvent.detent}, position: ${e.nativeEvent.position}`
           );

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
       "types": "./lib/typescript/src/index.d.ts",
       "default": "./lib/module/index.js"
     },
+    "./reanimated": {
+      "source": "./src/reanimated/index.ts",
+      "types": "./lib/typescript/src/reanimated/index.d.ts",
+      "default": "./lib/module/reanimated/index.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export * from './TrueSheet';
 export * from './TrueSheet.types';
-export * from './reanimated';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "paths": {
-      "@lodev09/react-native-true-sheet": ["./src/index"]
+      "@lodev09/react-native-true-sheet": ["./src/index"],
+      "@lodev09/react-native-true-sheet/reanimated": ["./src/reanimated/index"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
## Summary

Makes `react-native-reanimated` truly optional by moving reanimated exports to a separate subpath.

## Changes

- Remove unconditional reanimated export from main `src/index.ts`
- Add separate export path `./reanimated` in `package.json`
- Add TypeScript path mapping in `tsconfig.json`
- Update example app to use new import path
- Update docs with new import examples

## Usage

Users without reanimated can now use the library without errors:
```tsx
import { TrueSheet } from '@lodev09/react-native-true-sheet'
```

Users who want reanimated features import from the subpath:
```tsx
import { ReanimatedTrueSheet } from '@lodev09/react-native-true-sheet/reanimated'
```

## Breaking Change

Users who were importing reanimated components from the main entry need to update their imports:

```diff
- import { ReanimatedTrueSheet } from '@lodev09/react-native-true-sheet'
+ import { ReanimatedTrueSheet } from '@lodev09/react-native-true-sheet/reanimated'
```