### PR TITLE
fix(ios): avoid deadlock when registering screens event observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **iOS**: Fixed crash and blank sheet when using Reanimated exiting animations. ([#493](https://github.com/lodev09/react-native-true-sheet/pull/493) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed default background color not respecting dark mode on AppCompat-based apps. ([#501](https://github.com/lodev09/react-native-true-sheet/pull/501) by [@lodev09](https://github.com/lodev09))
 - **Web**: Fixed default background color not respecting dark mode. ([#502](https://github.com/lodev09/react-native-true-sheet/pull/502) by [@lodev09](https://github.com/lodev09))
+- **iOS**: Fixed main thread deadlock when keyboard events fire while sheet is mounted. ([#506](https://github.com/lodev09/react-native-true-sheet/pull/506) by [@lodev09](https://github.com/lodev09))
 
 ### 💡 Others
 

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -272,8 +272,6 @@ using namespace facebook::react;
   if (_controller) {
     [self updateStateWithSize:_controller.view.frame.size];
   }
-
-  [_screensEventObserver startObservingWithState:_state.get()->getData()];
 }
 
 /**
@@ -467,6 +465,7 @@ using namespace facebook::react;
   [_controller setupActiveDetentWithIndex:index];
 
   [_screensEventObserver capturePresenterScreenFromView:self];
+  [_screensEventObserver startObservingWithState:_state.get()->getData()];
 
   [presentingViewController presentViewController:_controller
                                          animated:animated


### PR DESCRIPTION
## Summary

Move `startObservingWithState:` from `updateState:oldState:` to `presentAtIndex:` to avoid a main thread deadlock (`0x8BADF00D`) when keyboard events fire while a TrueSheet is mounted.

The deadlock occurs because `updateState:oldState:` can be called during mount instructions inside an event dispatch (which holds a shared lock on `EventListenerContainer`'s mutex), and `addListener` needs an exclusive lock on the same mutex.

Moving to `presentAtIndex:` is correct since the observer only needs to listen for screen lifecycle events while the sheet is presented.

Fixes #504

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Verified the screens event observer still registers correctly when presenting a sheet within a navigation stack.

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)