### PR TITLE
fix(ios,android): prevent auto detent height staggering on content change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **iOS**: Fixed main thread deadlock when keyboard events fire while sheet is mounted. ([#506](https://github.com/lodev09/react-native-true-sheet/pull/506) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed stale nested scrolling ref blocking drag after dismissing a child sheet with a ScrollView. ([#523](https://github.com/lodev09/react-native-true-sheet/pull/523) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed children not taking full width and height due to state wrapper assignment order. ([#531](https://github.com/lodev09/react-native-true-sheet/pull/531) by [@lodev09](https://github.com/lodev09))
+- **iOS, Android**: Fixed `auto` detent height staggering on content change due to Yoga layout feedback loop. ([#537](https://github.com/lodev09/react-native-true-sheet/pull/537) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed keyboard detent not committing on scroll, causing sheet to snap back when keyboard hides. ([#525](https://github.com/lodev09/react-native-true-sheet/pull/525) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fixed thread blocking on gesture dismissal when sheet is presented in a stack. ([#511](https://github.com/lodev09/react-native-true-sheet/pull/511) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed keyboard not dismissing when sheet is dragged to a non-keyboard detent position. ([#513](https://github.com/lodev09/react-native-true-sheet/pull/513) by [@lodev09](https://github.com/lodev09))

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -551,7 +551,11 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
   }
 
   override fun viewControllerDidChangeSize(width: Int, height: Int) {
-    updateState(width, height)
+    // When scrollable, pass actual height so Yoga container matches the real sheet size
+    // (content uses flex:1, needs correct bounds for padding/layout).
+    // When not scrollable, keep height at screen size to avoid feedback loop with "auto" detent.
+    val effectiveHeight = if (viewController.scrollable) height else lastContainerHeight
+    updateState(width, effectiveHeight)
   }
 
   override fun viewControllerWillFocus() {

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -640,7 +640,12 @@ using namespace facebook::react;
 }
 
 - (void)viewControllerDidChangeSize:(CGSize)size {
-  [self updateStateWithSize:size];
+  // When scrollable, pass actual height so Yoga container matches the real sheet size
+  // (content uses flex:1, needs correct bounds for padding/layout).
+  // When not scrollable, keep height at screen size to avoid feedback loop with "auto" detent.
+  CGFloat effectiveHeight = _scrollable ? size.height : _lastStateSize.height;
+  CGSize adjustedSize = CGSizeMake(size.width, effectiveHeight);
+  [self updateStateWithSize:adjustedSize];
 }
 
 - (void)viewControllerWillFocus {


### PR DESCRIPTION
## Summary

Fix Yoga layout feedback loop that causes sheet height to stair-step incrementally when content changes on a sheet with `detents={["auto"]}`.

**Root cause:** `viewControllerDidChangeSize` updates Fabric state with the current sheet frame height → Yoga constrains children to that height → content reports a smaller height → sheet resizes → repeat.

**Fix:** Keep Yoga container height at screen size (unconstrained) for non-scrollable sheets so content measures its full natural height in one pass. Pass actual height for scrollable sheets so `flex: 1` content gets correct bounds for padding/layout.

Closes #532

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Non-scrollable sheet with `detents={["auto"]}` + dynamic content change → height jumps correctly in one pass
- Scrollable sheet with bottom padding on container style → padding visible
- Rotation updates width correctly in both modes

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)