### PR TITLE
fix(ios): scrollView unscrollable when draggable=false

### DIFF
--- a/example/src/components/sheets/FlatListSheet.tsx
+++ b/example/src/components/sheets/FlatListSheet.tsx
@@ -20,8 +20,6 @@ export const FlatListSheet = forwardRef((props: FlatListSheetProps, ref: Ref<Tru
       keyboardMode="pan"
       edgeToEdgeFullScreen
       scrollable
-      draggable={false}
-      dismissible={false}
       header={
         <Header>
           <Input />


### PR DESCRIPTION
## Summary

Fixes #282

When `draggable={false}` was set on a TrueSheet, nested ScrollView elements became unscrollable.

## Changes

- Only disable pan gestures on the presented view (sheet), not on the ScrollView - this preserves scroll functionality
- Set `prefersScrollingExpandsWhenScrolledToEdge = self.draggable` to prevent scrolling from expanding the sheet when draggable is disabled

## Note

When using `draggable={false}` with a ScrollView, dragging down on the ScrollView can still dismiss the sheet (iOS built-in behavior). Users who need this combination should also set `dismissible={false}` to prevent unintended dismissal.