### PR TITLE
fix: android build error

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerViewManager.kt
@@ -19,7 +19,7 @@ class TrueSheetContainerViewManager : ViewGroupManager<TrueSheetContainerView>()
 
   @ReactProp(name = "pointerEvents")
   fun setPointerEvents(view: TrueSheetContainerView, pointerEventsStr: String?) {
-    view.pointerEvents = PointerEvents.parsePointerEvents(pointerEventsStr)
+    view.setPointerEvents(PointerEvents.parsePointerEvents(pointerEventsStr))
   }
 
   companion object {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentViewManager.kt
@@ -19,7 +19,7 @@ class TrueSheetContentViewManager : ViewGroupManager<TrueSheetContentView>() {
 
   @ReactProp(name = "pointerEvents")
   fun setPointerEvents(view: TrueSheetContentView, pointerEventsStr: String?) {
-    view.pointerEvents = PointerEvents.parsePointerEvents(pointerEventsStr)
+    view.setPointerEvents(PointerEvents.parsePointerEvents(pointerEventsStr))
   }
 
   companion object {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetFooterViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetFooterViewManager.kt
@@ -19,7 +19,7 @@ class TrueSheetFooterViewManager : ViewGroupManager<TrueSheetFooterView>() {
 
   @ReactProp(name = "pointerEvents")
   fun setPointerEvents(view: TrueSheetFooterView, pointerEventsStr: String?) {
-    view.pointerEvents = PointerEvents.parsePointerEvents(pointerEventsStr)
+    view.setPointerEvents(PointerEvents.parsePointerEvents(pointerEventsStr))
   }
 
   companion object {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetHeaderViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetHeaderViewManager.kt
@@ -19,7 +19,7 @@ class TrueSheetHeaderViewManager : ViewGroupManager<TrueSheetHeaderView>() {
 
   @ReactProp(name = "pointerEvents")
   fun setPointerEvents(view: TrueSheetHeaderView, pointerEventsStr: String?) {
-    view.pointerEvents = PointerEvents.parsePointerEvents(pointerEventsStr)
+    view.setPointerEvents(PointerEvents.parsePointerEvents(pointerEventsStr))
   }
 
   companion object {


### PR DESCRIPTION
## Summary

Fix `'val' cannot be reassigned` error when building with Android

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Reproducible by building on Android with RN `0.79.7` and true-sheet version `3.7.0-beta.3`

## Screenshots / Videos

<!-- Add screenshots or videos if applicable -->

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
