### PR TITLE
fix: include __mocks__ in build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
   "react-native-builder-bob": {
     "source": "src",
     "output": "lib",
+    "exclude": "**/{__tests__,__fixtures__}/**",
     "targets": [
       [
         "module",


### PR DESCRIPTION
Include the `__mocks__` folder in the build output so consumers can use it to mock the library in their tests.

## Changes
- Updated react-native-builder-bob exclude pattern to only exclude `__tests__` and `__fixtures__` (not `__mocks__`)
- Removed `__mocks__` from tsconfig.json exclude list

Fixes #313