### PR TITLE
feat: add animated parameter to present and dismiss methods

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetModule.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetModule.kt
@@ -46,12 +46,12 @@ class TrueSheetModule(reactContext: ReactApplicationContext) :
    * @throws OPERATION_FAILED if the operation fails for any other reason
    */
   @ReactMethod
-  fun presentByRef(viewTag: Double, index: Double, promise: Promise) {
+  fun presentByRef(viewTag: Double, index: Double, animated: Boolean, promise: Promise) {
     val tag = viewTag.toInt()
     val detentIndex = index.toInt()
 
     withTrueSheetView(tag, promise) { view ->
-      view.present(detentIndex) {
+      view.present(detentIndex, animated) {
         promise.resolve(null)
       }
     }
@@ -67,11 +67,11 @@ class TrueSheetModule(reactContext: ReactApplicationContext) :
    * @throws OPERATION_FAILED if the operation fails for any other reason
    */
   @ReactMethod
-  fun dismissByRef(viewTag: Double, promise: Promise) {
+  fun dismissByRef(viewTag: Double, animated: Boolean, promise: Promise) {
     val tag = viewTag.toInt()
 
     withTrueSheetView(tag, promise) { view ->
-      view.dismiss {
+      view.dismiss(animated) {
         promise.resolve(null)
       }
     }
@@ -89,8 +89,8 @@ class TrueSheetModule(reactContext: ReactApplicationContext) :
    */
   @ReactMethod
   fun resizeByRef(viewTag: Double, index: Double, promise: Promise) {
-    // Resize is just an alias for present
-    presentByRef(viewTag, index, promise)
+    // Resize is just an alias for present (always animated)
+    presentByRef(viewTag, index, true, promise)
   }
 
   /**

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -326,9 +326,9 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
   }
 
   @UiThread
-  fun dismiss(promiseCallback: () -> Unit) {
+  fun dismiss(animated: Boolean = true, promiseCallback: () -> Unit) {
     viewController.dismissPromise = promiseCallback
-    viewController.dismiss()
+    viewController.dismiss(animated)
   }
 
   /**

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -524,12 +524,16 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     }
   }
 
-  fun dismiss() {
+  fun dismiss(animated: Boolean = true) {
     this.post {
       // Emit off-screen position (detent = 0 since sheet is fully hidden)
       emitChangePositionDelegate(screenHeight, realtime = false)
     }
-    dialog?.dismiss()
+
+    dialog?.apply {
+      if (!animated) window?.setWindowAnimations(0)
+      post { dismiss() }
+    }
   }
 
   // ====================================================================

--- a/docs/docs/reference/03-methods.mdx
+++ b/docs/docs/reference/03-methods.mdx
@@ -21,23 +21,34 @@ return (
 
 ### `present`
 
-Present the sheet. Optionally accepts a detent `index`. See [`detents`](/reference/configuration#detents) prop.
+Present the sheet. Optionally accepts a detent `index` and `animated` flag. See [`detents`](/reference/configuration#detents) prop.
 
-| Parameters | Required |
-| - | - |
-| `index: number = 0` | No |
+| Parameters | Required | Default |
+| - | - | - |
+| `index: number` | No | `0` |
+| `animated: boolean` | No | `true` |
 
 ```tsx
 await sheet.current?.present()
+
+// Present without animation
+await sheet.current?.present(0, false)
 ```
 
 
 ### `dismiss`
 
-Dismisses the sheet.
+Dismisses the sheet. Optionally accepts an `animated` flag.
+
+| Parameters | Required | Default |
+| - | - | - |
+| `animated: boolean` | No | `true` |
 
 ```tsx
 await sheet.current?.dismiss()
+
+// Dismiss without animation
+await sheet.current?.dismiss(false)
 ```
 
 ### `resize`
@@ -74,9 +85,15 @@ You can then use these methods globally.
 
 ```tsx
 await TrueSheet.present('my-sheet')
+
+// Present without animation
+await TrueSheet.present('my-sheet', 0, false)
 ```
 ```tsx
 await TrueSheet.dismiss('my-sheet')
+
+// Dismiss without animation
+await TrueSheet.dismiss('my-sheet', false)
 ```
 ```tsx
 // Resize to 80%

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2646,7 +2646,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNTrueSheet (3.1.0-beta.0):
+  - RNTrueSheet (3.1.0-beta.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3095,7 +3095,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: e1cf8ef3f11045536eed6bd4f132b003ef5f9a5f
   RNReanimated: ac06da53579693ab451941ef89f5a55afeab0dd9
   RNScreens: d821082c6dd1cb397cc0c98b026eeafaa68be479
-  RNTrueSheet: 523c2db7352101070e2a65cfb43e394a5e64074e
+  RNTrueSheet: 6f6df1b5c719023a2e63a14c77ed21a1d2397486
   RNWorklets: ab618bf7d1c7fd2cb793b9f0f39c3e29274b3ebf
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb

--- a/example/src/components/sheets/BasicSheet.tsx
+++ b/example/src/components/sheets/BasicSheet.tsx
@@ -23,7 +23,7 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
   };
 
   const dismiss = async () => {
-    await sheetRef.current?.dismiss();
+    await sheetRef.current?.dismiss(false);
     console.log('Basic sheet dismiss asynced');
   };
 

--- a/ios/TrueSheetModule.mm
+++ b/ios/TrueSheetModule.mm
@@ -46,6 +46,7 @@ RCT_EXPORT_MODULE(TrueSheetModule)
 
 - (void)presentByRef:(double)viewTag
                index:(double)index
+            animated:(BOOL)animated
              resolve:(RCTPromiseResolveBlock)resolve
               reject:(RCTPromiseRejectBlock)reject {
   RCTExecuteOnMainQueue(^{
@@ -57,7 +58,7 @@ RCT_EXPORT_MODULE(TrueSheetModule)
     }
 
     [trueSheetView presentAtIndex:(NSInteger)index
-                         animated:YES
+                         animated:animated
                        completion:^(BOOL success, NSError *_Nullable error) {
                          if (success) {
                            resolve(nil);
@@ -68,7 +69,10 @@ RCT_EXPORT_MODULE(TrueSheetModule)
   });
 }
 
-- (void)dismissByRef:(double)viewTag resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+- (void)dismissByRef:(double)viewTag
+            animated:(BOOL)animated
+             resolve:(RCTPromiseResolveBlock)resolve
+              reject:(RCTPromiseRejectBlock)reject {
   RCTExecuteOnMainQueue(^{
     TrueSheetView *trueSheetView = [TrueSheetModule getTrueSheetViewByTag:@((NSInteger)viewTag)];
 
@@ -77,7 +81,7 @@ RCT_EXPORT_MODULE(TrueSheetModule)
       return;
     }
 
-    [trueSheetView dismissAnimated:YES
+    [trueSheetView dismissAnimated:animated
                         completion:^(BOOL success, NSError *_Nullable error) {
                           if (success) {
                             resolve(nil);
@@ -92,8 +96,8 @@ RCT_EXPORT_MODULE(TrueSheetModule)
               index:(double)index
             resolve:(RCTPromiseResolveBlock)resolve
              reject:(RCTPromiseRejectBlock)reject {
-  // Resize is just present with a different index
-  [self presentByRef:viewTag index:index resolve:resolve reject:reject];
+  // Resize is just present with a different index (always animated)
+  [self presentByRef:viewTag index:index animated:YES resolve:resolve reject:reject];
 }
 
 #pragma mark - Helper Methods

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -160,31 +160,37 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
    * Present the sheet by given `name` (Promise-based)
    * @param name - Sheet name (must match sheet's name prop)
    * @param index - Detent index (default: 0)
+   * @param animated - Whether to animate the presentation (default: true)
    * @returns Promise that resolves when sheet is fully presented
    * @throws Error if sheet not found or presentation fails
    */
-  public static async present(name: string, index: number = 0): Promise<void> {
+  public static async present(
+    name: string,
+    index: number = 0,
+    animated: boolean = true
+  ): Promise<void> {
     const instance = TrueSheet.getInstance(name);
     if (!instance) {
       throw new Error(`Sheet with name "${name}" not found`);
     }
 
-    return instance.present(index);
+    return instance.present(index, animated);
   }
 
   /**
    * Dismiss the sheet by given `name` (Promise-based)
    * @param name - Sheet name
+   * @param animated - Whether to animate the dismissal (default: true)
    * @returns Promise that resolves when sheet is fully dismissed
    * @throws Error if sheet not found or dismissal fails
    */
-  public static async dismiss(name: string): Promise<void> {
+  public static async dismiss(name: string, animated: boolean = true): Promise<void> {
     const instance = TrueSheet.getInstance(name);
     if (!instance) {
       throw new Error(`Sheet with name "${name}" not found`);
     }
 
-    return instance.dismiss();
+    return instance.dismiss(animated);
   }
 
   /**
@@ -286,8 +292,9 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
   /**
    * Present the Sheet by `index` (Promise-based)
    * @param index - Detent index (default: 0)
+   * @param animated - Whether to animate the presentation (default: true)
    */
-  public async present(index: number = 0): Promise<void> {
+  public async present(index: number = 0, animated: boolean = true): Promise<void> {
     const detentsLength = Math.min(this.props.detents?.length ?? 2, 3); // Max 3 detents
     if (index < 0 || index >= detentsLength) {
       throw new Error(
@@ -303,7 +310,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
       });
     }
 
-    return TrueSheetModule?.presentByRef(this.handle, index);
+    return TrueSheetModule?.presentByRef(this.handle, index, animated);
   }
 
   /**
@@ -316,9 +323,10 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
 
   /**
    * Dismisses the Sheet
+   * @param animated - Whether to animate the dismissal (default: true)
    */
-  public async dismiss(): Promise<void> {
-    return TrueSheetModule?.dismissByRef(this.handle);
+  public async dismiss(animated: boolean = true): Promise<void> {
+    return TrueSheetModule?.dismissByRef(this.handle, animated);
   }
 
   componentDidMount(): void {

--- a/src/specs/NativeTrueSheetModule.ts
+++ b/src/specs/NativeTrueSheetModule.ts
@@ -13,18 +13,20 @@ interface Spec extends TurboModule {
    * Present a sheet by reference
    * @param viewTag - Native view tag of the sheet component
    * @param index - Detent index to present at
+   * @param animated - Whether to animate the presentation
    * @returns Promise that resolves when sheet is fully presented
    * @throws PRESENT_FAILED if presentation fails
    */
-  presentByRef(viewTag: number, index: number): Promise<void>;
+  presentByRef(viewTag: number, index: number, animated: boolean): Promise<void>;
 
   /**
    * Dismiss a sheet by reference
    * @param viewTag - Native view tag of the sheet component
+   * @param animated - Whether to animate the dismissal
    * @returns Promise that resolves when sheet is fully dismissed
    * @throws DISMISS_FAILED if dismissal fails
    */
-  dismissByRef(viewTag: number): Promise<void>;
+  dismissByRef(viewTag: number, animated: boolean): Promise<void>;
 
   /**
    * Resize a sheet to a different index by reference


### PR DESCRIPTION
## Summary

Adds an `animated` parameter to `present()` and `dismiss()` imperative methods, allowing control over whether the sheet animates during presentation and dismissal.

## Changes

- **TurboModule spec**: Added `animated: boolean` parameter to `presentByRef` and `dismissByRef`
- **TypeScript**: Updated instance and static methods with `animated` parameter (defaults to `true`)
- **iOS**: Pass `animated` parameter through to native view methods
- **Android**: Pass `animated` parameter and disable window animations when `false`
- **Docs**: Updated methods documentation

## Usage

```tsx
// Present without animation
await sheetRef.current?.present(0, false);

// Dismiss without animation
await sheetRef.current?.dismiss(false);

// Static methods
await TrueSheet.present('mySheet', 0, false);
await TrueSheet.dismiss('mySheet', false);
```