### PR TITLE
fix(ios): clear stale ScrollView reference when content changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- **iOS**: Fixed content clipping when sheet content changes dynamically by clearing stale ScrollView reference. ([#482](https://github.com/lodev09/react-native-true-sheet/pull/482) by [@sbs44](https://github.com/sbs44))
+
 ## 3.8.1
 
 ### 📖 Documentation

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -93,7 +93,13 @@ using namespace facebook::react;
     return;
   }
 
-  // Already set up with same inset
+  // Check if pinned scroll view is still valid (still in view hierarchy)
+  // This handles the case where content changes and the old scroll view is unmounted
+  if (_pinnedScrollView && ![_pinnedScrollView isDescendantOfView:self]) {
+    [self clearScrollable];
+  }
+
+  // Already set up with same inset and valid scroll view
   if (_pinnedScrollView && _bottomInset == bottomInset) {
     return;
   }


### PR DESCRIPTION
## Summary

Content gets clipped when dynamically switching sheet content (e.g., SearchView → SettingsView). Dragging the sheet and releasing fixes it, suggesting a stale reference.

`setupScrollable:bottomInset:` has an early return that doesn't verify `_pinnedScrollView` is still in the view hierarchy. When content changes, the old ScrollView is unmounted but we keep the reference.

This adds an `isDescendantOfView:` check to clear invalid references.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Tested with an app switching between two content views with ScrollViews. Content now renders correctly on first open.

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)

Fixes #481