### PR TITLE
fix(android): keyboard and focus handling inside RN Modal

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -489,7 +489,7 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
    * of whichever window this view is in - whether that's the activity's window or a
    * Modal's dialog window.
    */
-  private fun findRootContainerView(): ViewGroup? {
+  override fun findRootContainerView(): ViewGroup? {
     var current: android.view.ViewParent? = parent
 
     while (current != null) {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -46,6 +46,7 @@ data class DetentInfo(val index: Int, val position: Float)
 
 interface TrueSheetViewControllerDelegate {
   val eventDispatcher: EventDispatcher?
+  fun findRootContainerView(): ViewGroup?
   fun viewControllerWillPresent(index: Int, position: Float, detent: Float)
   fun viewControllerDidPresent(index: Int, position: Float, detent: Float)
   fun viewControllerWillDismiss()
@@ -892,7 +893,8 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   }
 
   fun saveFocusedView() {
-    focusedViewBeforeBlur = reactContext.currentActivity?.currentFocus
+    focusedViewBeforeBlur = delegate?.findRootContainerView()?.findFocus()
+      ?: reactContext.currentActivity?.currentFocus
   }
 
   fun restoreFocusedView() {

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetKeyboardObserver.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetKeyboardObserver.kt
@@ -35,7 +35,7 @@ class TrueSheetKeyboardObserver(private val targetView: View, private val reactC
     private set
 
   fun isFocusedViewWithinSheet(sheetView: View): Boolean {
-    val focusedView = reactContext.currentActivity?.currentFocus ?: return false
+    val focusedView = targetView.rootView?.findFocus() ?: return false
     var current: View? = focusedView
     while (current != null && current !== targetView) {
       if (current === sheetView) return true
@@ -131,7 +131,7 @@ class TrueSheetKeyboardObserver(private val targetView: View, private val reactC
     // Ensure we don't add duplicate listeners
     if (globalLayoutListener != null) return
 
-    val rootView = reactContext.currentActivity?.window?.decorView?.rootView ?: return
+    val rootView = targetView.rootView ?: return
     activityRootView = rootView
 
     globalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {


### PR DESCRIPTION
## Summary
Fix keyboard and focus detection when TrueSheet is presented inside a React Native Modal.

## Type of Change
- [x] Bug fix

## Test Plan
1. Open the example app
2. Navigate to Modal Screen
3. Open RN Modal
4. Present Prompt Sheet (has inputs and footer)
5. Focus an input - keyboard should show and footer should position correctly

## Checklist
- [x] I have tested this on Android

Fixes #385