### PR TITLE
fix: remove focus/blur events for external sheet presentation

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -373,26 +373,14 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   private fun setupModalObserver() {
     rnScreensObserver = RNScreensFragmentObserver(
       reactContext = reactContext,
-      onModalWillPresent = {
-        if (isPresented) {
-          delegate?.viewControllerWillBlur()
-        }
-      },
       onModalPresented = {
         if (isPresented) {
           hideDialog()
-          delegate?.viewControllerDidBlur()
-        }
-      },
-      onModalWillDismiss = {
-        if (isPresented) {
-          delegate?.viewControllerWillFocus()
         }
       },
       onModalDismissed = {
         if (isPresented) {
           showDialog()
-          delegate?.viewControllerDidFocus()
         }
       }
     )

--- a/android/src/main/java/com/lodev09/truesheet/core/RNScreensFragmentObserver.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/RNScreensFragmentObserver.kt
@@ -13,9 +13,7 @@ private const val RN_SCREENS_PACKAGE = "com.swmansion.rnscreens"
  */
 class RNScreensFragmentObserver(
   private val reactContext: ReactContext,
-  private val onModalWillPresent: () -> Unit = {},
   private val onModalPresented: () -> Unit,
-  private val onModalWillDismiss: () -> Unit = {},
   private val onModalDismissed: () -> Unit
 ) {
   private var fragmentLifecycleCallback: FragmentManager.FragmentLifecycleCallbacks? = null
@@ -33,14 +31,8 @@ class RNScreensFragmentObserver(
         super.onFragmentStarted(fm, fragment)
 
         if (isModalFragment(fragment) && !activeModalFragments.contains(fragment)) {
-          // Notify willPresent before adding to active set
-          if (activeModalFragments.isEmpty()) {
-            onModalWillPresent()
-          }
-
           activeModalFragments.add(fragment)
 
-          // Notify didPresent after modal is started
           if (activeModalFragments.size == 1) {
             onModalPresented()
           }
@@ -51,14 +43,8 @@ class RNScreensFragmentObserver(
         super.onFragmentStopped(fm, fragment)
 
         if (activeModalFragments.contains(fragment)) {
-          // Notify willDismiss before removing from active set
-          if (activeModalFragments.size == 1) {
-            onModalWillDismiss()
-          }
-
           activeModalFragments.remove(fragment)
 
-          // Notify didDismiss after all modals are dismissed
           if (activeModalFragments.isEmpty()) {
             onModalDismissed()
           }

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -38,7 +38,6 @@
   TrueSheetGrabberView *_grabberView;
 
   NSMutableArray<NSNumber *> *_resolvedDetentPositions;
-  BOOL _hasPresentedController;
 }
 
 #pragma mark - Initialization
@@ -67,7 +66,6 @@
     _blurInteraction = YES;
     _insetAdjustment = @"automatic";
     _resolvedDetentPositions = [NSMutableArray array];
-    _hasPresentedController = NO;
   }
   return self;
 }
@@ -315,58 +313,6 @@
   }
 
   _isTrackingPositionFromLayout = NO;
-}
-
-#pragma mark - Presentation Tracking (RN Screens)
-
-- (void)presentViewController:(UIViewController *)viewControllerToPresent
-                     animated:(BOOL)flag
-                   completion:(void (^)(void))completion {
-  BOOL isExternalController = ![viewControllerToPresent isKindOfClass:[TrueSheetViewController class]];
-
-  if (isExternalController && !_hasPresentedController) {
-    _hasPresentedController = YES;
-    if ([self.delegate respondsToSelector:@selector(viewControllerWillBlur)]) {
-      [self.delegate viewControllerWillBlur];
-    }
-  }
-
-  [super presentViewController:viewControllerToPresent
-                      animated:flag
-                    completion:^{
-                      if (isExternalController && self->_hasPresentedController) {
-                        if ([self.delegate respondsToSelector:@selector(viewControllerDidBlur)]) {
-                          [self.delegate viewControllerDidBlur];
-                        }
-                      }
-                      if (completion) {
-                        completion();
-                      }
-                    }];
-}
-
-- (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion {
-  UIViewController *presented = self.presentedViewController;
-  BOOL isExternalController = presented && ![presented isKindOfClass:[TrueSheetViewController class]];
-
-  if (isExternalController && _hasPresentedController) {
-    if ([self.delegate respondsToSelector:@selector(viewControllerWillFocus)]) {
-      [self.delegate viewControllerWillFocus];
-    }
-  }
-
-  [super dismissViewControllerAnimated:flag
-                            completion:^{
-                              if (isExternalController && self->_hasPresentedController) {
-                                self->_hasPresentedController = NO;
-                                if ([self.delegate respondsToSelector:@selector(viewControllerDidFocus)]) {
-                                  [self.delegate viewControllerDidFocus];
-                                }
-                              }
-                              if (completion) {
-                                completion();
-                              }
-                            }];
 }
 
 #pragma mark - Position & Gesture Handling


### PR DESCRIPTION
Removes focus/blur event emissions when external (non-TrueSheet) views are presented/dismissed on top of a sheet.

### Changes

**iOS:**
- Removed `presentViewController:` and `dismissViewControllerAnimated:` overrides from `TrueSheetViewController`

**Android:**
- Removed focus/blur emissions from `RNScreensFragmentObserver` callbacks
- Removed unused `onModalWillPresent` and `onModalWillDismiss` parameters

Focus/blur events are still emitted when TrueSheets are stacked on top of each other.