### PR TITLE
docs: add initial present and deep linking troubleshooting

### DIFF
--- a/docs/docs/guides/navigation.mdx
+++ b/docs/docs/guides/navigation.mdx
@@ -177,12 +177,6 @@ function DetailsSheet() {
 
 See [Lifecycle Events](/reference/events) for more details.
 
-### Deep Linking
-
-:::warning[iOS Limitation]
-`initialDetentIndex` may not work when deep linking to a modal screen from a cold start. See [troubleshooting](/troubleshooting#initial-present-and-deep-linking) for workaround.
-:::
-
 ### Expo Router
 
 TrueSheet works with Expo Router using `withLayoutContext`.

--- a/docs/docs/guides/onmount.mdx
+++ b/docs/docs/guides/onmount.mdx
@@ -32,6 +32,8 @@ const App = () => {
 
 You may want to disable the present animation. To do this, simply set [`initialDetentAnimated`](/reference/configuration#initialdetentanimated) to `false`.
 
-### Using with React Navigation
+### Deep Linking on iOS
 
-Using this with [`react-navigation`](https://reactnavigation.org) can cause render issue. Check out the [reat-navigation guide](/guides/navigation#present-during-mount) for the fix.
+:::warning[iOS Limitation]
+`initialDetentIndex` may not work when deep linking to a modal screen from a cold start. See [troubleshooting](/troubleshooting#initial-present-and-deep-linking) for workaround.
+:::

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -112,11 +112,13 @@ using namespace facebook::react;
 
     // Only present if the view controller is in the same window and not being dismissed
     if (vc && vc.view.window == self.window && !vc.isBeingDismissed) {
-      _didInitiallyPresent = YES;
       [self presentAtIndex:_initialDetentIndex animated:_initialDetentAnimated completion:nil];
     } else {
-      // Animate next time when sheet finally moves to the correct window
-      _initialDetentAnimated = YES;
+      RCTLogWarn(@"TrueSheet: Failed to initially present the sheet, it is in the wrong window.");
+      
+      // Flag as initially presented to prevent re-presenting when moved to the correct window.
+      // This is for consistency with modal controllers that doesn't trigger this callback.
+      _didInitiallyPresent = YES;
     }
   }
 }


### PR DESCRIPTION
## Summary
Document iOS limitation where `initialDetentIndex` may not work when deep linking to a modal screen from a cold start.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes
- Add warning log when initial presentation fails on iOS
- Prevent re-presenting sheet on window change for consistency with modal controllers
- Add troubleshooting section for initial present and deep linking
- Link from navigation guide to troubleshooting

## Test Plan
Documentation only - verified links work locally.