### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/lodev09/react-native-true-sheet/actions/workflows/checks.yml/badge.svg)](https://github.com/lodev09/react-native-true-sheet/actions/workflows/checks.yml)
 [![NPM Downloads](https://img.shields.io/npm/d18m/%40lodev09%2Freact-native-true-sheet)](https://www.npmjs.com/package/@lodev09/react-native-true-sheet)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/lodev09/react-native-true-sheet)
 
 The true native bottom sheet experience for your React Native Apps. 💩
 


### PR DESCRIPTION
Added a badge for DeepWiki to the README.

## Summary

Deepwiki indexing is really good to learn more about this library. The badge allows it to update automatically and reindex more frequently you can look at the wiki [here](https://deepwiki.com/lodev09/react-native-true-sheet/1-overview)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Test Plan

<!-- How did you test these changes? -->

## Screenshots / Videos

<!-- Add screenshots or videos if applicable -->

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)
