### PR TITLE
docs: additional troubleshooting for weird layout issue

### DIFF
--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -90,6 +90,8 @@ function HomeScreen() {
 
 The sheet does not have control over how React Native renders components and may lead to rendering issues. To resolve this, try to minimize the use of `flex=1` in your content styles. Instead, use fixed `height` or employ `flexGrow`, `flexBasis`, etc., to manage your layout requirements.
 
+Try moving the sheet component up to a higher level in the component tree as some container may interfere with the sheet's content rendering.
+
 ## Xcode and EAS Build Issues
 
 ### Xcode Version


### PR DESCRIPTION
## Summary

I spent around 1-2 hours trying to fix an issue where I have a scrollable sheet, the content is rendered with a weird right padding and the its initial height is very small such that I cannot see anything in the sheet. This bug is weird since it only happens in Android, compared to iOS which works out of the box.

I tried looking through documentation, bug reports and any online mentions of this but it all seems to not be working. I believe it is up until I read through the issue comments more carefully that I see this https://github.com/lodev09/react-native-true-sheet/issues/388#issuecomment-3738794540 that I think a parent component might be causing this. The screenshots are also very similar to what I'm seeing on my side.

At first I didn't think much of it since I don't have any `SafeAreaView` or any padding related style in my app. But I realize that my sheet is not at the top-most level of the component tree where I think it is probably the root cause of the problem.

I moved the `TrueSheet` out and it works! (It is originally within a `View` with some flexDirection and alignment styling)

I would love to leave a quick guidance for any future developers who might face similar issue in the documentation. Not sure if my wording is okay so let me know if any changes is needed.

Thanks!

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update