### PR TITLE
fix(android): use RN BackHandler for back press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- **Android**: Use RN `BackHandler` for back press detection for reliability across Android versions. ([#580](https://github.com/lodev09/react-native-true-sheet/pull/580) by [@lodev09](https://github.com/lodev09))
+
 ## 3.9.9
 
 ### 🐛 Bug fixes

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetModule.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetModule.kt
@@ -141,7 +141,7 @@ class TrueSheetModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun backPress(viewTag: Double, promise: Promise) {
+  fun handleBackPress(viewTag: Double, promise: Promise) {
     val tag = viewTag.toInt()
 
     withTrueSheetView(tag, promise) { view ->

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetModule.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetModule.kt
@@ -140,6 +140,16 @@ class TrueSheetModule(reactContext: ReactApplicationContext) :
     }
   }
 
+  @ReactMethod
+  fun backPress(viewTag: Double, promise: Promise) {
+    val tag = viewTag.toInt()
+
+    withTrueSheetView(tag, promise) { view ->
+      view.handleBackPress()
+      promise.resolve(null)
+    }
+  }
+
   /**
    * Helper method to get TrueSheetView by tag and execute closure
    */

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -380,6 +380,11 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
   }
 
   @UiThread
+  fun handleBackPress() {
+    viewController.handleBackPress()
+  }
+
+  @UiThread
   fun dismiss(animated: Boolean = true, promiseCallback: () -> Unit) {
     if (viewController.isBeingDismissed || !viewController.isPresented) {
       RNLog.w(reactContext, "TrueSheet: sheet is already dismissed. No need to dismiss it again.")
@@ -577,9 +582,9 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     eventDispatcher?.dispatchEvent(BlurEvent(surfaceId, id))
   }
 
-  override fun viewControllerDidBackPress() {
+  override fun viewControllerDidChangeVisibility(visible: Boolean) {
     val surfaceId = UIManagerHelper.getSurfaceId(this)
-    eventDispatcher?.dispatchEvent(BackPressEvent(surfaceId, id))
+    eventDispatcher?.dispatchEvent(VisibilityChangeEvent(surfaceId, id, visible))
   }
 
   // ==================== TrueSheetContainerViewDelegate ====================

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -9,8 +9,6 @@ import android.view.ViewGroup
 import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.ImageView
 import android.widget.ScrollView
-import androidx.activity.OnBackPressedCallback
-import androidx.appcompat.app.AppCompatActivity
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.graphics.createBitmap
 import androidx.core.view.isNotEmpty
@@ -64,7 +62,7 @@ interface TrueSheetViewControllerDelegate {
   fun viewControllerDidFocus()
   fun viewControllerWillBlur()
   fun viewControllerDidBlur()
-  fun viewControllerDidBackPress()
+  fun viewControllerDidChangeVisibility(visible: Boolean)
 }
 
 // =============================================================================
@@ -145,9 +143,6 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   internal var coordinatorLayout: TrueSheetCoordinatorLayout? = null
   private var dimView: TrueSheetDimView? = null
   private var parentDimView: TrueSheetDimView? = null
-
-  // Back button handling
-  private var backCallback: OnBackPressedCallback? = null
 
   // Presentation State
   var isPresented = false
@@ -349,7 +344,6 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   private fun cleanupSheet() {
     cleanupKeyboardObserver()
-    cleanupBackCallback()
     sheetView?.animate()?.cancel()
 
     // Cleanup dim views
@@ -412,28 +406,6 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   }
 
   // =============================================================================
-  // MARK: - Back Button Handling
-  // =============================================================================
-
-  private fun setupBackCallback() {
-    val activity = reactContext.currentActivity as? AppCompatActivity ?: return
-
-    backCallback = object : OnBackPressedCallback(true) {
-      override fun handleOnBackPressed() {
-        delegate?.viewControllerDidBackPress()
-        dismissOrCollapseToLowest()
-      }
-    }
-
-    activity.onBackPressedDispatcher.addCallback(backCallback!!)
-  }
-
-  private fun cleanupBackCallback() {
-    backCallback?.remove()
-    backCallback = null
-  }
-
-  // =============================================================================
   // MARK: - TrueSheetCoordinatorLayout.Delegate
   // =============================================================================
 
@@ -480,7 +452,11 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
       children.forEach { it.viewController.dismiss(animated = true) }
     }
 
-    dismissOrCollapseToLowest()
+    if (dismissible) {
+      dismiss(animated = true)
+    } else if (parentSheetView == null && isDimmedAtCurrentDetent && dimmedDetentIndex > 0) {
+      setStateForDetentIndex(dimmedDetentIndex - 1)
+    }
   }
 
   // =============================================================================
@@ -624,8 +600,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
     isSheetVisible = false
     wasHiddenByScreen = true
-    backCallback?.isEnabled = false
-
+    delegate?.viewControllerDidChangeVisibility(false)
     dimViews.forEach { it.animate().alpha(0f).setDuration(SCREEN_FADE_DURATION).start() }
     sheet.animate()
       .alpha(0f)
@@ -641,10 +616,10 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   internal fun showAfterScreen() {
     isSheetVisible = true
+    delegate?.viewControllerDidChangeVisibility(true)
     setSheetVisibility(true)
     sheetView?.alpha = 1f
     updateDimAmount(animated = true)
-    backCallback?.isEnabled = true
   }
 
   /**
@@ -677,7 +652,6 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     setupSheetDetents()
     setupDimmedBackground()
     setupKeyboardObserver()
-    setupBackCallback()
 
     sheet.setupBackground()
     sheet.setupElevation()
@@ -754,11 +728,11 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     KeyboardUtils.dismiss(reactContext)
   }
 
-  private fun dismissOrCollapseToLowest() {
+  fun handleBackPress() {
     if (dismissible) {
       dismiss(animated = true)
-    } else if (parentSheetView == null && isDimmedAtCurrentDetent && dimmedDetentIndex > 0) {
-      setStateForDetentIndex(dimmedDetentIndex - 1)
+    } else if (currentDetentIndex > 0) {
+      setStateForDetentIndex(0)
     }
   }
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -74,7 +74,7 @@ class TrueSheetViewManager :
       FocusEvent.EVENT_NAME to hashMapOf("registrationName" to FocusEvent.REGISTRATION_NAME),
       WillBlurEvent.EVENT_NAME to hashMapOf("registrationName" to WillBlurEvent.REGISTRATION_NAME),
       BlurEvent.EVENT_NAME to hashMapOf("registrationName" to BlurEvent.REGISTRATION_NAME),
-      BackPressEvent.EVENT_NAME to hashMapOf("registrationName" to BackPressEvent.REGISTRATION_NAME)
+      VisibilityChangeEvent.EVENT_NAME to hashMapOf("registrationName" to VisibilityChangeEvent.REGISTRATION_NAME)
     )
 
   // ==================== Props ====================

--- a/android/src/main/java/com/lodev09/truesheet/events/TrueSheetLifecycleEvents.kt
+++ b/android/src/main/java/com/lodev09/truesheet/events/TrueSheetLifecycleEvents.kt
@@ -94,16 +94,20 @@ class DidDismissEvent(surfaceId: Int, viewId: Int) : Event<DidDismissEvent>(surf
 }
 
 /**
- * Fired when the hardware back button is pressed (Android only)
+ * Fired when the sheet visibility changes due to screen transitions
  */
-class BackPressEvent(surfaceId: Int, viewId: Int) : Event<BackPressEvent>(surfaceId, viewId) {
+class VisibilityChangeEvent(surfaceId: Int, viewId: Int, private val visible: Boolean) :
+  Event<VisibilityChangeEvent>(surfaceId, viewId) {
 
   override fun getEventName(): String = EVENT_NAME
 
-  override fun getEventData(): WritableMap = Arguments.createMap()
+  override fun getEventData(): WritableMap =
+    Arguments.createMap().apply {
+      putBoolean("visible", visible)
+    }
 
   companion object {
-    const val EVENT_NAME = "topBackPress"
-    const val REGISTRATION_NAME = "onBackPress"
+    const val EVENT_NAME = "topVisibilityChange"
+    const val REGISTRATION_NAME = "onVisibilityChange"
   }
 }

--- a/example/shared/src/components/sheets/PromptSheet.tsx
+++ b/example/shared/src/components/sheets/PromptSheet.tsx
@@ -65,7 +65,6 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
       }
       onBackPress={() => {
         console.log('Back button pressed!');
-        sheetRef.current?.dismiss();
       }}
       header={<Header />}
       footer={<Footer />}

--- a/ios/TrueSheetModule.mm
+++ b/ios/TrueSheetModule.mm
@@ -140,6 +140,11 @@ RCT_EXPORT_MODULE(TrueSheetModule)
   });
 }
 
