### PR TITLE
fix(web): use M3 baseline colors for default sheet background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - **iOS**: Fixed crash and blank sheet when using Reanimated exiting animations. ([#493](https://github.com/lodev09/react-native-true-sheet/pull/493) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed default background color not respecting dark mode on AppCompat-based apps. ([#501](https://github.com/lodev09/react-native-true-sheet/pull/501) by [@lodev09](https://github.com/lodev09))
+- **Web**: Fixed default background color not respecting dark mode. ([#502](https://github.com/lodev09/react-native-true-sheet/pull/502) by [@lodev09](https://github.com/lodev09))
 
 ### 💡 Others
 

--- a/example/shared/src/screens/MapScreen.tsx
+++ b/example/shared/src/screens/MapScreen.tsx
@@ -118,7 +118,6 @@ const MapScreenInner = ({
         dimmed={false}
         dismissible={false}
         style={styles.content}
-        backgroundColor={Platform.select({ ios: undefined, default: DARK })}
         onLayout={(e: LayoutChangeEvent) => {
           console.log(
             `sheet layout width: ${e.nativeEvent.layout.width}, height: ${e.nativeEvent.layout.height}`

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -12,7 +12,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { View, StyleSheet, useWindowDimensions } from 'react-native';
+import { View, StyleSheet, useColorScheme, useWindowDimensions } from 'react-native';
 
 import BottomSheet, {
   BottomSheetBackdrop,
@@ -50,6 +50,10 @@ const DEFAULT_CORNER_RADIUS = 16;
 const DEFAULT_ELEVATION = 4;
 
 const DEFAULT_MAX_WIDTH = 640;
+// M3 baseline surfaceContainerLow
+const COLOR_SURFACE_CONTAINER_LOW_LIGHT = '#F7F2FA';
+const COLOR_SURFACE_CONTAINER_LOW_DARK = '#1D1B20';
+
 const DEFAULT_GRABBER_COLOR = 'rgba(0, 0, 0, 0.3)';
 const DEFAULT_GRABBER_WIDTH = 32;
 const DEFAULT_GRABBER_HEIGHT = 4;
@@ -89,7 +93,7 @@ const TrueSheetComponent = forwardRef<TrueSheetRefMethods, TrueSheetProps>((prop
     children,
     scrollable = false,
     initialDetentIndex = -1,
-    backgroundColor = '#ffffff',
+    backgroundColor: backgroundColorProp,
     cornerRadius = DEFAULT_CORNER_RADIUS,
     elevation = DEFAULT_ELEVATION,
     grabber = true,
@@ -119,6 +123,11 @@ const TrueSheetComponent = forwardRef<TrueSheetRefMethods, TrueSheetProps>((prop
     stackBehavior = 'switch',
     style,
   } = props;
+
+  const colorScheme = useColorScheme();
+  const backgroundColor =
+    backgroundColorProp ??
+    (colorScheme === 'dark' ? COLOR_SURFACE_CONTAINER_LOW_DARK : COLOR_SURFACE_CONTAINER_LOW_LIGHT);
 
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const isLandscapeOrTablet = windowWidth >= 600 || windowWidth > windowHeight;


### PR DESCRIPTION
## Summary

Use M3 baseline `surfaceContainerLow` colors for the default sheet background on web, respecting `prefers-color-scheme` via `useColorScheme()`. Previously hardcoded to `#ffffff`.

Follows the same approach as #501 for Android.

## Type of Change

- [x] Bug fix

## Test Plan

Tested on web with dark and light color schemes.

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)