### PR TITLE
refactor: separate present and resize methods

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -328,13 +328,8 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
 
   @UiThread
   fun resize(detentIndex: Int, promiseCallback: () -> Unit) {
-    if (!viewController.isPresented) {
-      RNLog.w(reactContext, "TrueSheet: Cannot resize. Sheet is not presented.")
-      promiseCallback()
-      return
-    }
-
-    present(detentIndex, true, promiseCallback)
+    viewController.resizePromise = promiseCallback
+    viewController.resize(detentIndex)
   }
 
   /**

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -398,9 +398,7 @@ using namespace facebook::react;
   }
 
   if (_controller.isPresented) {
-    [_controller.sheetPresentationController animateChanges:^{
-      [self->_controller resizeToDetentIndex:index];
-    }];
+    RCTLogWarn(@"TrueSheet: sheet is already presented. Use resize() to change detent.");
     if (completion) {
       completion(YES, nil);
     }
@@ -463,7 +461,13 @@ using namespace facebook::react;
     return;
   }
 
-  [self presentAtIndex:index animated:YES completion:completion];
+  [_controller.sheetPresentationController animateChanges:^{
+    [self->_controller resizeToDetentIndex:index];
+  }];
+
+  if (completion) {
+    completion(YES, nil);
+  }
 }
 
 - (TrueSheetViewController *)viewController {

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -332,7 +332,7 @@ export class TrueSheet
   }
 
   public async resize(index: number): Promise<void> {
-    await this.present(index);
+    await TrueSheetModule?.resizeByRef(this.handle, index);
   }
 
   public async dismiss(animated: boolean = true): Promise<void> {


### PR DESCRIPTION
## Summary

Separates `resize()` to be independent from `present()` instead of calling `present()` internally.

### Changes

- **TypeScript**: `resize()` now calls `TrueSheetModule.resizeByRef()` directly instead of delegating to `present()`
- **iOS**: `present:` logs a warning if already presented; `resize:` handles resize logic directly
- **Android**: Added separate `resizePromise`; new `resize()` method in `TrueSheetViewController`

### Behavioral Change

Previously, calling `present()` on an already-presented sheet would resize it. Now it logs a warning and does nothing—use `resize()` explicitly to change the detent.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Test Plan

Tested on iOS and Android example app:
1. Present sheet at detent index 0
2. Call `present()` again → logs warning, no resize
3. Call `resize(1)` → sheet resizes correctly

## Checklist

- [x] I have tested this on iOS
- [x] I have tested this on Android
- [ ] I have tested this on Web
- [ ] I have updated the documentation
- [ ] I have updated the changelog