### PR TITLE
fix: key window fallback for cold start and deep link handling

### DIFF
--- a/ios/utils/WindowUtil.mm
+++ b/ios/utils/WindowUtil.mm
@@ -15,10 +15,13 @@
 + (nullable UIWindow *)keyWindow {
   NSSet<UIScene *> *connectedScenes = [UIApplication sharedApplication].connectedScenes;
 
+  UIWindow *fallbackWindow = nil;
+
   for (UIScene *scene in connectedScenes) {
     if ([scene isKindOfClass:[UIWindowScene class]]) {
       UIWindowScene *windowScene = (UIWindowScene *)scene;
 
+      // Check for foreground active first (preferred)
       if (windowScene.activationState == UISceneActivationStateForegroundActive) {
         for (UIWindow *window in windowScene.windows) {
           if (window.isKeyWindow) {
@@ -31,10 +34,23 @@
           return windowScene.windows.firstObject;
         }
       }
+
+      // Store a fallback window for transitional states (e.g., deep link handling from background or cold start)
+      if (fallbackWindow == nil && windowScene.windows.count > 0) {
+        for (UIWindow *window in windowScene.windows) {
+          if (window.isKeyWindow) {
+            fallbackWindow = window;
+            break;
+          }
+        }
+        if (fallbackWindow == nil) {
+          fallbackWindow = windowScene.windows.firstObject;
+        }
+      }
     }
   }
 
-  return nil;
+  return fallbackWindow;
 }
 
 @end


### PR DESCRIPTION
## Summary

Fixes #321 - Sheet won't open when entering the app from a deep link

## Problem

When launching the app via deep link (e.g., `<app-name>://favorites`), the app navigates to the correct route but the sheet fails to display. This happens because:

1. **iOS**: During cold start or deep link handling from background, no scene is in `UISceneActivationStateForegroundActive` state yet, so `keyWindow` returns `nil` and no presenting view controller is found
2. **Navigation**: Deep links bypass the base route, breaking the expected route structure that `TrueSheetView` relies on (`const [baseRoute, ...sheetRoutes] = state.routes`)

## Changes

### iOS (`WindowUtil.mm`)
- Added fallback window lookup for transitional states
- Still prefers foreground active scenes, but falls back to any available key window
- Returns a valid window instead of `nil` during app launch transitions

### Navigation (`TrueSheetRouter.ts`)
- Ensures base route is always present in `getInitialState` and `getRehydratedState`
- Extracted common logic into `ensureBaseRoute` helper
- Inserts base route at index 0 when missing (deep link scenarios)
- Correctly sets index to point to the deep link target

## Testing

- Verified both call sites of `keyWindow` already handle `nil` gracefully
- Router changes align with `TrueSheetView`'s expectation: `const [baseRoute, ...sheetRoutes] = state.routes`
- goBack/dismiss logic properly protects base route at index 0
