### PR TITLE
feat(ios): add default blur tint for iOS < 26

### DIFF
--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -781,19 +781,26 @@
 
   self.view.backgroundColor = self.backgroundColor;
 
-  BOOL blurTintChanged = ![_blurView.blurTint isEqualToString:self.blurTint];
+  NSString *effectiveBlurTint = self.blurTint;
+  if (@available(iOS 26.0, *)) {
+    // iOS 26+ has defualt liquid glass effect
+  } else if ((!effectiveBlurTint || effectiveBlurTint.length == 0) && !self.backgroundColor) {
+    effectiveBlurTint = @"system-material";
+  }
+
+  BOOL blurTintChanged = ![_blurView.blurTint isEqualToString:effectiveBlurTint];
 
   if (_blurView && blurTintChanged) {
     [_blurView removeFromSuperview];
     _blurView = nil;
   }
 
-  if (self.blurTint && self.blurTint.length > 0) {
+  if (effectiveBlurTint && effectiveBlurTint.length > 0) {
     if (!_blurView) {
       _blurView = [[TrueSheetBlurView alloc] init];
       [_blurView addToView:self.view];
     }
-    _blurView.blurTint = self.blurTint;
+    _blurView.blurTint = effectiveBlurTint;
     _blurView.blurIntensity = self.blurIntensity;
     _blurView.blurInteraction = self.blurInteraction;
     [_blurView applyBlurEffect];

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -357,7 +357,7 @@ export interface TrueSheetProps extends ViewProps {
 
   /**
    * The blur effect style on iOS.
-   * Overrides `backgroundColor` if set.
+   * Blends with `backgroundColor` when provided.
    *
    * @platform ios
    */


### PR DESCRIPTION
Fixes #333

On iOS < 26, the sheet now defaults to `system-material` blur when no `blurTint` or `backgroundColor` is specified. This prevents the transparent background issue on older iOS versions.

iOS 26+ has native sheet blur so no default is needed.