### PR TITLE
feat: add adaptive grabber color for light/dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The true native bottom sheet experience for your React Native Apps. 💩
 
-<img alt="React Native True Sheet - IOS" src="docs/static/img/preview-ios.gif" height="500" /><img alt="React Native True Sheet - Android" src="docs/static/img/preview-android.gif" height="500" /><img alt="React Native True Sheet - Web" src="docs/static/img/preview-web.gif" height="500" />
+<img alt="React Native True Sheet - IOS" src="docs/static/img/preview-ios.gif" width="246 height="500" /><img alt="React Native True Sheet - Android" src="docs/static/img/preview-android.gif" width="246 height="500" /><img alt="React Native True Sheet - Web" src="docs/static/img/preview-web.gif" width="246 height="500" />
 
 ## Features
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -130,7 +130,8 @@ class TrueSheetViewManager :
       } else {
         null
       },
-      color = if (options.hasKey("color") && !options.isNull("color")) options.getInt("color") else null
+      color = if (options.hasKey("color") && !options.isNull("color")) options.getInt("color") else null,
+      adaptive = if (options.hasKey("adaptive")) options.getBoolean("adaptive") else true
     )
     view.setGrabberOptions(grabberOptions)
   }

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetGrabberView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetGrabberView.kt
@@ -19,7 +19,8 @@ data class GrabberOptions(
   val height: Float? = null,
   val topMargin: Float? = null,
   val cornerRadius: Float? = null,
-  val color: Int? = null
+  val color: Int? = null,
+  val adaptive: Boolean = true
 )
 
 /**
@@ -34,6 +35,7 @@ class TrueSheetGrabberView(context: Context, private val options: GrabberOptions
     private const val DEFAULT_HEIGHT = 4f // dp
     private const val DEFAULT_TOP_MARGIN = 16f // dp
     private const val DEFAULT_ALPHA = 0.4f
+    private val DEFAULT_COLOR = Color.argb((DEFAULT_ALPHA * 255).toInt(), 73, 69, 79) // #49454F @ 40%
   }
 
   private val grabberWidth: Float
@@ -48,8 +50,11 @@ class TrueSheetGrabberView(context: Context, private val options: GrabberOptions
   private val grabberCornerRadius: Float
     get() = options?.cornerRadius ?: (grabberHeight / 2)
 
+  private val isAdaptive: Boolean
+    get() = options?.adaptive ?: true
+
   private val grabberColor: Int
-    get() = getAdaptiveColor(options?.color)
+    get() = if (isAdaptive) getAdaptiveColor(options?.color) else options?.color ?: DEFAULT_COLOR
 
   init {
     layoutParams = FrameLayout.LayoutParams(
@@ -70,10 +75,6 @@ class TrueSheetGrabberView(context: Context, private val options: GrabberOptions
     elevation = 100f
   }
 
-  /**
-   * Gets an adaptive color based on the current light/dark mode.
-   * If a base color is provided, it blends with white/black based on the mode.
-   */
   private fun getAdaptiveColor(baseColor: Int? = null): Int {
     val nightMode = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
     val isDarkMode = nightMode == Configuration.UI_MODE_NIGHT_YES

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -12,9 +12,9 @@ import previewWeb from '/img/preview-web.gif'
 
 The **_true_** native bottom sheet experience for your [React Native](https://reactnative.dev) Apps.
 
-<img alt="preview ios" src={previewIos} height="500"/>
-<img alt="preview android" src={previewAndroid} height="500"/>
-<img alt="preview web" src={previewWeb} height="500"/>
+<img alt="preview ios" src={previewIos} width="246" height="500"/>
+<img alt="preview android" src={previewAndroid} width="246" height="500"/>
+<img alt="preview web" src={previewWeb} width="246" height="500"/>
 
 ## Features
 

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -85,6 +85,7 @@ Options for customizing the grabber (drag handle) appearance.
     topMargin: 10,
     cornerRadius: 3,
     color: '#FF0000',
+    adaptive: false,
   }}
 >
   <View />
@@ -98,6 +99,7 @@ Options for customizing the grabber (drag handle) appearance.
 | `topMargin` | `number` | The top margin from the sheet edge. | iOS: `5`, Android: `16` |
 | `cornerRadius` | `number` | The corner radius of the grabber pill. | `height / 2` |
 | `color` | `ColorValue` | The color of the grabber. Uses native styling when not provided. | |
+| `adaptive` | `boolean` | Whether the grabber adapts to light/dark mode. Uses vibrancy on iOS and theme-based colors on Android. | `true` |
 
 ## `InsetAdjustment`
 

