### PR TITLE
feat: add scrollingExpandsSheet to scrollableOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ## Unreleased
 
+### 🎉 New features
+
+- Add `scrollingExpandsSheet` option to `scrollableOptions`. ([#585](https://github.com/lodev09/react-native-true-sheet/pull/585) by [@lodev09](https://github.com/lodev09))
+
 ### 🐛 Bug fixes
 
 - **iOS**: Fixed position change not emitting when detent or index changed. ([#584](https://github.com/lodev09/react-native-true-sheet/pull/584) by [@lodev09](https://github.com/lodev09))
 - **Android**: Use RN `BackHandler` for back press detection for reliability across Android versions. ([#580](https://github.com/lodev09/react-native-true-sheet/pull/580) by [@lodev09](https://github.com/lodev09))
+
+### ⚠️ Breaking
+
+- **Android**: `nestedScrollingEnabled` is now automatically managed when `scrollable` is enabled. ([#585](https://github.com/lodev09/react-native-true-sheet/pull/585))
 
 ## 3.9.9
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
@@ -2,7 +2,6 @@ package com.lodev09.truesheet
 
 import android.annotation.SuppressLint
 import android.view.View
-import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.view.ReactViewGroup
@@ -40,7 +39,7 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
   var insetAdjustment: TrueSheetInsetAdjustment = TrueSheetInsetAdjustment.AUTOMATIC
   var scrollViewBottomInset: Int = 0
   var scrollableEnabled: Boolean = false
-  var scrollableOptions: ReadableMap? = null
+  var scrollableOptions: ScrollableOptions? = null
     set(value) {
       field = value
       contentView?.scrollableOptions = value

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.ThemedReactContext
@@ -94,6 +95,9 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
       originalScrollViewPaddingBottom = scrollView.paddingBottom
       pinnedScrollView = scrollView
 
+      scrollView.isNestedScrollingEnabled = true
+      (scrollView.parent as? SwipeRefreshLayout)?.isNestedScrollingEnabled = false
+
       scrollView.setOnScrollChangeListener { _, _, scrollY, _, oldScrollY ->
         if (scrollY != oldScrollY) {
           delegate?.contentViewDidScroll()
@@ -125,6 +129,8 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
 
   fun clearScrollable() {
     pinnedScrollView?.setOnScrollChangeListener(null as View.OnScrollChangeListener?)
+    pinnedScrollView?.isNestedScrollingEnabled = false
+    (pinnedScrollView?.parent as? SwipeRefreshLayout)?.isNestedScrollingEnabled = true
     setScrollViewPaddingBottom(originalScrollViewPaddingBottom)
     pinnedScrollView = null
     originalScrollViewPaddingBottom = 0

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -39,13 +39,10 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
   private var keyboardScrollOffset: Float = 0f
   private var keyboardObserver: TrueSheetKeyboardObserver? = null
 
-  private var scrollingExpandsSheet: Boolean = true
-
   var scrollableOptions: ReadableMap? = null
     set(value) {
       field = value
-      keyboardScrollOffset = value?.getDouble("keyboardScrollOffset")?.toFloat()?.dpToPx() ?: 0f
-      scrollingExpandsSheet = if (value?.hasKey("scrollingExpandsSheet") == true) value.getBoolean("scrollingExpandsSheet") else true
+      keyboardScrollOffset = if (value?.hasKey("keyboardScrollOffset") == true) value.getDouble("keyboardScrollOffset").toFloat().dpToPx() else 0f
     }
 
   override fun addView(child: View?, index: Int) {
@@ -104,8 +101,6 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
       }
     }
 
-    scrollView.isNestedScrollingEnabled = scrollingExpandsSheet
-
     this.bottomInset = bottomInset
 
     setScrollViewPaddingBottom(originalScrollViewPaddingBottom + bottomInset)
@@ -129,7 +124,6 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
   }
 
   fun clearScrollable() {
-    pinnedScrollView?.isNestedScrollingEnabled = true
     pinnedScrollView?.setOnScrollChangeListener(null as View.OnScrollChangeListener?)
     setScrollViewPaddingBottom(originalScrollViewPaddingBottom)
     pinnedScrollView = null

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
+import androidx.core.widget.NestedScrollView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.PixelUtil.dpToPx
@@ -12,6 +13,8 @@ import com.facebook.react.views.view.ReactViewGroup
 import com.lodev09.truesheet.core.TrueSheetKeyboardObserver
 import com.lodev09.truesheet.core.TrueSheetKeyboardObserverDelegate
 import com.lodev09.truesheet.utils.isDescendantOf
+import com.lodev09.truesheet.utils.smoothScrollBy
+import com.lodev09.truesheet.utils.smoothScrollTo
 
 /**
  * Delegate interface for content view size changes
@@ -33,7 +36,7 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
   private var lastWidth = 0
   private var lastHeight = 0
 
-  private var pinnedScrollView: ScrollView? = null
+  private var pinnedScrollView: ViewGroup? = null
   private var originalScrollViewPaddingBottom: Int = 0
   private var bottomInset: Int = 0
 
@@ -137,14 +140,14 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     bottomInset = 0
   }
 
-  fun findScrollView(): ScrollView? {
+  fun findScrollView(): ViewGroup? {
     if (pinnedScrollView != null) return pinnedScrollView
     return findScrollView(this as View)
   }
 
-  private fun findScrollView(view: View): ScrollView? {
-    if (view is ScrollView) {
-      return view
+  private fun findScrollView(view: View): ViewGroup? {
+    if (view is ScrollView || view is NestedScrollView) {
+      return view as ViewGroup
     }
 
     if (view is ViewGroup) {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import android.widget.ScrollView
 import androidx.core.widget.NestedScrollView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
@@ -15,6 +14,11 @@ import com.lodev09.truesheet.core.TrueSheetKeyboardObserverDelegate
 import com.lodev09.truesheet.utils.isDescendantOf
 import com.lodev09.truesheet.utils.smoothScrollBy
 import com.lodev09.truesheet.utils.smoothScrollTo
+
+data class ScrollableOptions(
+  val keyboardScrollOffset: Float = 0f,
+  val scrollingExpandsSheet: Boolean = true
+)
 
 /**
  * Delegate interface for content view size changes
@@ -44,10 +48,10 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
   private var keyboardScrollOffset: Float = 0f
   private var keyboardObserver: TrueSheetKeyboardObserver? = null
 
-  var scrollableOptions: ReadableMap? = null
+  var scrollableOptions: ScrollableOptions? = null
     set(value) {
       field = value
-      keyboardScrollOffset = if (value?.hasKey("keyboardScrollOffset") == true) value.getDouble("keyboardScrollOffset").toFloat().dpToPx() else 0f
+      keyboardScrollOffset = value?.keyboardScrollOffset?.dpToPx() ?: 0f
     }
 
   override fun addView(child: View?, index: Int) {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -39,6 +39,7 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
   private var pinnedScrollView: ViewGroup? = null
   private var originalScrollViewPaddingBottom: Int = 0
   private var bottomInset: Int = 0
+  private var scrollExpansionPadding: Int = 0
 
   private var keyboardScrollOffset: Float = 0f
   private var keyboardObserver: TrueSheetKeyboardObserver? = null
@@ -119,6 +120,19 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     }
   }
 
+  // TODO: Replace this workaround with synchronous state layout updates on every sheet resize.
+  // The container is currently sized to the largest detent, so at smaller detents the ScrollView
+  // viewport extends beyond the visible area, reducing the effective scroll range. This padding
+  // compensates for that difference until we can resize the container per-detent synchronously.
+  fun updateScrollExpansionPadding(padding: Int) {
+    if (scrollExpansionPadding == padding) return
+    scrollExpansionPadding = padding
+    val keyboardHeight = keyboardObserver?.currentHeight ?: 0
+    val basePadding = if (keyboardHeight > 0) keyboardHeight else bottomInset
+    setScrollViewPaddingBottom(originalScrollViewPaddingBottom + basePadding)
+    nudgeScrollView()
+  }
+
   private fun setScrollViewPaddingBottom(paddingBottom: Int) {
     val scrollView = pinnedScrollView ?: return
     scrollView.clipToPadding = false
@@ -126,7 +140,7 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
       scrollView.paddingLeft,
       scrollView.paddingTop,
       scrollView.paddingRight,
-      paddingBottom
+      paddingBottom + scrollExpansionPadding
     )
   }
 
@@ -134,6 +148,7 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     pinnedScrollView?.setOnScrollChangeListener(null as View.OnScrollChangeListener?)
     pinnedScrollView?.isNestedScrollingEnabled = false
     (pinnedScrollView?.parent as? SwipeRefreshLayout)?.isNestedScrollingEnabled = true
+    scrollExpansionPadding = 0
     setScrollViewPaddingBottom(originalScrollViewPaddingBottom)
     pinnedScrollView = null
     originalScrollViewPaddingBottom = 0
@@ -200,11 +215,13 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     val totalBottomInset = if (keyboardHeight > 0) keyboardHeight else bottomInset
     setScrollViewPaddingBottom(originalScrollViewPaddingBottom + totalBottomInset)
 
-    // Trigger a scroll to force update
-    scrollView.post {
-      scrollView.smoothScrollBy(0, 1)
-      scrollView.smoothScrollBy(0, -1)
-    }
+    scrollView.post { nudgeScrollView() }
+  }
+
+  private fun nudgeScrollView() {
+    val scrollView = pinnedScrollView ?: return
+    scrollView.smoothScrollBy(0, 1)
+    scrollView.smoothScrollBy(0, -1)
   }
 
   private fun scrollToFocusedInput() {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -39,10 +39,13 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
   private var keyboardScrollOffset: Float = 0f
   private var keyboardObserver: TrueSheetKeyboardObserver? = null
 
+  private var scrollingExpandsSheet: Boolean = true
+
   var scrollableOptions: ReadableMap? = null
     set(value) {
       field = value
       keyboardScrollOffset = value?.getDouble("keyboardScrollOffset")?.toFloat()?.dpToPx() ?: 0f
+      scrollingExpandsSheet = if (value?.hasKey("scrollingExpandsSheet") == true) value.getBoolean("scrollingExpandsSheet") else true
     }
 
   override fun addView(child: View?, index: Int) {
@@ -101,6 +104,8 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
       }
     }
 
+    scrollView.isNestedScrollingEnabled = scrollingExpandsSheet
+
     this.bottomInset = bottomInset
 
     setScrollViewPaddingBottom(originalScrollViewPaddingBottom + bottomInset)
@@ -124,6 +129,7 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
   }
 
   fun clearScrollable() {
+    pinnedScrollView?.isNestedScrollingEnabled = true
     pinnedScrollView?.setOnScrollChangeListener(null as View.OnScrollChangeListener?)
     setScrollViewPaddingBottom(originalScrollViewPaddingBottom)
     pinnedScrollView = null

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import android.view.accessibility.AccessibilityEvent
 import androidx.annotation.UiThread
 import com.facebook.react.bridge.LifecycleEventListener
-import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.StateWrapper
@@ -282,7 +281,7 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     setupScrollable()
   }
 
-  fun setScrollableOptions(options: ReadableMap?) {
+  fun setScrollableOptions(options: ScrollableOptions?) {
     viewController.scrollableOptions = options
     setupScrollable()
   }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -12,7 +12,6 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.graphics.createBitmap
 import androidx.core.view.isNotEmpty
 import com.facebook.react.R
-import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.JSPointerDispatcher
 import com.facebook.react.uimanager.JSTouchDispatcher
 import com.facebook.react.uimanager.PixelUtil.dpToPx
@@ -208,12 +207,10 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   var scrollable: Boolean = false
 
-  var scrollableOptions: ReadableMap? = null
+  var scrollableOptions: ScrollableOptions? = null
     set(value) {
       field = value
-      behavior?.scrollingExpandsSheet = value?.let {
-        if (it.hasKey("scrollingExpandsSheet")) it.getBoolean("scrollingExpandsSheet") else true
-      } ?: true
+      behavior?.scrollingExpandsSheet = value?.scrollingExpandsSheet ?: true
       if (isPresented) sheetView?.let { updateScrollExpansionPadding(it.top) }
     }
 
@@ -718,9 +715,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     // Configure behavior
     behavior.isHideable = true
     behavior.isDraggable = draggable
-    behavior.scrollingExpandsSheet = scrollableOptions?.let {
-      if (it.hasKey("scrollingExpandsSheet")) it.getBoolean("scrollingExpandsSheet") else true
-    } ?: true
+    behavior.scrollingExpandsSheet = scrollableOptions?.scrollingExpandsSheet ?: true
     behavior.state = BottomSheetBehavior.STATE_HIDDEN
     behavior.addBottomSheetCallback(sheetCallback)
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -214,6 +214,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
       behavior?.scrollingExpandsSheet = value?.let {
         if (it.hasKey("scrollingExpandsSheet")) it.getBoolean("scrollingExpandsSheet") else true
       } ?: true
+      if (isPresented) sheetView?.let { updateScrollExpansionPadding(it.top) }
     }
 
   override var sheetCornerRadius: Float = DEFAULT_CORNER_RADIUS.dpToPx()
@@ -530,6 +531,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
       else -> { }
     }
 
+    updateScrollExpansionPadding(sheetView.top)
     emitChangePositionDelegate(sheetView.top)
 
     // On older APIs, use onSlide for footer positioning during keyboard transitions
@@ -541,6 +543,15 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     if (!isKeyboardTransitioning) {
       updateDimAmount(sheetView.top)
     }
+  }
+
+  private fun updateScrollExpansionPadding(sheetTop: Int) {
+    if (!scrollable) {
+      containerView?.contentView?.updateScrollExpansionPadding(0)
+      return
+    }
+    val expandedOffset = behavior?.expandedOffset ?: return
+    containerView?.contentView?.updateScrollExpansionPadding(maxOf(0, sheetTop - expandedOffset))
   }
 
   private fun handleStateSettled(sheetView: View, newState: Int) {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -24,6 +24,7 @@ import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.util.RNLog
 import com.facebook.react.views.view.ReactViewGroup
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.lodev09.truesheet.core.TrueSheetBottomSheetBehavior
 import com.lodev09.truesheet.core.GrabberOptions
 import com.lodev09.truesheet.core.TrueSheetBottomSheetView
 import com.lodev09.truesheet.core.TrueSheetBottomSheetViewDelegate
@@ -209,6 +210,12 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   var scrollable: Boolean = false
 
   var scrollableOptions: ReadableMap? = null
+    set(value) {
+      field = value
+      behavior?.scrollingExpandsSheet = value?.let {
+        if (it.hasKey("scrollingExpandsSheet")) it.getBoolean("scrollingExpandsSheet") else true
+      } ?: true
+    }
 
   override var sheetCornerRadius: Float = DEFAULT_CORNER_RADIUS.dpToPx()
     set(value) {
@@ -240,7 +247,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   // =============================================================================
 
   // Behavior
-  private val behavior: BottomSheetBehavior<TrueSheetBottomSheetView>?
+  private val behavior: TrueSheetBottomSheetBehavior<TrueSheetBottomSheetView>?
     get() = sheetView?.behavior
 
   internal val containerView: TrueSheetContainerView?
@@ -696,11 +703,14 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     val params = sheet.createLayoutParams()
 
     @Suppress("UNCHECKED_CAST")
-    val behavior = params.behavior as BottomSheetBehavior<TrueSheetBottomSheetView>
+    val behavior = params.behavior as TrueSheetBottomSheetBehavior<TrueSheetBottomSheetView>
 
     // Configure behavior
     behavior.isHideable = true
     behavior.isDraggable = draggable
+    behavior.scrollingExpandsSheet = scrollableOptions?.let {
+      if (it.hasKey("scrollingExpandsSheet")) it.getBoolean("scrollingExpandsSheet") else true
+    } ?: true
     behavior.state = BottomSheetBehavior.STATE_HIDDEN
     behavior.addBottomSheetCallback(sheetCallback)
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.ImageView
-import android.widget.ScrollView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.graphics.createBitmap
 import androidx.core.view.isNotEmpty
@@ -432,7 +431,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     sheetView?.let { emitChangePositionDelegate(it.top, realtime = false) }
   }
 
-  override fun findScrollView(): ScrollView? = containerView?.contentView?.findScrollView()
+  override fun findScrollView(): ViewGroup? = containerView?.contentView?.findScrollView()
   override fun findSheetView(): TrueSheetBottomSheetView? = sheetView
 
   // =============================================================================

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -218,7 +218,16 @@ class TrueSheetViewManager :
 
   @ReactProp(name = "scrollableOptions")
   override fun setScrollableOptions(view: TrueSheetView, options: ReadableMap?) {
-    view.setScrollableOptions(options)
+    if (options == null) {
+      view.setScrollableOptions(null)
+      return
+    }
+
+    val scrollableOptions = ScrollableOptions(
+      keyboardScrollOffset = if (options.hasKey("keyboardScrollOffset")) options.getDouble("keyboardScrollOffset").toFloat() else 0f,
+      scrollingExpandsSheet = if (options.hasKey("scrollingExpandsSheet")) options.getBoolean("scrollingExpandsSheet") else true
+    )
+    view.setScrollableOptions(scrollableOptions)
   }
 
   companion object {

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetBottomSheetBehavior.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetBottomSheetBehavior.kt
@@ -1,0 +1,36 @@
+package com.lodev09.truesheet.core
+
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+
+class TrueSheetBottomSheetBehavior<V : View> : BottomSheetBehavior<V>() {
+  var scrollingExpandsSheet: Boolean = true
+
+  override fun onNestedPreScroll(
+    coordinatorLayout: CoordinatorLayout,
+    child: V,
+    target: View,
+    dx: Int,
+    dy: Int,
+    consumed: IntArray,
+    type: Int
+  ) {
+    // dy > 0 = user swiping up = sheet expanding
+    // Block expansion from scroll, but allow if sheet is already being dragged
+    if (!scrollingExpandsSheet && dy > 0 && state != STATE_DRAGGING) return
+    super.onNestedPreScroll(coordinatorLayout, child, target, dx, dy, consumed, type)
+  }
+
+  override fun onNestedPreFling(
+    coordinatorLayout: CoordinatorLayout,
+    child: V,
+    target: View,
+    velocityX: Float,
+    velocityY: Float
+  ): Boolean {
+    // Don't consume flings — let the ScrollView decelerate naturally
+    if (!scrollingExpandsSheet) return false
+    return super.onNestedPreFling(coordinatorLayout, child, target, velocityX, velocityY)
+  }
+}

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetBottomSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetBottomSheetView.kt
@@ -63,9 +63,9 @@ class TrueSheetBottomSheetView(private val reactContext: ThemedReactContext) : F
 
   // Behavior reference (set after adding to CoordinatorLayout)
   @Suppress("UNCHECKED_CAST")
-  val behavior: BottomSheetBehavior<TrueSheetBottomSheetView>?
+  val behavior: TrueSheetBottomSheetBehavior<TrueSheetBottomSheetView>?
     get() = (layoutParams as? CoordinatorLayout.LayoutParams)
-      ?.behavior as? BottomSheetBehavior<TrueSheetBottomSheetView>
+      ?.behavior as? TrueSheetBottomSheetBehavior<TrueSheetBottomSheetView>
 
   // =============================================================================
   // MARK: - Initialization
@@ -106,7 +106,7 @@ class TrueSheetBottomSheetView(private val reactContext: ThemedReactContext) : F
   fun createLayoutParams(): CoordinatorLayout.LayoutParams {
     val applyMaxWidth = delegate?.maxContentWidth != null && !ScreenUtils.isPortraitPhone(reactContext)
     val effectiveMaxWidth = if (applyMaxWidth) delegate!!.maxContentWidth!! else DEFAULT_MAX_WIDTH.dpToPx().toInt()
-    val behavior = BottomSheetBehavior<TrueSheetBottomSheetView>().apply {
+    val behavior = TrueSheetBottomSheetBehavior<TrueSheetBottomSheetView>().apply {
       isHideable = true
       maxWidth = effectiveMaxWidth
     }

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetCoordinatorLayout.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetCoordinatorLayout.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.content.res.Configuration
 import android.view.MotionEvent
 import android.view.ViewConfiguration
-import android.widget.ScrollView
+import android.view.ViewGroup
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.facebook.react.uimanager.PointerEvents
@@ -15,7 +15,7 @@ import com.lodev09.truesheet.utils.isDescendantOf
 interface TrueSheetCoordinatorLayoutDelegate {
   fun coordinatorLayoutDidLayout(changed: Boolean)
   fun coordinatorLayoutDidChangeConfiguration()
-  fun findScrollView(): ScrollView?
+  fun findScrollView(): ViewGroup?
   fun findSheetView(): TrueSheetBottomSheetView?
 }
 
@@ -104,6 +104,7 @@ class TrueSheetCoordinatorLayout(context: Context) :
       !hasRefreshControl &&
       scrollView.scrollY == 0 &&
       !scrollView.canScrollVertically(1)
+
 
     if (cannotScroll) {
       when (ev.action and MotionEvent.ACTION_MASK) {

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetCoordinatorLayout.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetCoordinatorLayout.kt
@@ -75,7 +75,7 @@ class TrueSheetCoordinatorLayout(context: Context) :
     val sheet = delegate?.findSheetView() ?: return
     val behavior = sheet.behavior ?: return
     try {
-      val field = behavior.javaClass.getDeclaredField("nestedScrollingChildRef")
+      val field = behavior.javaClass.superclass.getDeclaredField("nestedScrollingChildRef")
       field.isAccessible = true
       @Suppress("UNCHECKED_CAST")
       val ref = field.get(behavior) as? java.lang.ref.WeakReference<android.view.View> ?: return

--- a/android/src/main/java/com/lodev09/truesheet/utils/ViewUtils.kt
+++ b/android/src/main/java/com/lodev09/truesheet/utils/ViewUtils.kt
@@ -1,6 +1,9 @@
 package com.lodev09.truesheet.utils
 
 import android.view.View
+import android.view.ViewGroup
+import android.widget.ScrollView
+import androidx.core.widget.NestedScrollView
 
 fun View.isDescendantOf(ancestor: View): Boolean {
   if (!isAttachedToWindow) return false
@@ -10,4 +13,18 @@ fun View.isDescendantOf(ancestor: View): Boolean {
     current = (current.parent as? View)
   }
   return false
+}
+
+fun ViewGroup.smoothScrollBy(dx: Int, dy: Int) {
+  when (this) {
+    is ScrollView -> smoothScrollBy(dx, dy)
+    is NestedScrollView -> smoothScrollBy(dx, dy)
+  }
+}
+
+fun ViewGroup.smoothScrollTo(x: Int, y: Int) {
+  when (this) {
+    is ScrollView -> smoothScrollTo(x, y)
+    is NestedScrollView -> smoothScrollTo(x, y)
+  }
 }

--- a/docs/docs/guides/header.mdx
+++ b/docs/docs/guides/header.mdx
@@ -21,7 +21,7 @@ const App = () => {
         </View>
       }
     >
-      <ScrollView nestedScrollEnabled>
+      <ScrollView>
         <View>{/* Your scrollable content */}</View>
       </ScrollView>
     </TrueSheet>
@@ -53,7 +53,6 @@ const App = () => {
       }
     >
       <FlatList
-        nestedScrollEnabled
         data={items}
         renderItem={({ item }) => <ItemRow item={item} />}
       />

--- a/docs/docs/guides/keyboard.mdx
+++ b/docs/docs/guides/keyboard.mdx
@@ -34,6 +34,18 @@ const App = () => {
 }
 ```
 
+## Scrollable + Keyboard
+
+When using [`scrollable`](/reference/configuration#scrollable) with `TextInput` inside a `ScrollView`, the sheet auto-scrolls to keep the focused input visible above the keyboard. Use `keyboardScrollOffset` in [`scrollableOptions`](/reference/configuration#scrollableoptions) to add extra spacing between the input and the keyboard:
+
+```tsx
+<TrueSheet scrollable scrollableOptions={{ keyboardScrollOffset: 16 }}>
+  <ScrollView>
+    <TextInput placeholder="Type something..." />
+  </ScrollView>
+</TrueSheet>
+```
+
 ## Footer Behavior
 
 When using a [`footer`](/reference/configuration#footer) component, it automatically repositions above the keyboard, staying visible while the user types.

--- a/docs/docs/guides/scrolling.mdx
+++ b/docs/docs/guides/scrolling.mdx
@@ -14,7 +14,7 @@ Follow the guide below so you can scroll your content using `TrueSheet`.
 
 ## How?
 
-Enable the `scrollable` prop and set `nestedScrollEnabled` on your `ScrollView` or `FlatList` to properly handle scrolling within the sheet.
+Enable the `scrollable` prop on your `TrueSheet` to properly handle scrolling within the sheet.
 
 ```tsx {5-7}
 const App = () => {
@@ -23,7 +23,7 @@ const App = () => {
   return (
     <TrueSheet ref={sheet} scrollable>
       <View>{/* Header content */}</View>
-      <ScrollView nestedScrollEnabled>
+      <ScrollView>
         <View />
       </ScrollView>
     </TrueSheet>
@@ -36,7 +36,7 @@ By default, `scrollable` is `false`. Set it to `true` to enable automatic Scroll
 :::
 
 :::warning
-The [`auto`](/reference/types#sheetdetent) detent does not work well with `scrollable`. Use fixed fractional detents (e.g., `0.5`, `0.8`, `1`) instead when using `scrollable`. This may be supported in the future once synchronous UI updates are officially supported by React Native.
+The [`auto`](/reference/types#sheetdetent) detent is not supported with `scrollable`. Use fixed fractional detents (e.g., `0.5`, `0.8`, `1`) instead.
 :::
 
 ### iOS
@@ -49,20 +49,36 @@ The scroll view detection supports up to 2 levels deep in the view hierarchy, so
 <TrueSheet scrollable>
   <View style={{ flex: 1 }}>
     <View>{/* Header content */}</View>
-    <FlatList nestedScrollEnabled data={data} renderItem={renderItem} />
+    <FlatList data={data} renderItem={renderItem} />
   </View>
 </TrueSheet>
 ```
 
 ### Android
 
-On Android, `scrollable` ensures the scroll view fills the available sheet space. You must also enable `nestedScrollEnabled` on your `ScrollView` or `FlatList` for scrolling to work properly.
+On Android, `scrollable` ensures the scroll view fills the available sheet space. Nested scrolling is automatically enabled on the detected scroll view, so you don't need to set `nestedScrollEnabled` manually.
 
-:::warning
-`RefreshControl` does not work with `nestedScrollEnabled` on Android due to how `SwipeRefreshLayout` interferes with the `BottomSheetBehavior`'s nested scrolling coordination. This is a known limitation of the Android platform.
-
-As a workaround, you can disable `nestedScrollEnabled` to make `RefreshControl` work, but the sheet will no longer be draggable from within the scroll view. In this case, ensure you have a draggable area outside the scroll view (e.g., a header with a grabber) to allow users to drag the sheet.
+:::info
+When `scrollable` is enabled, any `nestedScrollEnabled` prop on your `ScrollView` or `FlatList` is ignored — TrueSheet manages nested scrolling internally. `RefreshControl` is also fully supported.
 :::
+
+## Preventing Scroll-to-Expand
+
+By default, scrolling content to the top edge expands the sheet to the next detent. To disable this (e.g., for YouTube-style comments sheets where only the grabber should expand the sheet), set `scrollingExpandsSheet` to `false`:
+
+```tsx
+<TrueSheet
+  scrollable
+  scrollableOptions={{ scrollingExpandsSheet: false }}
+  detents={[0.5, 1]}
+>
+  <ScrollView>
+    <View />
+  </ScrollView>
+</TrueSheet>
+```
+
+On iOS, this uses [`prefersScrollingExpandsWhenScrolledToEdge`](https://developer.apple.com/documentation/uikit/uisheetpresentationcontroller/3858107-prefersscrollingexpandswhenscrol). On Android, a custom `BottomSheetBehavior` selectively blocks scroll-driven expansion while preserving normal scrolling, fling deceleration, and grabber-based dragging.
 
 ## Using `scrollToEnd`
 
@@ -80,7 +96,7 @@ const scrollToEnd = () => {
 
 return (
   <TrueSheet scrollable onDidPresent={scrollToEnd}>
-    <FlatList ref={scrollRef} nestedScrollEnabled data={data} renderItem={renderItem} />
+    <FlatList ref={scrollRef} data={data} renderItem={renderItem} />
   </TrueSheet>
 );
 ```

--- a/docs/docs/reference/01-configuration.mdx
+++ b/docs/docs/reference/01-configuration.mdx
@@ -292,15 +292,23 @@ Style for the footer container.
 
 On iOS, automatically pins ScrollView or FlatList to fit within the sheet's available space. When enabled, the ScrollView's top edge will be pinned below any top sibling views, and its left, right, and bottom edges will be pinned to the container. See [this guide](/guides/scrolling) for example.
 
-On Android, it adds additional style to the content for scrollable to work.
+On Android, it ensures the scroll view fills the available sheet space and automatically manages nested scrolling. Any `nestedScrollEnabled` prop on your `ScrollView` or `FlatList` is ignored when `scrollable` is enabled.
 
 | Type | Default | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |
 | `boolean` | `false` | ✅ | ✅ | |
 
 :::warning
-The [`auto`](/reference/types#sheetdetent) detent does not work well with `scrollable`. Use fixed fractional detents (e.g., `0.5`, `0.8`, `1`) instead. This may be supported in the future once synchronous UI updates are officially supported by React Native.
+The [`auto`](/reference/types#sheetdetent) detent is not supported with `scrollable`. Use fixed fractional detents (e.g., `0.5`, `0.8`, `1`) instead.
 :::
+
+## `scrollableOptions`
+
+Options for customizing scrollable behavior. Only applies when [`scrollable`](#scrollable) is `true`. See [this guide](/guides/scrolling) for details.
+
+| Type | Default | 🍎 | 🤖 | 🌐 |
+| - | - | - | - | - |
+| [`ScrollableOptions`](/reference/types#scrollableoptions) | | ✅ | ✅ | |
 
 ## `pageSizing`
 

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -17,6 +17,10 @@ keywords: [bottom sheet types, bottom sheet typescript, bottom sheet definitions
 | `"auto"` | Auto resize based on content height. | **_16+_** | ✅ | ✅ |
 | `number` | Fractional height (0-1) representing percentage of screen height. | ✅ | ✅ | ✅ |
 
+:::warning
+The `"auto"` detent is not supported with [`scrollable`](/reference/configuration#scrollable). Use fixed fractional detents (e.g., `0.5`, `0.8`, `1`) instead.
+:::
+
 ## `BackgroundBlur`
 
 Blur style that is mapped into native values in iOS.
@@ -71,6 +75,28 @@ Options for customizing the blur effect. Only applies when `backgroundBlur` is s
 | - | - | - | - |
 | `intensity` | `number` | The intensity of the blur effect (0-100). | _system default_ |
 | `interaction` | `boolean` | Enables or disables user interaction on the blur view. Disabling can help with visual artifacts on iOS 18+. | `true` |
+
+## `ScrollableOptions`
+
+Options for customizing scrollable behavior. Only applies when `scrollable` is `true`.
+
+```tsx
+<TrueSheet
+  scrollable
+  scrollableOptions={{
+    scrollingExpandsSheet: false,
+  }}
+>
+  <ScrollView>
+    <View />
+  </ScrollView>
+</TrueSheet>
+```
+
+| Property | Type | Description | Default |
+| - | - | - | - |
+| `scrollingExpandsSheet` | `boolean` | When `false`, scrolling the content does not expand the sheet to the next detent. Only dragging the grabber or sheet background expands it. Useful for YouTube-style comments sheets. | `true` |
+| `keyboardScrollOffset` | `number` | Additional offset when scrolling to a focused input above the keyboard. | `0` |
 
 ## `GrabberOptions`
 

--- a/example/shared/src/components/sheets/FlatListSheet.tsx
+++ b/example/shared/src/components/sheets/FlatListSheet.tsx
@@ -38,7 +38,6 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
       <View style={styles.wrapper}>
         <FlatList
           ref={scrollRef}
-          nestedScrollEnabled
           data={times(10, (i) => i)}
           contentContainerStyle={styles.content}
           indicatorStyle="black"

--- a/example/shared/src/components/sheets/ScrollViewSheet.tsx
+++ b/example/shared/src/components/sheets/ScrollViewSheet.tsx
@@ -1,7 +1,8 @@
-import { forwardRef, useState } from 'react';
+import { forwardRef, useCallback, useState } from 'react';
 import {
   StyleSheet,
   ScrollView,
+  RefreshControl,
   View,
   Text,
   Image,
@@ -41,6 +42,12 @@ const HeavyItem = ({ index }: { index: number }) => {
 
 export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((props, ref) => {
   const [showList, setShowList] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    setTimeout(() => setRefreshing(false), 2000);
+  }, []);
 
   return (
     <TrueSheet
@@ -48,6 +55,7 @@ export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((prop
       detents={[0.8, 1]}
       name="scrollview"
       scrollable
+      scrollableOptions={{ scrollingExpandsSheet: false }}
       backgroundColor={Platform.select({ android: DARK })}
       header={<Header />}
       footer={<Footer text="TOGGLE LISTVIEW" onPress={() => setShowList(!showList)} />}
@@ -62,6 +70,7 @@ export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((prop
           indicatorStyle="black"
           scrollIndicatorInsets={{ bottom: FOOTER_HEIGHT }}
           keyboardDismissMode="on-drag"
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
         >
           {times(20, (i) => (
             <HeavyItem key={i} index={i} />

--- a/example/shared/src/components/sheets/ScrollViewSheet.tsx
+++ b/example/shared/src/components/sheets/ScrollViewSheet.tsx
@@ -65,7 +65,6 @@ export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((prop
     >
       {showList ? (
         <ScrollView
-          nestedScrollEnabled
           contentContainerStyle={styles.content}
           indicatorStyle="black"
           scrollIndicatorInsets={{ bottom: FOOTER_HEIGHT }}

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -13,6 +13,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface ScrollableOptions : NSObject
+
+@property (nonatomic, assign) CGFloat keyboardScrollOffset;
+@property (nonatomic, assign) BOOL scrollingExpandsSheet;
+
+@end
+
 @protocol TrueSheetContainerViewDelegate <NSObject>
 
 - (void)containerViewContentDidChangeSize:(CGSize)newSize;
@@ -44,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Options for scrollable behavior
  */
-@property (nonatomic, strong, nullable) NSDictionary *scrollableOptions;
+@property (nonatomic, strong, nullable) ScrollableOptions *scrollableOptions;
 
 /**
  * Returns the current content height

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -27,6 +27,18 @@
 
 using namespace facebook::react;
 
+@implementation ScrollableOptions
+
+- (instancetype)init {
+  if (self = [super init]) {
+    _keyboardScrollOffset = 0;
+    _scrollingExpandsSheet = YES;
+  }
+  return self;
+}
+
+@end
+
 @interface TrueSheetContainerView () <TrueSheetContentViewDelegate, TrueSheetHeaderViewDelegate>
 @end
 
@@ -87,14 +99,9 @@ using namespace facebook::react;
   _scrollableSet = YES;
 }
 
-- (void)setScrollableOptions:(NSDictionary *)scrollableOptions {
+- (void)setScrollableOptions:(ScrollableOptions *)scrollableOptions {
   _scrollableOptions = scrollableOptions;
-  if (scrollableOptions) {
-    NSNumber *offset = scrollableOptions[@"keyboardScrollOffset"];
-    _contentView.keyboardScrollOffset = offset ? [offset floatValue] : 0;
-  } else {
-    _contentView.keyboardScrollOffset = 0;
-  }
+  _contentView.keyboardScrollOffset = scrollableOptions ? scrollableOptions.keyboardScrollOffset : 0;
 }
 
 - (void)setupScrollable {

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -251,17 +251,21 @@ using namespace facebook::react;
   _scrollable = newProps.scrollable;
 
   const auto &scrollableOpts = newProps.scrollableOptions;
-  BOOL hasScrollableOptions = scrollableOpts.keyboardScrollOffset > 0;
+  BOOL scrollingExpandsSheet = scrollableOpts.scrollingExpandsSheet;
+  BOOL hasScrollableOptions = scrollableOpts.keyboardScrollOffset > 0 || !scrollingExpandsSheet;
 
   if (hasScrollableOptions) {
     NSMutableDictionary *options = [NSMutableDictionary dictionary];
     if (scrollableOpts.keyboardScrollOffset > 0) {
       options[@"keyboardScrollOffset"] = @(scrollableOpts.keyboardScrollOffset);
     }
+    options[@"scrollingExpandsSheet"] = @(scrollingExpandsSheet);
     _scrollableOptions = options;
   } else {
     _scrollableOptions = nil;
   }
+
+  _controller.scrollingExpandsSheet = scrollingExpandsSheet;
 
   _insetAdjustment = (NSInteger)newProps.insetAdjustment;
   _controller.insetAdjustment = _insetAdjustment;

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -53,7 +53,7 @@ using namespace facebook::react;
   NSInteger _initialDetentIndex;
   NSInteger _insetAdjustment;
   BOOL _scrollable;
-  NSDictionary *_scrollableOptions;
+  ScrollableOptions *_scrollableOptions;
   BOOL _initialDetentAnimated;
   BOOL _isSheetUpdatePending;
   BOOL _pendingLayoutUpdate;
@@ -213,25 +213,13 @@ using namespace facebook::react;
                            grabberOpts.cornerRadius >= 0 || grabberColor != nil || !grabberOpts.adaptive;
 
   if (hasGrabberOptions) {
-    NSMutableDictionary *options = [NSMutableDictionary dictionary];
-
-    if (grabberOpts.width > 0) {
-      options[@"width"] = @(grabberOpts.width);
-    }
-    if (grabberOpts.height > 0) {
-      options[@"height"] = @(grabberOpts.height);
-    }
-    if (grabberOpts.topMargin > 0) {
-      options[@"topMargin"] = @(grabberOpts.topMargin);
-    }
-    if (grabberOpts.cornerRadius >= 0) {
-      options[@"cornerRadius"] = @(grabberOpts.cornerRadius);
-    }
-    if (grabberColor) {
-      options[@"color"] = grabberColor;
-    }
-    options[@"adaptive"] = @(grabberOpts.adaptive);
-
+    GrabberOptions *options = [[GrabberOptions alloc] init];
+    if (grabberOpts.width > 0) options.width = @(grabberOpts.width);
+    if (grabberOpts.height > 0) options.height = @(grabberOpts.height);
+    if (grabberOpts.topMargin > 0) options.topMargin = @(grabberOpts.topMargin);
+    if (grabberOpts.cornerRadius >= 0) options.cornerRadius = @(grabberOpts.cornerRadius);
+    if (grabberColor) options.color = grabberColor;
+    options.adaptive = grabberOpts.adaptive;
     _controller.grabberOptions = options;
   } else {
     _controller.grabberOptions = nil;
@@ -255,11 +243,9 @@ using namespace facebook::react;
   BOOL hasScrollableOptions = scrollableOpts.keyboardScrollOffset > 0 || !scrollingExpandsSheet;
 
   if (hasScrollableOptions) {
-    NSMutableDictionary *options = [NSMutableDictionary dictionary];
-    if (scrollableOpts.keyboardScrollOffset > 0) {
-      options[@"keyboardScrollOffset"] = @(scrollableOpts.keyboardScrollOffset);
-    }
-    options[@"scrollingExpandsSheet"] = @(scrollingExpandsSheet);
+    ScrollableOptions *options = [[ScrollableOptions alloc] init];
+    options.keyboardScrollOffset = scrollableOpts.keyboardScrollOffset;
+    options.scrollingExpandsSheet = scrollingExpandsSheet;
     _scrollableOptions = options;
   } else {
     _scrollableOptions = nil;

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import "core/TrueSheetDetentCalculator.h"
+#import "core/TrueSheetGrabberView.h"
 
 #if __has_include(<RNScreens/RNSDismissibleModalProtocol.h>)
 #import <RNScreens/RNSDismissibleModalProtocol.h>
@@ -58,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) UIColor *backgroundColor;
 @property (nonatomic, strong, nullable) NSNumber *cornerRadius;
 @property (nonatomic, assign) BOOL grabber;
-@property (nonatomic, strong, nullable) NSDictionary *grabberOptions;
+@property (nonatomic, strong, nullable) GrabberOptions *grabberOptions;
 @property (nonatomic, assign) BOOL draggable;
 @property (nonatomic, assign) BOOL dimmed;
 @property (nonatomic, strong, nullable) NSNumber *dimmedDetentIndex;

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -68,6 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL pageSizing;
 @property (nonatomic, assign) NSInteger anchor;
 @property (nonatomic, assign) NSInteger insetAdjustment;
+@property (nonatomic, assign) BOOL scrollingExpandsSheet;
 @property (nonatomic, assign) BOOL dismissible;
 @property (nonatomic, assign) BOOL isPresented;
 @property (nonatomic, assign) NSInteger activeDetentIndex;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -749,13 +749,13 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
   if (self.grabberOptions) {
     self.sheet.prefersGrabberVisible = NO;
 
-    NSDictionary *options = self.grabberOptions;
-    _grabberView.grabberWidth = options[@"width"];
-    _grabberView.grabberHeight = options[@"height"];
-    _grabberView.topMargin = options[@"topMargin"];
-    _grabberView.cornerRadius = options[@"cornerRadius"];
-    _grabberView.color = options[@"color"];
-    _grabberView.adaptive = options[@"adaptive"];
+    GrabberOptions *options = self.grabberOptions;
+    _grabberView.grabberWidth = options.width;
+    _grabberView.grabberHeight = options.height;
+    _grabberView.topMargin = options.topMargin;
+    _grabberView.cornerRadius = options.cornerRadius;
+    _grabberView.color = options.color;
+    _grabberView.adaptive = @(options.adaptive);
     [_grabberView applyConfiguration];
     _grabberView.hidden = !showGrabber;
 

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -71,6 +71,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
     _headerHeight = @(0);
     _grabber = YES;
     _draggable = YES;
+    _scrollingExpandsSheet = YES;
     _dismissible = YES;
     _dimmed = YES;
     _dimmedDetentIndex = @(0);
@@ -850,7 +851,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
 
   sheet.delegate = self;
   sheet.prefersEdgeAttachedInCompactHeight = YES;
-  sheet.prefersScrollingExpandsWhenScrolledToEdge = self.draggable;
+  sheet.prefersScrollingExpandsWhenScrolledToEdge = self.draggable && self.scrollingExpandsSheet;
 
   if (self.cornerRadius) {
     sheet.preferredCornerRadius = [self.cornerRadius floatValue];

--- a/ios/core/TrueSheetGrabberView.h
+++ b/ios/core/TrueSheetGrabberView.h
@@ -10,6 +10,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface GrabberOptions : NSObject
+
+@property (nonatomic, strong, nullable) NSNumber *width;
+@property (nonatomic, strong, nullable) NSNumber *height;
+@property (nonatomic, strong, nullable) NSNumber *topMargin;
+@property (nonatomic, strong, nullable) NSNumber *cornerRadius;
+@property (nonatomic, strong, nullable) UIColor *color;
+@property (nonatomic, assign) BOOL adaptive;
+
+@end
+
 /**
  * Native grabber (drag handle) view for the bottom sheet.
  * Uses UIVibrancyEffect to adapt color based on the background.

--- a/ios/core/TrueSheetGrabberView.mm
+++ b/ios/core/TrueSheetGrabberView.mm
@@ -8,6 +8,17 @@
 
 #import "TrueSheetGrabberView.h"
 
+@implementation GrabberOptions
+
+- (instancetype)init {
+  if (self = [super init]) {
+    _adaptive = YES;
+  }
+  return self;
+}
+
+@end
+
 static const CGFloat kDefaultGrabberWidth = 36.0;
 static const CGFloat kDefaultGrabberHeight = 5.0;
 static const CGFloat kDefaultGrabberTopMargin = 5.0;

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -98,6 +98,14 @@ export interface ScrollableOptions {
    * @default 0
    */
   keyboardScrollOffset?: number;
+
+  /**
+   * Whether scrolling the content expands the sheet to the next detent.
+   * When `false`, only the grabber can expand the sheet.
+   *
+   * @default true
+   */
+  scrollingExpandsSheet?: boolean;
 }
 
 /**

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -23,6 +23,7 @@ type BlurOptionsType = Readonly<{
 
 type ScrollableOptionsType = Readonly<{
   keyboardScrollOffset?: WithDefault<Double, 0>;
+  scrollingExpandsSheet?: WithDefault<boolean, true>;
 }>;
 
 export interface DetentInfoEventPayload {


### PR DESCRIPTION
## Summary

Adds `scrollingExpandsSheet` option to `scrollableOptions`, allowing scrollable content to remain interactive at smaller detents without expanding the sheet. Only grabber drag expands the sheet when set to `false`.

Requested in https://github.com/lodev09/react-native-true-sheet/discussions/582

- **iOS**: Uses native `prefersScrollingExpandsWhenScrolledToEdge` on `UISheetPresentationController`
- **Android**: Custom `TrueSheetBottomSheetBehavior` that intercepts nested scroll/fling to prevent sheet expansion
- **Android**: Scroll expansion padding workaround to ensure full scroll range at smaller detents
- **Both**: Typed `ScrollableOptions` and `GrabberOptions` replacing `NSDictionary`/`ReadableMap`

## Type of Change

- [x] New feature
- [x] Documentation update

## Test Plan

- Present a scrollable sheet with `scrollableOptions={{ scrollingExpandsSheet: false }}` at a smaller detent
- Verify scrolling the list does NOT expand the sheet
- Verify grabber drag still expands the sheet
- Verify default behavior (without the option) is unchanged
- Verify scroll range is correct at all detents

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)