+- (void)backPress:(double)viewTag resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+  // No-op on iOS — no hardware back button
+  resolve(nil);
+}
+
 - (void)dismissAll:(BOOL)animated resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
   RCTExecuteOnMainQueue(^{
     @synchronized(viewRegistry) {

--- a/ios/TrueSheetModule.mm
+++ b/ios/TrueSheetModule.mm
@@ -140,7 +140,7 @@ RCT_EXPORT_MODULE(TrueSheetModule)
   });
 }
 
-- (void)backPress:(double)viewTag resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+- (void)handleBackPress:(double)viewTag resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
   // No-op on iOS — no hardware back button
   resolve(nil);
 }

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -352,7 +352,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
   private handleBackPress(): boolean {
     if (!this.isPresented || !this.isSheetVisible) return false;
 
-    TrueSheetModule?.backPress(this.handle);
+    TrueSheetModule?.handleBackPress(this.handle);
     return this.props.onBackPress?.() ?? true;
   }
 

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -24,7 +24,6 @@ import type {
   DidFocusEvent,
   WillBlurEvent,
   DidBlurEvent,
-  BackPressEvent,
 } from './TrueSheet.types';
 import TrueSheetViewNativeComponent from './fabric/TrueSheetViewNativeComponent';
 import TrueSheetContainerViewNativeComponent from './fabric/TrueSheetContainerViewNativeComponent';
