### PR TITLE
docs: add Xcode 26.2 and EAS Build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The true native bottom sheet experience for your React Native Apps. 💩
 
 - React Native >= 0.76 (Expo SDK 52+)
 - New Architecture enabled (default in RN 0.76+)
+- Xcode 26.2 (strongly recommended for better library functionality)
 
 ### Expo
 
@@ -43,6 +44,27 @@ npx expo install @lodev09/react-native-true-sheet
 ```sh
 yarn add @lodev09/react-native-true-sheet
 cd ios && pod install
+```
+
+### EAS Build (iOS)
+
+When using [EAS Build](https://docs.expo.dev/build/introduction/) to build your iOS app, you must configure your `eas.json` to use a build image that includes Xcode 26.2. Use `"image": "latest"` or choose from the [available build images](https://docs.expo.dev/build-reference/infrastructure/#ios-server-images):
+
+```json
+{
+  "build": {
+    "production": {
+      "ios": {
+        "image": "latest"
+      }
+    },
+    "development": {
+      "ios": {
+        "image": "latest"
+      }
+    }
+  }
+}
 ```
 
 ## Documentation

--- a/docs/docs/install.mdx
+++ b/docs/docs/install.mdx
@@ -10,6 +10,7 @@ keywords: [bottom sheet installation, bottom sheet yarn, bottom sheet npm, ios b
 
 - React Native >= 0.76 (Expo SDK 52+)
 - New Architecture enabled (default in RN 0.76+)
+- Xcode 26.2 (strongly recommended for better library functionality)
 
 :::info
 This package is not compatible with [Expo Go](https://docs.expo.dev/get-started/expo-go/). Use this with [Expo CNG](https://docs.expo.dev/workflow/continuous-native-generation/) instead.
@@ -31,4 +32,25 @@ Then install the native dependencies:
 
 ```sh
 cd ios && pod install
+```
+
+## EAS Build (iOS)
+
+When using [EAS Build](https://docs.expo.dev/build/introduction/) to build your iOS app, you must configure your `eas.json` to use a build image that includes Xcode 26.2. Use `"image": "latest"` or choose from the [available build images](https://docs.expo.dev/build-reference/infrastructure/#ios-server-images):
+
+```json
+{
+  "build": {
+    "production": {
+      "ios": {
+        "image": "latest"
+      }
+    },
+    "development": {
+      "ios": {
+        "image": "latest"
+      }
+    }
+  }
+}
 ```

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -94,3 +94,40 @@ A fix has been submitted to React Native. See [PR #55005](https://github.com/fac
 ## Weird layout render
 
 The sheet does not have control over how React Native renders components and may lead to rendering issues. To resolve this, try to minimize the use of `flex=1` in your content styles. Instead, use fixed `height` or employ `flexGrow`, `flexBasis`, etc., to manage your layout requirements.
+
+## Build Failures with Xcode or EAS
+
+If you encounter build failures when building your iOS app, it may be due to an incorrect Xcode version or EAS build configuration.
+
+### Xcode Version
+
+The package works better with **Xcode 26.2**. If you're building locally, check your Xcode version:
+
+```sh
+xcodebuild -version
+```
+
+If you're experiencing issues, we recommend updating to Xcode 26.2.
+
+### EAS Build Configuration
+
+When using [EAS Build](https://docs.expo.dev/build/introduction/), you must configure your `eas.json` to use a build image that includes Xcode 26.2 to build your app. Use `"image": "latest"` or choose from the [available build images](https://docs.expo.dev/build-reference/infrastructure/#ios-server-images):
+
+```json
+{
+  "build": {
+    "production": {
+      "ios": {
+        "image": "latest"
+      }
+    },
+    "development": {
+      "ios": {
+        "image": "latest"
+      }
+    }
+  }
+}
+```
+
+Without this configuration, EAS may use an older build image that doesn't include Xcode 26.2, causing build failures.


### PR DESCRIPTION
- Add Xcode 26.2 as strongly recommended prerequisite
- Add EAS Build configuration section with iOS build image requirements
- Add troubleshooting section for Xcode and EAS build issues

## Summary
Closes https://github.com/lodev09/react-native-true-sheet/issues/367

This PR adds documentation for Xcode 26.2 requirements and EAS Build configuration to help users properly set up their development environment and build their iOS apps.

The changes include:
- Add Xcode 26.2 as strongly recommended prerequisite
- Add EAS Build configuration section with iOS build image requirements
- Add troubleshooting section for Xcode and EAS build issues

This ensures users understand that Xcode 26.2 is recommended for better library functionality and required when using EAS Build to build iOS apps.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Test Plan

- Reviewed all documentation files (README.md, docs/docs/install.mdx, docs/docs/troubleshooting.mdx) for grammar, clarity, and consistency
- Verified all links to EAS Build documentation are correct and working
- Ensured consistent messaging across all three documentation files

## Screenshots / Videos

<!-- Not applicable for documentation changes -->

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)