### PR TITLE
fix(android): add RootNodeKind trait for nested sheet touch handling

### DIFF
--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetViewShadowNode.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetViewShadowNode.h
@@ -22,6 +22,12 @@ class JSI_EXPORT TrueSheetViewShadowNode final
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 
  public:
+  static ShadowNodeTraits BaseTraits() {
+    auto traits = ConcreteViewShadowNode::BaseTraits();
+    traits.set(ShadowNodeTraits::Trait::RootNodeKind);
+    return traits;
+  }
+
   void adjustLayoutWithState();
 };
 

--- a/example/shared/src/screens/MapScreen.tsx
+++ b/example/shared/src/screens/MapScreen.tsx
@@ -192,11 +192,11 @@ const MapScreenInner = ({
             onPress={() => sheetRef.current?.dismiss()}
           />
         </View>
+        <BasicSheet ref={basicSheet} onNavigateToModal={onNavigateToModal} />
+        <PromptSheet ref={promptSheet} />
+        <ScrollViewSheet ref={scrollViewSheet} />
+        <GestureSheet ref={gestureSheet} />
       </ReanimatedTrueSheet>
-      <BasicSheet ref={basicSheet} onNavigateToModal={onNavigateToModal} />
-      <PromptSheet ref={promptSheet} />
-      <ScrollViewSheet ref={scrollViewSheet} />
-      <GestureSheet ref={gestureSheet} />
       <FlatListSheet ref={flatListSheet} />
     </View>
   );


### PR DESCRIPTION
## Summary

Fixes pressables not working in nested sheets on Android real devices.

The issue was that `TrueSheetViewShadowNode` was missing the `RootNodeKind` trait. This trait is used by React Native's Fabric renderer to:

1. **Stop coordinate accumulation** - In `computeRelativeLayoutMetrics()`, the algorithm stops at nodes with `RootNodeKind`, treating them as new roots for layout calculations
2. **Proper touch routing** - In `findNodeAtPoint()`, coordinates are calculated correctly for nested views within their own coordinate space

Without this trait, nested TrueSheet components have their coordinates calculated relative to the parent sheet, which causes touch events to be routed incorrectly.

This is the same pattern used by:
- React Native's `ModalHostViewShadowNode`
- react-native-screens' `RNSModalScreenShadowNode`, `RNSFullWindowOverlayShadowNode`, and `RNSSplitViewScreenShadowNode`

Fixes #163

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Tested nested sheets with pressables on Android real device - pressables now respond correctly.

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)