@@ -34,7 +33,14 @@ import TrueSheetFooterViewNativeComponent from './fabric/TrueSheetFooterViewNati
 
 import TrueSheetModule from './specs/NativeTrueSheetModule';
 
-import { Platform, StyleSheet, findNodeHandle, processColor } from 'react-native';
+import {
+  Platform,
+  StyleSheet,
+  BackHandler,
+  findNodeHandle,
+  processColor,
+  type NativeEventSubscription,
+} from 'react-native';
 
 const LINKING_ERROR =
   `The package '@lodev09/react-native-true-sheet' doesn't seem to be linked. Make sure: \n\n` +
@@ -60,6 +66,9 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
 
   private cachedGrabberOptions: TrueSheetProps['grabberOptions'] | undefined;
   private resolvedGrabberOptions: Record<string, unknown> | undefined;
+  private backHandlerSubscription: NativeEventSubscription | null = null;
+  private isPresented: boolean = false;
+  private isSheetVisible: boolean = true;
 
   /**
    * Map of sheet names against their instances.
@@ -105,7 +114,8 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
     this.onDidFocus = this.onDidFocus.bind(this);
     this.onWillBlur = this.onWillBlur.bind(this);
     this.onDidBlur = this.onDidBlur.bind(this);
-    this.onBackPress = this.onBackPress.bind(this);
+    this.handleBackPress = this.handleBackPress.bind(this);
+    this.onVisibilityChange = this.onVisibilityChange.bind(this);
   }
 
   private validateDetents(): void {
@@ -261,6 +271,16 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
   }
 
   private onDidPresent(event: DidPresentEvent): void {
+    this.isPresented = true;
+
+    if (Platform.OS === 'android') {
+      this.backHandlerSubscription?.remove();
+      this.backHandlerSubscription = BackHandler.addEventListener(
+        'hardwareBackPress',
+        this.handleBackPress
+      );
+    }
+
     this.props.onDidPresent?.(event);
   }
 
@@ -269,6 +289,11 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
   }
 
   private onDidDismiss(event: DidDismissEvent): void {
+    this.isPresented = false;
+    this.isSheetVisible = true;
+    this.backHandlerSubscription?.remove();
+    this.backHandlerSubscription = null;
+
     // Clean up native view after dismiss for lazy loading.
     // Skip unmount if a present is in progress to avoid race condition.
     if (!this.isPresenting) {
@@ -320,8 +345,15 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
     this.props.onDidBlur?.(event);
   }
 
-  private onBackPress(event: BackPressEvent): void {
-    this.props.onBackPress?.(event);
+  private onVisibilityChange(event: { nativeEvent: { visible: boolean } }): void {
+    this.isSheetVisible = event.nativeEvent.visible;
+  }
+
+  private handleBackPress(): boolean {
+    if (!this.isPresented || !this.isSheetVisible) return false;
+
+    TrueSheetModule?.backPress(this.handle);
+    return this.props.onBackPress?.() ?? true;
   }
 
   /**
@@ -391,8 +423,8 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
 
   componentWillUnmount(): void {
     this.unregisterInstance();
-
-    // Clean up presentation resolver
+    this.backHandlerSubscription?.remove();
+    this.backHandlerSubscription = null;
     this.presentationResolver = null;
   }
 
@@ -488,7 +520,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
         onDidFocus={this.onDidFocus}
         onWillBlur={this.onWillBlur}
         onDidBlur={this.onDidBlur}
-        onBackPress={this.onBackPress}
+        onVisibilityChange={this.onVisibilityChange}
       >
         {this.state.shouldRenderNativeView && (
           <TrueSheetContainerViewNativeComponent

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -44,7 +44,6 @@ export type DidFocusEvent = NativeSyntheticEvent<null>;
 export type DidBlurEvent = NativeSyntheticEvent<null>;
 export type WillFocusEvent = NativeSyntheticEvent<null>;
 export type WillBlurEvent = NativeSyntheticEvent<null>;
-export type BackPressEvent = NativeSyntheticEvent<null>;
 
 /**
  * Options for customizing the grabber (drag handle) appearance.
@@ -550,9 +549,9 @@ export interface TrueSheetProps extends ViewProps {
 
   /**
    * Called when the hardware back button is pressed on Android.
-   * Use this to handle custom back press behavior.
+   * Optionally return `false` to let the back event propagate to other handlers (e.g. navigation).
    *
    * @platform android
    */
