### PR TITLE
fix(ios): defer scroll-to-responder with dispatch_async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 3.10.0-beta.0
-
 ### 🎉 New features
 
 - Add accessibility support to grabber view with VoiceOver/TalkBack actions and state descriptions. ([#587](https://github.com/lodev09/react-native-true-sheet/pull/587) by [@lodev09](https://github.com/lodev09))
@@ -11,6 +9,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Fixed keyboard scroll positioning when sheet auto-expands from a smaller detent. ([#592](https://github.com/lodev09/react-native-true-sheet/pull/592) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fixed position change not emitting when detent or index changed. ([#584](https://github.com/lodev09/react-native-true-sheet/pull/584) by [@lodev09](https://github.com/lodev09))
 - **Android**: Use RN `BackHandler` for back press detection for reliability across Android versions. ([#580](https://github.com/lodev09/react-native-true-sheet/pull/580) by [@lodev09](https://github.com/lodev09))
 

--- a/example/shared/src/components/sheets/PromptSheet.tsx
+++ b/example/shared/src/components/sheets/PromptSheet.tsx
@@ -44,7 +44,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
     <TrueSheet
       ref={sheetRef}
       name="prompt-sheet"
-      detents={[1]}
+      detents={[0.75, 1]}
       scrollable
       scrollableOptions={{ keyboardScrollOffset: FOOTER_HEIGHT + SPACING }}
       backgroundBlur="dark"

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -216,15 +216,18 @@ using namespace facebook::react;
                    animations:^{
                      [self setScrollViewContentInset:height
                                       indicatorInset:self->_originalIndicatorBottomInset + height];
-
-                     if (firstResponder) {
-                       CGRect responderFrame = [firstResponder convertRect:firstResponder.bounds
-                                                                    toView:self->_pinnedScrollView.scrollView];
-                       responderFrame.size.height += self.keyboardScrollOffset;
-                       [self->_pinnedScrollView.scrollView scrollRectToVisible:responderFrame animated:NO];
-                     }
                    }
                    completion:nil];
+
+  // Defer scroll until the next run loop so content insets are applied first
+  if (firstResponder) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      CGRect responderFrame = [firstResponder convertRect:firstResponder.bounds
+                                                   toView:self->_pinnedScrollView.scrollView];
+      responderFrame.size.height += self.keyboardScrollOffset;
+      [self->_pinnedScrollView.scrollView scrollRectToVisible:responderFrame animated:YES];
+    });
+  }
 }
 
 - (void)keyboardWillHide:(NSTimeInterval)duration curve:(UIViewAnimationOptions)curve {


### PR DESCRIPTION
## Summary

Fixes keyboard scroll positioning when a sheet auto-expands from a smaller detent (e.g. `0.5` → `1`). The `scrollRectToVisible` call was executing inside the `animateWithDuration` block before content insets were fully applied, leaving empty space below the responder.

Defers the scroll to the next run loop tick via `dispatch_async` so content insets are applied first.

Closes #588

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

1. Present a scrollable sheet with `detents={[0.5, 1]}`
2. Tap a `TextInput` at the bottom of the `ScrollView`
3. Verify the input scrolls into view above the keyboard without empty space

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)