### PR TITLE
fix(navigation): add insetAdjustment to TrueSheetNavigationOptions type

### DIFF
--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -142,6 +142,7 @@ export type TrueSheetNavigationOptions = Pick<
   | 'pageSizing'
   | 'header'
   | 'footer'
+  | 'insetAdjustment'
   | 'stackBehavior'
 > & {
   /**


### PR DESCRIPTION
Adds the missing `insetAdjustment` prop to `TrueSheetNavigationOptions` type definition.

The property already works at runtime but was missing from the TypeScript type, causing type errors when used in navigation screen options.

Closes #305