-  onBackPress?: (event: BackPressEvent) => void;
+  onBackPress?: () => boolean | void;
 }

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -113,7 +113,7 @@ export interface NativeProps extends ViewProps {
   onDidFocus?: DirectEventHandler<null>;
   onWillBlur?: DirectEventHandler<null>;
   onDidBlur?: DirectEventHandler<null>;
-  onBackPress?: DirectEventHandler<null>;
+  onVisibilityChange?: DirectEventHandler<Readonly<{ visible: boolean }>>;
 }
 
 export default codegenNativeComponent<NativeProps>('TrueSheetView', {

--- a/src/specs/NativeTrueSheetModule.ts
+++ b/src/specs/NativeTrueSheetModule.ts
@@ -57,7 +57,7 @@ interface Spec extends TurboModule {
    * Dismisses or collapses to the lowest detent natively
    * @param viewTag - Native view tag of the sheet component
    */
-  backPress(viewTag: number): Promise<void>;
+  handleBackPress(viewTag: number): Promise<void>;
 }
 
 export default TurboModuleRegistry.get<Spec>('TrueSheetModule');

--- a/src/specs/NativeTrueSheetModule.ts
+++ b/src/specs/NativeTrueSheetModule.ts
@@ -51,6 +51,13 @@ interface Spec extends TurboModule {
    * @returns Promise that resolves when all sheets are dismissed
    */
   dismissAll(animated: boolean): Promise<void>;
+
+  /**
+   * Handle back press for a sheet (Android only)
+   * Dismisses or collapses to the lowest detent natively
+   * @param viewTag - Native view tag of the sheet component
+   */
+  backPress(viewTag: number): Promise<void>;
 }
 
 export default TurboModuleRegistry.get<Spec>('TrueSheetModule');


### PR DESCRIPTION
## Summary

Replaces Android's native `OnBackPressedCallback` with React Native's `BackHandler` for back press detection. Fixes #574.

- Moves back press detection to JS for reliability and consistency across Android versions
- Adds `handleBackPress` TurboModule method so dismiss/collapse still happens natively
- Adds internal `onVisibilityChange` event to track sheet visibility during screen transitions
- Back press now always collapses to lowest detent when not dismissible

## Type of Change

- [x] Bug fix

## Test Plan

- Present sheet, press hardware back → sheet dismisses
- Present non-dismissible sheet, press back → collapses to lowest detent
- Navigate to another screen with sheet open, go back → back handler re-enabled
- Test `onBackPress` prop returning `false` → event propagates to other handlers

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)