### PR TITLE
refactor: rename background prop to backgroundColor

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -267,7 +267,7 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     viewController.sheetCornerRadius = radius
   }
 
-  fun setSheetBackgroundColor(color: Int) {
+  fun setSheetBackgroundColor(color: Int?) {
     if (viewController.sheetBackgroundColor == color) return
     viewController.sheetBackgroundColor = color
   }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -142,7 +142,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   var grabber: Boolean = true
   var grabberOptions: GrabberOptions? = null
   var sheetCornerRadius: Float = -1f
-  var sheetBackgroundColor: Int = 0
+  var sheetBackgroundColor: Int? = null
   var edgeToEdgeFullScreen: Boolean = false
 
   var dismissible: Boolean = true
@@ -574,7 +574,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
     val cornerRadius = if (sheetCornerRadius < 0) DEFAULT_CORNER_RADIUS.dpToPx() else sheetCornerRadius
     val outerRadii = floatArrayOf(cornerRadius, cornerRadius, cornerRadius, cornerRadius, 0f, 0f, 0f, 0f)
-    val backgroundColor = if (sheetBackgroundColor != 0) sheetBackgroundColor else getDefaultBackgroundColor()
+    val backgroundColor = sheetBackgroundColor ?: getDefaultBackgroundColor()
 
     bottomSheet.background = ShapeDrawable(RoundRectShape(outerRadii, null, null)).apply {
       paint.color = backgroundColor

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -97,8 +97,8 @@ class TrueSheetViewManager :
     view.setDetents(detents)
   }
 
-  @ReactProp(name = "background", defaultInt = 0)
-  override fun setBackground(view: TrueSheetView, color: Int) {
+  @ReactProp(name = "backgroundColor", customType = "Color")
+  override fun setBackgroundColor(view: TrueSheetView, color: Int?) {
     view.setSheetBackgroundColor(color)
   }
 

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -15,8 +15,7 @@
     <style name="TrueSheetEdgeToEdgeEnabledDialog" parent="Theme.Design.Light.BottomSheetDialog">
         <item name="android:windowIsFloating">false</item>
         <item name="enableEdgeToEdge">true</item>
-<!--        <item name="android:navigationBarColor">@android:color/transparent</item>-->
-        <item name="android:navigationBarColor">#90000000</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowAnimationStyle">@style/TrueSheetAnimation</item>
     </style>
 </resources>

--- a/example/src/screens/MapScreen.tsx
+++ b/example/src/screens/MapScreen.tsx
@@ -45,12 +45,14 @@ export const MapScreen = () => {
   const navigation = useAppNavigation();
 
   const sheetRef = useRef<TrueSheet>(null);
+  const minHeight = HEADER_HEIGHT + Platform.select({ android: SPACING, default: 0 });
 
   const basicSheet = useRef<TrueSheet>(null);
   const promptSheet = useRef<TrueSheet>(null);
   const scrollViewSheet = useRef<TrueSheet>(null);
   const flatListSheet = useRef<TrueSheet>(null);
   const gestureSheet = useRef<TrueSheet>(null);
+
   const [scrollViewLoading, setScrollViewLoading] = useState(false);
   const [showExtraContent, setShowExtraContent] = useState(false);
 
@@ -101,7 +103,7 @@ export const MapScreen = () => {
         onPress={() => sheetRef.current?.resize(0)}
       />
       <ReanimatedTrueSheet
-        detents={[HEADER_HEIGHT / height, 'auto', 1]}
+        detents={[minHeight / height, 'auto', 1]}
         ref={sheetRef}
         initialDetentIndex={0}
         dimmedDetentIndex={2}
@@ -109,7 +111,7 @@ export const MapScreen = () => {
         // insetAdjustment="never"
         edgeToEdgeFullScreen
         style={styles.content}
-        backgroundColor={Platform.select({ default: DARK })}
+        backgroundColor={Platform.select({ android: DARK })}
         onLayout={(e: LayoutChangeEvent) => {
           console.log(
             `sheet layout width: ${e.nativeEvent.layout.width}, height: ${e.nativeEvent.layout.height}`

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -123,8 +123,7 @@ using namespace facebook::react;
   _controller.detents = detents;
 
   // Background color
-  _controller.backgroundColor =
-    newProps.background == 0 ? nil : RCTUIColorFromSharedColor(SharedColor(newProps.background));
+  _controller.backgroundColor = RCTUIColorFromSharedColor(newProps.backgroundColor);
 
   // Blur tint
   _controller.blurTint = !newProps.blurTint.empty() ? RCTNSStringFromString(newProps.blurTint) : nil;

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -408,7 +408,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
         detents={resolvedDetents}
         blurTint={blurTint}
         blurOptions={blurOptions}
-        background={(processColor(backgroundColor) as number) ?? 0}
+        backgroundColor={backgroundColor}
         cornerRadius={cornerRadius}
         grabber={grabber}
         grabberOptions={{

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -1,4 +1,4 @@
-import type { ViewProps } from 'react-native';
+import type { ColorValue, ViewProps } from 'react-native';
 import type {
   DirectEventHandler,
   Double,
@@ -39,8 +39,10 @@ export interface NativeProps extends ViewProps {
 
   // Number properties - use 0 as default to avoid nil insertion
   maxHeight?: WithDefault<Double, 0>;
-  background?: WithDefault<Int32, 0>;
   cornerRadius?: WithDefault<Double, -1>;
+
+  // Color properties
+  backgroundColor?: ColorValue;
   initialDetentIndex?: WithDefault<Int32, -1>;
   dimmedDetentIndex?: WithDefault<Int32, 0>;
 


### PR DESCRIPTION
## Summary

- Renamed `background` prop to `backgroundColor` for consistency with React Native conventions
- Use `ColorValue` type in native component spec for proper color handling
- iOS: Use `RCTUIColorFromSharedColor` directly with SharedColor
- Android: Use `customType="Color"` for automatic color conversion
- Remove manual `processColor` call in TrueSheet.tsx