### PR TITLE
fix(grabber): use ProcessedColorValue for color prop and fix z-order

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -130,7 +130,7 @@ class TrueSheetViewManager :
       } else {
         null
       },
-      color = if (options.hasKey("color") && options.getInt("color") != 0) options.getInt("color") else null
+      color = if (options.hasKey("color") && !options.isNull("color")) options.getInt("color") else null
     )
     view.setGrabberOptions(grabberOptions)
   }

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -148,8 +148,9 @@ using namespace facebook::react;
 
   // Grabber options - check if any non-default values are set
   const auto &grabberOpts = newProps.grabberOptions;
+  UIColor *grabberColor = RCTUIColorFromSharedColor(grabberOpts.color);
   BOOL hasGrabberOptions = grabberOpts.width > 0 || grabberOpts.height > 0 || grabberOpts.topMargin > 0 ||
-                           grabberOpts.cornerRadius >= 0 || grabberOpts.color != 0;
+                           grabberOpts.cornerRadius >= 0 || grabberColor != nil;
 
   if (hasGrabberOptions) {
     NSMutableDictionary *options = [NSMutableDictionary dictionary];
@@ -166,8 +167,8 @@ using namespace facebook::react;
     if (grabberOpts.cornerRadius >= 0) {
       options[@"cornerRadius"] = @(grabberOpts.cornerRadius);
     }
-    if (grabberOpts.color != 0) {
-      options[@"color"] = RCTUIColorFromSharedColor(SharedColor(grabberOpts.color));
+    if (grabberColor) {
+      options[@"color"] = grabberColor;
     }
 
     _controller.grabberOptions = options;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -859,6 +859,9 @@
     _grabberView.color = options[@"color"];
     [_grabberView applyConfiguration];
     _grabberView.hidden = !showGrabber;
+
+    // Ensure grabber is above container/header views
+    [self.view bringSubviewToFront:_grabberView];
   } else {
     sheet.prefersGrabberVisible = showGrabber;
     _grabberView.hidden = YES;

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -34,7 +34,7 @@ import TrueSheetFooterViewNativeComponent from './fabric/TrueSheetFooterViewNati
 
 import TrueSheetModule from './specs/NativeTrueSheetModule';
 
-import { Platform, processColor, StyleSheet, findNodeHandle, View } from 'react-native';
+import { Platform, StyleSheet, findNodeHandle, View, processColor } from 'react-native';
 
 const LINKING_ERROR =
   `The package '@lodev09/react-native-true-sheet' doesn't seem to be linked. Make sure: \n\n` +
@@ -413,7 +413,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
         grabber={grabber}
         grabberOptions={{
           ...grabberOptions,
-          color: (processColor(grabberOptions?.color) as number) ?? 0,
+          color: processColor(grabberOptions?.color),
         }}
         dimmed={dimmed}
         dimmedDetentIndex={dimmedDetentIndex}

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -1,4 +1,4 @@
-import type { ColorValue, ViewProps } from 'react-native';
+import type { ColorValue, ProcessedColorValue, ViewProps } from 'react-native';
 import type {
   DirectEventHandler,
   Double,
@@ -12,7 +12,7 @@ type GrabberOptionsType = Readonly<{
   height?: Double;
   topMargin?: Double;
   cornerRadius?: WithDefault<Double, -1>;
-  color?: Int32;
+  color?: ProcessedColorValue | null;
 }>;
 
 type BlurOptionsType = Readonly<{


### PR DESCRIPTION
## Changes

### Color type fix
- Changed `grabberOptions.color` from `Int32` to `ProcessedColorValue | null` in the native component spec
- Added `processColor()` in TrueSheet.tsx to convert colors before passing to native
- Updated iOS native code to use `RCTUIColorFromSharedColor` directly (removed `SharedColor()` wrapper)
- Updated Android null check to use `isNull()` instead of comparing to `0`

### Z-order fix (iOS only)
- Added `bringSubviewToFront` for custom grabber view to ensure it renders above header views

Android z-order is already correct since the grabber is added after the content view.