### PR TITLE
fix(ios): check position, detent, and index before emitting change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Fixed position change not emitting when detent or index changed. ([#584](https://github.com/lodev09/react-native-true-sheet/pull/584) by [@lodev09](https://github.com/lodev09))
 - **Android**: Use RN `BackHandler` for back press detection for reliability across Android versions. ([#580](https://github.com/lodev09/react-native-true-sheet/pull/580) by [@lodev09](https://github.com/lodev09))
 
 ## 3.9.9

--- a/example/bare/ios/Podfile.lock
+++ b/example/bare/ios/Podfile.lock
@@ -2649,7 +2649,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNTrueSheet (3.9.0-beta.4):
+  - RNTrueSheet (3.9.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -3104,7 +3104,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: e1cf8ef3f11045536eed6bd4f132b003ef5f9a5f
   RNReanimated: f1868b36f4b2b52a0ed00062cfda69506f75eaee
   RNScreens: d821082c6dd1cb397cc0c98b026eeafaa68be479
-  RNTrueSheet: d5cdfa19e0d9ff70abcde75fe198f324727a3799
+  RNTrueSheet: a3094081efc659586c568292d1b778703611a5dd
   RNWorklets: d9c050940f140af5d8b611d937eab1cbfce5e9a5
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -489,7 +489,7 @@ using namespace facebook::react;
 }
 
 - (void)emitDismissedPosition {
-  [self viewControllerDidChangePosition:-1 position:_controller.screenHeight detent:0 realtime:NO];
+  [TrueSheetStateEvents emitPositionChange:_eventEmitter index:-1 position:_controller.screenHeight detent:0 realtime:NO];
 }
 
 - (void)dismissAnimated:(BOOL)animated completion:(nullable TrueSheetCompletionBlock)completion {

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -22,12 +22,24 @@
 
 using namespace facebook::react;
 
+typedef struct {
+  CGFloat position;
+  CGFloat detent;
+  CGFloat index;
+} TrueSheetPositionState;
+
+static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPositionState b) {
+  return fabs(a.position - b.position) <= 0.01 &&
+         fabs(a.detent - b.detent) <= 0.01 &&
+         fabs(a.index - b.index) <= 0.01;
+}
+
 @interface TrueSheetViewController ()
 
 @end
 
 @implementation TrueSheetViewController {
-  CGFloat _lastPosition;
+  TrueSheetPositionState _lastEmittedPositionState;
   CGFloat _lastWidth;
   NSInteger _pendingDetentIndex;
   BOOL _pendingContentSizeChange;
@@ -63,7 +75,7 @@ using namespace facebook::react;
     _dimmed = YES;
     _dimmedDetentIndex = @(0);
     _pageSizing = YES;
-    _lastPosition = 0;
+    _lastEmittedPositionState = (TrueSheetPositionState){0, 0, 0};
     _isDragging = NO;
     _isPresented = NO;
     _isTransitioning = NO;
@@ -458,7 +470,7 @@ using namespace facebook::react;
     CGFloat layerPosition = layer.presentationLayer.frame.origin.y;
 
     if (self.currentPosition >= self.screenHeight) {
-      CGFloat position = fmax(_lastPosition, layerPosition);
+      CGFloat position = fmax(_lastEmittedPositionState.position, layerPosition);
 
       [self emitWillDismissEvents];
       [self emitChangePositionDelegateWithPosition:position realtime:YES debug:@"transition out"];
@@ -466,7 +478,7 @@ using namespace facebook::react;
     } else {
       CGFloat position = fmax(self.currentPosition, layerPosition);
       // Detect drag → snap transition jump; stay non-realtime for the rest of the animation
-      if (!_isTransitionSnapping && _isPresented && _lastPosition > 0 && fabs(_lastPosition - position) > 20) {
+      if (!_isTransitionSnapping && _isPresented && _lastEmittedPositionState.position > 0 && fabs(_lastEmittedPositionState.position - position) > 20) {
         _isTransitionSnapping = YES;
       }
       BOOL realtime = !_isTransitionSnapping;
@@ -485,13 +497,16 @@ using namespace facebook::react;
     }
   }
 
-  if (fabs(_lastPosition - position) > 0.01) {
-    _lastPosition = position;
+  TrueSheetPositionState state = {
+    .position = position,
+    .detent = [self interpolatedDetentForPosition:position],
+    .index = [self interpolatedIndexForPosition:position],
+  };
 
-    CGFloat index = [self interpolatedIndexForPosition:position];
-    CGFloat detent = [self interpolatedDetentForPosition:position];
-
-    [self.delegate viewControllerDidChangePosition:index position:position detent:detent realtime:realtime];
+  if (!TrueSheetPositionStateEquals(_lastEmittedPositionState, state)) {
+    _lastEmittedPositionState = state;
+    
+    [self.delegate viewControllerDidChangePosition:state.index position:state.position detent:state.detent realtime:realtime];
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #581

Position change events were only deduped by `position`. If detent or index changed while position stayed ~the same, the event wouldn't fire. This groups the three values into a `TrueSheetPositionState` struct and checks all three before emitting.

Also switches `emitDismissedPosition` to call the static emit directly.

## Type of Change

- [x] Bug fix

## Test Plan

- Present sheet, verify `onPositionChange` fires correctly across detents
- Verify `animatedIndex` starts at expected value on iOS 18

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)