### PR TITLE
fix(ios): preserve scroll position when nested sheet is dismissed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Fixed scroll position jumping when nested sheet is dismissed with inverted FlatList. ([#468](https://github.com/lodev09/react-native-true-sheet/pull/468) by [@lucasklaassen](https://github.com/lucasklaassen))
 - **Android**: Fixed present promise not resolving on resize. ([c3495500](https://github.com/lodev09/react-native-true-sheet/commit/c3495500) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fixed scroll view pinning to respect content view padding/margin. ([#429](https://github.com/lodev09/react-native-true-sheet/pull/429), [#446](https://github.com/lodev09/react-native-true-sheet/pull/446) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fixed footer not translating back when keyboard hides via ScrollView. ([#424](https://github.com/lodev09/react-native-true-sheet/pull/424) by [@lodev09](https://github.com/lodev09))

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -138,9 +138,15 @@ using namespace facebook::react;
   CGFloat newHeight = containerView.bounds.size.height - scrollViewFrameInContainer.origin.y;
 
   if (newHeight > 0) {
+    // Preserve contentOffset before changing frame to prevent scroll jump
+    CGPoint savedContentOffset = _pinnedScrollView.scrollView.contentOffset;
+
     CGRect frame = _pinnedScrollView.frame;
     frame.size.height = newHeight;
     _pinnedScrollView.frame = frame;
+
+    // Restore contentOffset after frame change
+    _pinnedScrollView.scrollView.contentOffset = savedContentOffset;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes scroll position jumping when a nested TrueSheet is dismissed while using an inverted `FlatList` with `scrollable={true}`.

The issue occurs because `updateScrollViewHeight` in `TrueSheetContentView.mm` modifies the scroll view's frame without preserving the `contentOffset`. When a child sheet is dismissed and the parent sheet's `layoutSubviews` is triggered, iOS adjusts the `contentOffset` causing unexpected scroll jumps.

This fix preserves and restores the `contentOffset` before and after modifying the scroll view's frame.

Fixes #467 

**Before:**
```objc
CGRect frame = _pinnedScrollView.frame;
frame.size.height = newHeight;
_pinnedScrollView.frame = frame;
```

**After:**
```objc
CGPoint savedContentOffset = _pinnedScrollView.scrollView.contentOffset;

CGRect frame = _pinnedScrollView.frame;
frame.size.height = newHeight;
_pinnedScrollView.frame = frame;

_pinnedScrollView.scrollView.contentOffset = savedContentOffset;
```

Fixes #XXX

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

1. Created a TrueSheet with `scrollable={true}` containing an inverted `FlatList` (chat interface)
2. Presented a nested TrueSheet on top (reaction picker)
3. Dismissed the nested TrueSheet
4. Verified scroll position is preserved in the parent FlatList

Tested with:
- React Native 0.76+
- Expo SDK 52
- iOS Simulator and physical device

## Screenshots / Videos

N/A - This is a behavioral fix. The scroll position now correctly stays in place when nested sheets are dismissed.

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)

---

## Commit Message

```
fix(ios): preserve scroll position when nested sheet is dismissed
```
