### PR TITLE
fix(android): auto detent not working correctly

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -467,7 +467,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
    */
   fun hideDialog() {
     isDialogVisible = false
-    dialog?.window?.decorView?.visibility = View.INVISIBLE
+    dialog?.window?.decorView?.visibility = INVISIBLE
 
     // Emit off-screen position (detent = 0 since sheet is fully hidden)
     emitChangePositionDelegate(screenHeight, realtime = false)
@@ -479,7 +479,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
    */
   fun showDialog() {
     isDialogVisible = true
-    dialog?.window?.decorView?.visibility = View.VISIBLE
+    dialog?.window?.decorView?.visibility = VISIBLE
 
     // Emit current position
     val positionPx = bottomSheetView?.let { ScreenUtils.getScreenY(it) } ?: screenHeight
@@ -564,12 +564,14 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
         1 -> {
           setPeekHeight(getDetentHeight(detents[0]), isPresented)
           expandedOffset = screenHeight - peekHeight
-          isFitToContents = true
+          isFitToContents = expandedOffset == 0
         }
 
         2 -> {
           setPeekHeight(getDetentHeight(detents[0]), isPresented)
+          halfExpandedRatio = minOf(getDetentHeight(detents[1]).toFloat() / screenHeight.toFloat(), 0.9f)
           expandedOffset = screenHeight - getDetentHeight(detents[1])
+          isFitToContents = expandedOffset == 0
         }
 
         3 -> {


### PR DESCRIPTION
Fixes #274

## Summary
Fixes two issues with `detents` prop on Android:

1. **`detents={["auto"]}`** - Sheet was opening to full size instead of respecting content height
2. **`detents={["auto", 1]}`** - Sheet was creating an unexpected third snapping position

## Changes
- Set `isFitToContents` based on `expandedOffset` for single detent (only fit to contents when expanded offset is 0)
- Calculate `halfExpandedRatio` for two detents to prevent the third snap point
- Minor cleanup: use `INVISIBLE`/`VISIBLE` constants directly