### PR TITLE
fix: do not invoke dismiss events if sheet is not presented

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -369,6 +369,12 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
 
   @UiThread
   fun dismiss(animated: Boolean = true, promiseCallback: () -> Unit) {
+    if (viewController.isBeingDismissed || !viewController.isPresented) {
+      RNLog.w(viewController.reactContext, "TrueSheet: sheet is already dismissed. No need to dismiss it again.")
+      promiseCallback()
+      return
+    }
+
     // Dismiss all sheets above first
     dismissStack(animated) {}
 
@@ -379,8 +385,13 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
 
   @UiThread
   fun dismissStack(animated: Boolean = true, promiseCallback: () -> Unit) {
+    if (viewController.isBeingDismissed || !viewController.isPresented) {
+      RNLog.w(viewController.reactContext, "TrueSheet: sheet is already dismissed. No need to dismiss it again.")
+      promiseCallback()
+      return
+    }
+
     val sheetsAbove = TrueSheetStackManager.getSheetsAbove(this)
-    if (sheetsAbove.isNotEmpty()) {
       // Create snapshot only for topmost sheet (first in reversed list)
       sheetsAbove.firstOrNull()?.viewController?.createSheetSnapshot()
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -752,12 +752,6 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   fun dismiss(animated: Boolean = true) {
     if (isBeingDismissed) return
 
-    if (!isPresented) {
-      dismissPromise?.invoke()
-      dismissPromise = null
-      return
-    }
-
     isBeingDismissed = true
     dismissKeyboard()
     emitWillDismissEvents()


### PR DESCRIPTION
## Summary

This change prevents dismiss from calling any dismiss events or continuing to dismiss if the sheet is not actually presented.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Tested on iOS and Android simulators, iPhone 12 and Samsung A23 physical devices. 

I don't have a web test setup, sorry, but I thought I would raise the pull request regardless.

## Checklist

- [X] I tested on iOS
- [X] I tested on Android
- [ ] I tested on Web
- [X] I updated the documentation (if needed)
- [X] I added a changelog entry (if needed)