--- a/example/bare/ios/Podfile.lock
+++ b/example/bare/ios/Podfile.lock
@@ -2646,7 +2646,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNTrueSheet (3.3.0-beta.0):
+  - RNTrueSheet (3.3.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3095,7 +3095,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: e1cf8ef3f11045536eed6bd4f132b003ef5f9a5f
   RNReanimated: f1868b36f4b2b52a0ed00062cfda69506f75eaee
   RNScreens: d821082c6dd1cb397cc0c98b026eeafaa68be479
-  RNTrueSheet: 60b7c29de68404a390dc7c22625e312475e9c41b
+  RNTrueSheet: 43f9102209f0456a33715b7ea717962158ab340c
   RNWorklets: d9c050940f140af5d8b611d937eab1cbfce5e9a5
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -150,7 +150,7 @@ using namespace facebook::react;
   const auto &grabberOpts = newProps.grabberOptions;
   UIColor *grabberColor = RCTUIColorFromSharedColor(grabberOpts.color);
   BOOL hasGrabberOptions = grabberOpts.width > 0 || grabberOpts.height > 0 || grabberOpts.topMargin > 0 ||
-                           grabberOpts.cornerRadius >= 0 || grabberColor != nil;
+                           grabberOpts.cornerRadius >= 0 || grabberColor != nil || !grabberOpts.adaptive;
 
   if (hasGrabberOptions) {
     NSMutableDictionary *options = [NSMutableDictionary dictionary];
@@ -170,6 +170,7 @@ using namespace facebook::react;
     if (grabberColor) {
       options[@"color"] = grabberColor;
     }
+    options[@"adaptive"] = @(grabberOpts.adaptive);
 
     _controller.grabberOptions = options;
   } else {

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -808,6 +808,7 @@
     _grabberView.topMargin = options[@"topMargin"];
     _grabberView.cornerRadius = options[@"cornerRadius"];
     _grabberView.color = options[@"color"];
+    _grabberView.adaptive = options[@"adaptive"];
     [_grabberView applyConfiguration];
     _grabberView.hidden = !showGrabber;
 

--- a/ios/core/TrueSheetGrabberView.h
+++ b/ios/core/TrueSheetGrabberView.h
@@ -31,6 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Custom color for the grabber (uses vibrancy effect when nil)
 @property (nonatomic, strong, nullable) UIColor *color;
 
+/// Whether the grabber color adapts to the background (default: YES)
+@property (nonatomic, strong, nullable) NSNumber *adaptive;
+
 /// Adds the grabber view to a parent view with proper constraints
 - (void)addToView:(UIView *)parentView;
 

--- a/ios/core/TrueSheetGrabberView.mm
+++ b/ios/core/TrueSheetGrabberView.mm
@@ -44,6 +44,10 @@ static const CGFloat kDefaultGrabberTopMargin = 5.0;
   return _cornerRadius ? [_cornerRadius floatValue] : [self effectiveHeight] / 2.0;
 }
 
+- (BOOL)isAdaptive {
+  return _adaptive ? [_adaptive boolValue] : YES;
+}
+
 #pragma mark - Setup
 
 - (void)setupView {
@@ -91,11 +95,15 @@ static const CGFloat kDefaultGrabberTopMargin = 5.0;
   _vibrancyView.frame = self.bounds;
   _fillView.frame = _vibrancyView.contentView.bounds;
 
-  // Apply custom color to vibrancy view
-  if (_color) {
+  if ([self isAdaptive]) {
+    _vibrancyView.effect = [UIVibrancyEffect effectForBlurEffect:[UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemChromeMaterial] style:UIVibrancyEffectStyleFill];
     _vibrancyView.backgroundColor = _color;
+    _fillView.hidden = NO;
   } else {
+    _vibrancyView.effect = nil;
     _vibrancyView.backgroundColor = nil;
+    _fillView.hidden = YES;
+    self.backgroundColor = _color ?: [UIColor.darkGrayColor colorWithAlphaComponent:0.7];
   }
 }
 

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -119,6 +119,14 @@ export interface GrabberOptions {
    * Uses native vibrancy/material styling when not provided.
    */
   color?: ColorValue;
+  /**
+   * Whether the grabber color adapts to light/dark mode.
+   * When enabled, the grabber uses vibrancy effect on iOS and
+   * adjusts color based on the current theme on Android.
+   *
+   * @default true
+   */
+  adaptive?: boolean;
 }
 
 /**

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -13,6 +13,7 @@ type GrabberOptionsType = Readonly<{
   topMargin?: Double;
   cornerRadius?: WithDefault<Double, -1>;
   color?: ProcessedColorValue | null;
+  adaptive?: WithDefault<boolean, true>;
 }>;
 
 type BlurOptionsType = Readonly<{


### PR DESCRIPTION
## Summary

Adds an `adaptive` option to `grabberOptions` that controls whether the grabber color adapts to light/dark mode.

### iOS
- Uses `UIVibrancyEffect` for adaptive appearance when `adaptive: true` (default)
- Uses solid color when `adaptive: false`

### Android
- Detects light/dark mode via `Configuration.UI_MODE_NIGHT_MASK`
- Blends user-provided color with white/black based on mode when `adaptive: true`
- Uses exact color when `adaptive: false`

## Usage

```tsx
<TrueSheet
  grabber
  grabberOptions={{
    color: '#F6F6F8',
    adaptive: false, // Disable adaptive behavior
  }}
>
  ...
</TrueSheet>
```

## Changes

- `TrueSheetGrabberView.kt`: Added adaptive color logic
- `TrueSheetGrabberView.mm`: Added adaptive vibrancy toggle
- `TrueSheet.types.ts`: Added `adaptive` to `GrabberOptions`
- Updated docs