### PR TITLE
fix(android,ios): dead state after rapid present/dismiss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 🐛 Bug fixes
 
 - **iOS**: Fixed keyboard scroll positioning when sheet auto-expands from a smaller detent. ([#592](https://github.com/lodev09/react-native-true-sheet/pull/592) by [@lodev09](https://github.com/lodev09))
+- **Android**: Fixed dead state after rapid present/dismiss cycles. ([#593](https://github.com/lodev09/react-native-true-sheet/pull/593) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fixed position change not emitting when detent or index changed. ([#584](https://github.com/lodev09/react-native-true-sheet/pull/584) by [@lodev09](https://github.com/lodev09))
 - **Android**: Use RN `BackHandler` for back press detection for reliability across Android versions. ([#580](https://github.com/lodev09/react-native-true-sheet/pull/580) by [@lodev09](https://github.com/lodev09))
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -119,9 +119,6 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
 
     if (child is TrueSheetContainerView) {
       child.delegate = this
-      viewController.createSheet()
-      setupScrollable()
-
       val surfaceId = UIManagerHelper.getSurfaceId(this)
       eventDispatcher?.dispatchEvent(MountEvent(surfaceId, id))
     }
@@ -349,11 +346,8 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
       return
     }
 
-    if (viewController.coordinatorLayout == null || viewController.sheetView == null) {
-      RNLog.w(reactContext, "TrueSheet: sheet is not ready. Ensure it is mounted before presenting.")
-      promiseCallback()
-      return
-    }
+    viewController.createSheet()
+    setupScrollable()
 
     // Dismiss keyboard if focused view is within a sheet or if target detent will be dimmed
     val parentSheet = TrueSheetStackManager.getTopmostSheet()

--- a/example/shared/src/components/Button.tsx
+++ b/example/shared/src/components/Button.tsx
@@ -4,11 +4,12 @@ import { BUTTON_HEIGHT, DARK_BLUE, SPACING } from '../utils';
 
 interface ButtonProps extends PressableProps {
   text: string;
+  hint?: string;
   loading?: boolean;
 }
 
 export const Button = (props: ButtonProps) => {
-  const { text, style, loading, ...rest } = props;
+  const { text, hint, style, loading, ...rest } = props;
   return (
     <Pressable
       style={(state) => [
@@ -19,6 +20,7 @@ export const Button = (props: ButtonProps) => {
       {...rest}
     >
       <Text style={styles.text}>{text}</Text>
+      {hint && <Text style={styles.hint}>{hint}</Text>}
       {loading && <ActivityIndicator style={styles.loader} size="small" color="#fff" />}
     </Pressable>
   );
@@ -38,6 +40,10 @@ const styles = StyleSheet.create({
   },
   text: {
     color: '#fff',
+  },
+  hint: {
+    fontSize: 10,
+    color: 'rgba(255, 255, 255, 0.5)',
   },
   loader: {
     position: 'absolute',

--- a/example/shared/src/components/sheets/FlatListSheet.tsx
+++ b/example/shared/src/components/sheets/FlatListSheet.tsx
@@ -28,10 +28,7 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
         </Header>
       }
       onDidDismiss={() => console.log('Sheet FlatList dismissed!')}
-      onDidPresent={() => {
-        console.log(`Sheet FlatList presented!`);
-        scrollRef.current?.scrollToOffset({ offset: 99999, animated: true });
-      }}
+      onDidPresent={() => console.log(`Sheet FlatList presented!`)}
       footer={<Footer text="OPEN BLANK SHEET" onPress={() => testRef.current?.present()} />}
       {...props}
     >

--- a/example/shared/src/screens/MapScreen.tsx
+++ b/example/shared/src/screens/MapScreen.tsx
@@ -78,6 +78,14 @@ const MapScreenInner = ({
     console.log('basic sheet presented');
   };
 
+  const rapidPresentDismiss = async () => {
+    for (let i = 0; i < 5; i++) {
+      await basicSheet.current?.present(0);
+      await basicSheet.current?.dismiss();
+    }
+    await basicSheet.current?.present(0);
+  };
+
   const presentScrollViewSheet = () => {
     setScrollViewLoading(true);
     requestAnimationFrame(async () => {
@@ -166,7 +174,12 @@ const MapScreenInner = ({
           <Text style={styles.title}>True Sheet</Text>
           <Text style={styles.subtitle}>The true native bottom sheet experience.</Text>
         </View>
-        <Button text="TrueSheet View" onPress={() => presentBasicSheet(0)} />
+        <Button
+          text="TrueSheet View"
+          hint="Long press to stress test"
+          onPress={() => presentBasicSheet(0)}
+          onLongPress={rapidPresentDismiss}
+        />
         <Button text="Open Modal" onPress={onNavigateToModal} />
         <Button text="Sheet Navigator" onPress={onNavigateToSheetStack} />
         {isTablet && (

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -261,11 +261,7 @@ using namespace facebook::react;
   _insetAdjustment = (NSInteger)newProps.insetAdjustment;
   _controller.insetAdjustment = _insetAdjustment;
 
-  if (_containerView) {
-    _containerView.scrollableEnabled = _scrollable;
-    _containerView.insetAdjustment = _insetAdjustment;
-    _containerView.scrollableOptions = _scrollableOptions;
-  }
+  [self setupScrollable];
 }
 
 - (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState {
@@ -314,9 +310,7 @@ using namespace facebook::react;
   if (!(updateMask & RNComponentViewUpdateMaskProps) || !_controller)
     return;
 
-  if (_containerView) {
-    [_containerView setupScrollable];
-  }
+  [self setupScrollable];
 
   if (_controller.isPresented) {
     [self applySheetPropsUpdate];
@@ -384,11 +378,6 @@ using namespace facebook::react;
     _controller.headerHeight = @(headerHeight);
   }
 
-  _containerView.scrollableEnabled = _scrollable;
-  _containerView.insetAdjustment = _insetAdjustment;
-  _containerView.scrollableOptions = _scrollableOptions;
-  [_containerView setupScrollable];
-
   if (_eventEmitter) {
     [TrueSheetLifecycleEvents emitMount:_eventEmitter];
   } else {
@@ -448,6 +437,8 @@ using namespace facebook::react;
   [_controller setupSheetProps];
   [_controller setupSheetDetents];
   [_controller setupActiveDetentWithIndex:index];
+
+  [self setupScrollable];
 
   [_screensEventObserver capturePresenterScreenFromView:self];
   [_screensEventObserver startObservingWithState:_state.get()->getData()];
@@ -575,7 +566,7 @@ using namespace facebook::react;
 
 // When the ScrollView changes (e.g. conditional remount), re-pin the new ScrollView.
 - (void)containerViewScrollViewDidChange {
-  [_containerView setupScrollable];
+  [self setupScrollable];
 }
 
 #pragma mark - TrueSheetViewControllerDelegate
@@ -696,6 +687,16 @@ using namespace facebook::react;
 }
 
 #pragma mark - Private Helpers
+
+- (void)setupScrollable {
+  if (!_containerView)
+    return;
+
+  _containerView.scrollableEnabled = _scrollable;
+  _containerView.insetAdjustment = _insetAdjustment;
+  _containerView.scrollableOptions = _scrollableOptions;
+  [_containerView setupScrollable];
+}
 
 - (void)applySheetPropsUpdate {
   BOOL pendingLayoutUpdate = _pendingLayoutUpdate;


### PR DESCRIPTION
## Summary

Fixes dead state after rapid present/dismiss cycles where `present()` resolves without error but the sheet never appears.

- **Android**: Moved `createSheet()` and `setupScrollable()` from mount time (`addView`) to present time (`present()`), removing the early-return guard that checked for null sheet components
- **iOS**: Mirrored the Android pattern — moved scrollable setup from `mountChildComponentView` to `presentAtIndex:`, added `setupScrollable` helper for consistent usage across the view
- **Example**: Added stress test (long press "TrueSheet View" button) for rapid present/dismiss cycles

Closes #590

## Type of Change

- [x] Bug fix

## Test Plan

- Long press the "TrueSheet View" button in the example app to trigger 5 rapid present/dismiss cycles
- Verify sheet presents correctly after the stress test
- Verify normal present/dismiss still works
- Verify ScrollView sheets still scroll correctly

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)