### PR TITLE
feat(ios): add scroll edge effect support for iOS 26+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add accessibility support to grabber view with VoiceOver/TalkBack actions and state descriptions. ([#587](https://github.com/lodev09/react-native-true-sheet/pull/587) by [@lodev09](https://github.com/lodev09))
 - Add `scrollingExpandsSheet` option to `scrollableOptions`. ([#585](https://github.com/lodev09/react-native-true-sheet/pull/585) by [@lodev09](https://github.com/lodev09))
+- **iOS**: Add `topScrollEdgeEffect` and `bottomScrollEdgeEffect` to `scrollableOptions` for iOS 26+. ([#595](https://github.com/lodev09/react-native-true-sheet/pull/595) by [@lodev09](https://github.com/lodev09))
 
 ### 🐛 Bug fixes
 

--- a/docs/docs/guides/scrolling.mdx
+++ b/docs/docs/guides/scrolling.mdx
@@ -80,6 +80,38 @@ By default, scrolling content to the top edge expands the sheet to the next dete
 
 On iOS, this uses [`prefersScrollingExpandsWhenScrolledToEdge`](https://developer.apple.com/documentation/uikit/uisheetpresentationcontroller/3858107-prefersscrollingexpandswhenscrol). On Android, a custom `BottomSheetBehavior` selectively blocks scroll-driven expansion while preserving normal scrolling, fling deceleration, and grabber-based dragging.
 
+## Scroll Edge Effect
+
+On iOS 26+, you can apply a blur/gradient edge effect on the header and footer when content scrolls behind them. This uses [`UIScrollEdgeElementContainerInteraction`](https://developer.apple.com/documentation/uikit/uiscrolledgeelementcontainerinteraction) under the hood.
+
+Set [`topScrollEdgeEffect`](../reference/types#scrollableoptions) and/or [`bottomScrollEdgeEffect`](../reference/types#scrollableoptions) in [`scrollableOptions`](../reference/configuration#scrollableoptions) to enable it:
+
+```tsx
+<TrueSheet
+  scrollable
+  scrollableOptions={{
+    topScrollEdgeEffect: 'automatic',
+    bottomScrollEdgeEffect: 'soft',
+  }}
+  header={<Header />}
+  footer={<Footer />}
+>
+  <ScrollView>
+    <View />
+  </ScrollView>
+</TrueSheet>
+```
+
+Available values: `'automatic'`, `'hard'`, `'soft'`, or `'hidden'` (default). See [`ScrollEdgeEffect`](../reference/types#scrolledgeeffect).
+
+:::info
+This also controls the scroll view's own edge effects ([`UIScrollEdgeEffect`](https://developer.apple.com/documentation/uikit/uiscrolledgeeffect)). `topScrollEdgeEffect` applies to both the header interaction and the scroll view's top edge, and `bottomScrollEdgeEffect` applies to both the footer interaction and the scroll view's bottom edge.
+:::
+
+:::note
+This feature requires iOS 26 or later. On older versions, these options are ignored.
+:::
+
 ## Using `scrollToEnd`
 
 When using `scrollable`, the native scroll view frame is modified to fit within the sheet container. This can cause `scrollToEnd()` on `FlatList` or `ScrollView` to not work as expected because React Native's JS-side scroll metrics may not reflect the actual native dimensions.

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -97,6 +97,19 @@ Options for customizing scrollable behavior. Only applies when `scrollable` is `
 | - | - | - | - |
 | `scrollingExpandsSheet` | `boolean` | When `false`, scrolling the content does not expand the sheet to the next detent. Only dragging the grabber or sheet background expands it. Useful for YouTube-style comments sheets. | `true` |
 | `keyboardScrollOffset` | `number` | Additional offset when scrolling to a focused input above the keyboard. | `0` |
+| `topScrollEdgeEffect` | [`ScrollEdgeEffect`](#scrolledgeeffect) | The scroll edge effect applied to the top edge of the scroll view and header. iOS 26+ only. | `'hidden'` |
+| `bottomScrollEdgeEffect` | [`ScrollEdgeEffect`](#scrolledgeeffect) | The scroll edge effect applied to the bottom edge of the scroll view and footer. iOS 26+ only. | `'hidden'` |
+
+## `ScrollEdgeEffect`
+
+Controls the blur/gradient edge effect on the scroll view edges and header/footer overlay views. iOS 26+ only.
+
+| Value | Description |
+| - | - |
+| `'automatic'` | System default edge effect style. |
+| `'hard'` | A hard, opaque edge effect. |
+| `'soft'` | A soft, gradient edge effect. |
+| `'hidden'` | No edge effect. This is the default. |
 
 ## `GrabberOptions`
 

--- a/example/bare/ios/Podfile.lock
+++ b/example/bare/ios/Podfile.lock
@@ -2649,7 +2649,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNTrueSheet (3.9.9):
+  - RNTrueSheet (3.10.0-beta.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3104,7 +3104,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: e1cf8ef3f11045536eed6bd4f132b003ef5f9a5f
   RNReanimated: f1868b36f4b2b52a0ed00062cfda69506f75eaee
   RNScreens: d821082c6dd1cb397cc0c98b026eeafaa68be479
-  RNTrueSheet: a3094081efc659586c568292d1b778703611a5dd
+  RNTrueSheet: cda20577e6b3553643620281ee9143f0ae6c8371
   RNWorklets: d9c050940f140af5d8b611d937eab1cbfce5e9a5
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb

--- a/example/shared/src/components/Footer.tsx
+++ b/example/shared/src/components/Footer.tsx
@@ -28,16 +28,20 @@ export const Footer = ({ children, text = 'FOOTER', onPress, ...rest }: FooterPr
 
 const styles = StyleSheet.create({
   wrapper: {
-    backgroundColor: DARK_GRAY,
+    backgroundColor: Platform.select({
+      default: DARK_GRAY,
+      ios: undefined,
+    }),
   },
   container: {
     height: FOOTER_HEIGHT,
-    padding: SPACING,
+    paddingHorizontal: SPACING,
   },
   pressed: {
     opacity: 0.6,
   },
   text: {
+    marginTop: SPACING,
     textAlign: 'center',
     color: '#fff',
   },

--- a/example/shared/src/components/Input.tsx
+++ b/example/shared/src/components/Input.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, TextInput, View, type TextInputProps } from 'react-native';
+import { Platform, StyleSheet, TextInput, View, type TextInputProps } from 'react-native';
 
 import { LIGHT_GRAY, INPUT_HEIGHT, SPACING } from '../utils';
 import { forwardRef } from 'react';
@@ -25,7 +25,10 @@ export const Input = forwardRef<TextInput, TextInputProps>((props, ref) => {
 
 const styles = StyleSheet.create({
   inputContainer: {
-    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+    backgroundColor: Platform.select({
+      ios: 'rgba(0, 0, 0, 0.5)',
+      default: 'rgba(0, 0, 0, 0.3)',
+    }),
     paddingHorizontal: SPACING,
     height: INPUT_HEIGHT,
     borderRadius: INPUT_HEIGHT,

--- a/example/shared/src/components/sheets/FlatListSheet.tsx
+++ b/example/shared/src/components/sheets/FlatListSheet.tsx
@@ -21,6 +21,10 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
       backgroundBlur="dark"
       backgroundColor={DARK}
       scrollable
+      scrollableOptions={{
+        bottomScrollEdgeEffect: 'soft',
+        topScrollEdgeEffect: 'soft',
+      }}
       header={<Header style={styles.header} />}
       onDidDismiss={() => console.log('Sheet FlatList dismissed!')}
       onDidPresent={() => console.log(`Sheet FlatList presented!`)}

--- a/example/shared/src/components/sheets/FlatListSheet.tsx
+++ b/example/shared/src/components/sheets/FlatListSheet.tsx
@@ -2,8 +2,7 @@ import { forwardRef, useRef } from 'react';
 import { StyleSheet, FlatList, View } from 'react-native';
 import { TrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
 
-import { DARK, DARK_GRAY, FOOTER_HEIGHT, SPACING, times } from '../../utils';
-import { Input } from '../Input';
+import { DARK, DARK_GRAY, FOOTER_HEIGHT, HEADER_HEIGHT, SPACING, times } from '../../utils';
 import { DemoContent } from '../DemoContent';
 import { Spacer } from '../Spacer';
 import { Header } from '../Header';
@@ -22,11 +21,7 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
       backgroundBlur="dark"
       backgroundColor={DARK}
       scrollable
-      header={
-        <Header>
-          <Input />
-        </Header>
-      }
+      header={<Header style={styles.header} />}
       onDidDismiss={() => console.log('Sheet FlatList dismissed!')}
       onDidPresent={() => console.log(`Sheet FlatList presented!`)}
       footer={<Footer text="OPEN BLANK SHEET" onPress={() => testRef.current?.present()} />}
@@ -56,8 +51,15 @@ const styles = StyleSheet.create({
   wrapper: {
     flex: 1,
   },
+  header: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    zIndex: 1,
+  },
   content: {
     padding: SPACING,
+    paddingTop: HEADER_HEIGHT,
     paddingBottom: FOOTER_HEIGHT + SPACING,
   },
 });

--- a/example/shared/src/components/sheets/ScrollViewSheet.tsx
+++ b/example/shared/src/components/sheets/ScrollViewSheet.tsx
@@ -65,7 +65,11 @@ export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((prop
       detents={[0.8, 1]}
       name="scrollview"
       scrollable
-      scrollableOptions={{ scrollingExpandsSheet: false }}
+      scrollableOptions={{
+        scrollingExpandsSheet: false,
+        bottomScrollEdgeEffect: 'soft',
+        topScrollEdgeEffect: 'soft',
+      }}
       backgroundColor={Platform.select({ android: DARK })}
       header={<Header />}
       headerStyle={styles.header}

--- a/example/shared/src/components/sheets/ScrollViewSheet.tsx
+++ b/example/shared/src/components/sheets/ScrollViewSheet.tsx
@@ -11,9 +11,19 @@ import {
 } from 'react-native';
 import { TrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
 
-import { BORDER_RADIUS, DARK, FOOTER_HEIGHT, GAP, LIGHT_GRAY, SPACING, times } from '../../utils';
+import {
+  BORDER_RADIUS,
+  DARK,
+  FOOTER_HEIGHT,
+  GAP,
+  HEADER_HEIGHT,
+  LIGHT_GRAY,
+  SPACING,
+  times,
+} from '../../utils';
 import { Footer } from '../Footer';
 import { Header } from '../Header';
+import { Button } from '../Button';
 
 interface ScrollViewSheetProps extends TrueSheetProps {}
 
@@ -58,7 +68,12 @@ export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((prop
       scrollableOptions={{ scrollingExpandsSheet: false }}
       backgroundColor={Platform.select({ android: DARK })}
       header={<Header />}
-      footer={<Footer text="TOGGLE LISTVIEW" onPress={() => setShowList(!showList)} />}
+      headerStyle={styles.header}
+      footer={
+        <Footer>
+          <Button text="Toggle ListView" onPress={() => setShowList(!showList)} />
+        </Footer>
+      }
       onDidDismiss={() => console.log('Sheet ScrollView dismissed!')}
       onDidPresent={() => console.log(`Sheet ScrollView presented!`)}
       {...props}
@@ -89,8 +104,15 @@ ScrollViewSheet.displayName = 'ScrollViewSheet';
 const styles = StyleSheet.create({
   content: {
     padding: SPACING,
+    paddingTop: HEADER_HEIGHT,
     paddingBottom: FOOTER_HEIGHT + SPACING,
     gap: GAP,
+  },
+  header: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    zIndex: 1,
   },
   item: {
     backgroundColor: 'rgba(0, 0, 0, 0.3)',

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -17,6 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) CGFloat keyboardScrollOffset;
 @property (nonatomic, assign) BOOL scrollingExpandsSheet;
+@property (nonatomic, assign) NSInteger topScrollEdgeEffect;
+@property (nonatomic, assign) NSInteger bottomScrollEdgeEffect;
 
 @end
 

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -33,6 +33,8 @@ using namespace facebook::react;
   if (self = [super init]) {
     _keyboardScrollOffset = 0;
     _scrollingExpandsSheet = YES;
+    _topScrollEdgeEffect = 0;
+    _bottomScrollEdgeEffect = 0;
   }
   return self;
 }
@@ -111,6 +113,7 @@ using namespace facebook::react;
       bottomInset = [WindowUtil keyWindow].safeAreaInsets.bottom;
     }
     [_contentView setupScrollable:_scrollableEnabled bottomInset:bottomInset];
+    [_contentView applyScrollEdgeEffects:_scrollableOptions];
   }
 }
 

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -127,12 +127,10 @@ using namespace facebook::react;
     return;
   }
 
-  NSInteger topEffect = _scrollableOptions
-    ? _scrollableOptions.topScrollEdgeEffect
-    : (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
-  NSInteger bottomEffect = _scrollableOptions
-    ? _scrollableOptions.bottomScrollEdgeEffect
-    : (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
+  NSInteger topEffect =
+    _scrollableOptions ? _scrollableOptions.topScrollEdgeEffect : (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
+  NSInteger bottomEffect = _scrollableOptions ? _scrollableOptions.bottomScrollEdgeEffect
+                                              : (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
 
   BOOL topHidden = topEffect == (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
   BOOL bottomHidden = bottomEffect == (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -34,8 +34,8 @@ using namespace facebook::react;
   if (self = [super init]) {
     _keyboardScrollOffset = 0;
     _scrollingExpandsSheet = YES;
-    _topScrollEdgeEffect = 0;
-    _bottomScrollEdgeEffect = 0;
+    _topScrollEdgeEffect = (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
+    _bottomScrollEdgeEffect = (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
   }
   return self;
 }
@@ -124,14 +124,24 @@ using namespace facebook::react;
     return;
   }
 
+  NSInteger topEffect = _scrollableOptions
+    ? _scrollableOptions.topScrollEdgeEffect
+    : (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
+  NSInteger bottomEffect = _scrollableOptions
+    ? _scrollableOptions.bottomScrollEdgeEffect
+    : (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
+
+  BOOL topHidden = topEffect == (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
+  BOOL bottomHidden = bottomEffect == (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
+
   RCTScrollViewComponentView *scrollViewComponent = [_contentView findScrollView];
   UIScrollView *scrollView = scrollViewComponent.scrollView;
 
   if (_headerView) {
-    [_headerView setupEdgeInteractionWithScrollView:scrollView];
+    [_headerView setupEdgeInteractionWithScrollView:topHidden ? nil : scrollView];
   }
   if (_footerView) {
-    [_footerView setupEdgeInteractionWithScrollView:scrollView];
+    [_footerView setupEdgeInteractionWithScrollView:bottomHidden ? nil : scrollView];
   }
 }
 

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -9,6 +9,7 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #import "TrueSheetContainerView.h"
+#import <React/RCTScrollViewComponentView.h>
 #import "TrueSheetContentView.h"
 #import "TrueSheetFooterView.h"
 #import "TrueSheetHeaderView.h"
@@ -114,6 +115,23 @@ using namespace facebook::react;
     }
     [_contentView setupScrollable:_scrollableEnabled bottomInset:bottomInset];
     [_contentView applyScrollEdgeEffects:_scrollableOptions];
+    [self setupEdgeInteractions];
+  }
+}
+
+- (void)setupEdgeInteractions API_AVAILABLE(ios(26.0)) {
+  if (!_contentView) {
+    return;
+  }
+
+  RCTScrollViewComponentView *scrollViewComponent = [_contentView findScrollView];
+  UIScrollView *scrollView = scrollViewComponent.scrollView;
+
+  if (_headerView) {
+    [_headerView setupEdgeInteractionWithScrollView:scrollView];
+  }
+  if (_footerView) {
+    [_footerView setupEdgeInteractionWithScrollView:scrollView];
   }
 }
 
@@ -147,6 +165,10 @@ using namespace facebook::react;
       return;
     }
     _footerView = (TrueSheetFooterView *)childComponentView;
+  }
+
+  if (@available(iOS 26.0, *)) {
+    [self setupEdgeInteractions];
   }
 }
 
@@ -187,6 +209,10 @@ using namespace facebook::react;
 
 - (void)contentViewScrollViewDidChange {
   [self.delegate containerViewScrollViewDidChange];
+
+  if (@available(iOS 26.0, *)) {
+    [self setupEdgeInteractions];
+  }
 }
 
 #pragma mark - TrueSheetHeaderViewDelegate

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -15,6 +15,7 @@
 #import "TrueSheetHeaderView.h"
 #import "TrueSheetViewController.h"
 #import "core/TrueSheetKeyboardObserver.h"
+#import "utils/UIView+ScrollEdgeInteraction.h"
 #import "utils/WindowUtil.h"
 
 #import <react/renderer/components/TrueSheetSpec/ComponentDescriptors.h>
@@ -115,7 +116,9 @@ using namespace facebook::react;
     }
     [_contentView setupScrollable:_scrollableEnabled bottomInset:bottomInset];
     [_contentView applyScrollEdgeEffects:_scrollableOptions];
-    [self setupEdgeInteractions];
+    if (@available(iOS 26.0, *)) {
+      [self setupEdgeInteractions];
+    }
   }
 }
 
@@ -138,10 +141,10 @@ using namespace facebook::react;
   UIScrollView *scrollView = scrollViewComponent.scrollView;
 
   if (_headerView) {
-    [_headerView setupEdgeInteractionWithScrollView:topHidden ? nil : scrollView];
+    [_headerView setupEdgeInteractionWithScrollView:topHidden ? nil : scrollView edge:UIRectEdgeTop];
   }
   if (_footerView) {
-    [_footerView setupEdgeInteractionWithScrollView:bottomHidden ? nil : scrollView];
+    [_footerView setupEdgeInteractionWithScrollView:bottomHidden ? nil : scrollView edge:UIRectEdgeBottom];
   }
 }
 
@@ -175,10 +178,6 @@ using namespace facebook::react;
       return;
     }
     _footerView = (TrueSheetFooterView *)childComponentView;
-  }
-
-  if (@available(iOS 26.0, *)) {
-    [self setupEdgeInteractions];
   }
 }
 
@@ -219,10 +218,6 @@ using namespace facebook::react;
 
 - (void)contentViewScrollViewDidChange {
   [self.delegate containerViewScrollViewDidChange];
-
-  if (@available(iOS 26.0, *)) {
-    [self setupEdgeInteractions];
-  }
 }
 
 #pragma mark - TrueSheetHeaderViewDelegate

--- a/ios/TrueSheetContentView.h
+++ b/ios/TrueSheetContentView.h
@@ -16,6 +16,7 @@
 
 @class TrueSheetViewController;
 @class RCTScrollViewComponentView;
+@class ScrollableOptions;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -45,6 +46,11 @@ NS_ASSUME_NONNULL_BEGIN
  * Update the pinned scroll view's height to fill the container
  */
 - (void)updateScrollViewHeight;
+
+/**
+ * Apply scroll edge effects to the pinned scroll view (iOS 26+)
+ */
+- (void)applyScrollEdgeEffects:(nullable ScrollableOptions *)options;
 
 @end
 

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -212,9 +212,9 @@ using namespace facebook::react;
   if (@available(iOS 26.0, *)) {
     UIScrollView *scrollView = _pinnedScrollView.scrollView;
     NSInteger topEffect =
-      options ? options.topScrollEdgeEffect : (NSInteger)TrueSheetViewTopScrollEdgeEffect::Automatic;
+      options ? options.topScrollEdgeEffect : (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
     NSInteger bottomEffect =
-      options ? options.bottomScrollEdgeEffect : (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Automatic;
+      options ? options.bottomScrollEdgeEffect : (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
 
     [self applyEdgeEffect:topEffect toEdge:scrollView.topEdgeEffect];
     [self applyEdgeEffect:bottomEffect toEdge:scrollView.bottomEdgeEffect];

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -211,8 +211,7 @@ using namespace facebook::react;
 
   if (@available(iOS 26.0, *)) {
     UIScrollView *scrollView = _pinnedScrollView.scrollView;
-    NSInteger topEffect =
-      options ? options.topScrollEdgeEffect : (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
+    NSInteger topEffect = options ? options.topScrollEdgeEffect : (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
     NSInteger bottomEffect =
       options ? options.bottomScrollEdgeEffect : (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
 

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -14,8 +14,10 @@
 #import <react/renderer/components/TrueSheetSpec/EventEmitters.h>
 #import <react/renderer/components/TrueSheetSpec/Props.h>
 #import <react/renderer/components/TrueSheetSpec/RCTComponentViewHelpers.h>
+#import "TrueSheetContainerView.h"
 #import "TrueSheetView.h"
 #import "TrueSheetViewController.h"
+#import "utils/PlatformUtil.h"
 #import "utils/UIView+FirstResponder.h"
 
 using namespace facebook::react;
@@ -199,6 +201,48 @@ using namespace facebook::react;
   }
   return nil;
 }
+
+#pragma mark - Scroll Edge Effects
+
+- (void)applyScrollEdgeEffects:(nullable ScrollableOptions *)options {
+#if RNTS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+  if (!_pinnedScrollView)
+    return;
+
+  if (@available(iOS 26.0, *)) {
+    UIScrollView *scrollView = _pinnedScrollView.scrollView;
+    NSInteger topEffect =
+      options ? options.topScrollEdgeEffect : (NSInteger)TrueSheetViewTopScrollEdgeEffect::Automatic;
+    NSInteger bottomEffect =
+      options ? options.bottomScrollEdgeEffect : (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Automatic;
+
+    [self applyEdgeEffect:topEffect toEdge:scrollView.topEdgeEffect];
+    [self applyEdgeEffect:bottomEffect toEdge:scrollView.bottomEdgeEffect];
+  }
+#endif
+}
+
+#if RNTS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+- (void)applyEdgeEffect:(NSInteger)effect toEdge:(UIScrollEdgeEffect *)edgeEffect API_AVAILABLE(ios(26.0)) {
+  switch (effect) {
+    case (NSInteger)TrueSheetViewTopScrollEdgeEffect::Automatic:
+      edgeEffect.hidden = NO;
+      edgeEffect.style = UIScrollEdgeEffectStyle.automaticStyle;
+      break;
+    case (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hard:
+      edgeEffect.hidden = NO;
+      edgeEffect.style = UIScrollEdgeEffectStyle.hardStyle;
+      break;
+    case (NSInteger)TrueSheetViewTopScrollEdgeEffect::Soft:
+      edgeEffect.hidden = NO;
+      edgeEffect.style = UIScrollEdgeEffectStyle.softStyle;
+      break;
+    case (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden:
+      edgeEffect.hidden = YES;
+      break;
+  }
+}
+#endif
 
 #pragma mark - TrueSheetKeyboardObserverDelegate
 

--- a/ios/TrueSheetFooterView.h
+++ b/ios/TrueSheetFooterView.h
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, nullable) TrueSheetKeyboardObserver *keyboardObserver;
 
 - (void)setupConstraintsWithHeight:(CGFloat)height;
-- (void)setupEdgeInteractionWithScrollView:(UIScrollView *)scrollView API_AVAILABLE(ios(26.0));
 
 @end
 

--- a/ios/TrueSheetFooterView.h
+++ b/ios/TrueSheetFooterView.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, nullable) TrueSheetKeyboardObserver *keyboardObserver;
 
 - (void)setupConstraintsWithHeight:(CGFloat)height;
+- (void)setupEdgeInteractionWithScrollView:(UIScrollView *)scrollView API_AVAILABLE(ios(26.0));
 
 @end
 

--- a/ios/TrueSheetFooterView.mm
+++ b/ios/TrueSheetFooterView.mm
@@ -102,15 +102,7 @@ using namespace facebook::react;
   [LayoutUtil unpinView:self fromParentView:self.superview];
 
   if (@available(iOS 26.0, *)) {
-    [_edgeEffectHint removeFromSuperview];
-    _edgeEffectHint = nil;
-
-    for (id<UIInteraction> interaction in [self.interactions copy]) {
-      if ([interaction isKindOfClass:[UIScrollEdgeElementContainerInteraction class]]) {
-        [self removeInteraction:interaction];
-        break;
-      }
-    }
+    [self cleanupEdgeInteraction];
   }
 
   _lastHeight = 0;
@@ -121,7 +113,7 @@ using namespace facebook::react;
 
 #pragma mark - Scroll Edge Interaction
 
-- (void)setupEdgeInteractionWithScrollView:(UIScrollView *)scrollView API_AVAILABLE(ios(26.0)) {
+- (void)cleanupEdgeInteraction API_AVAILABLE(ios(26.0)) {
   for (id<UIInteraction> interaction in [self.interactions copy]) {
     if ([interaction isKindOfClass:[UIScrollEdgeElementContainerInteraction class]]) {
       [self removeInteraction:interaction];
@@ -131,6 +123,10 @@ using namespace facebook::react;
 
   [_edgeEffectHint removeFromSuperview];
   _edgeEffectHint = nil;
+}
+
+- (void)setupEdgeInteractionWithScrollView:(UIScrollView *)scrollView API_AVAILABLE(ios(26.0)) {
+  [self cleanupEdgeInteraction];
 
   if (!scrollView) {
     return;

--- a/ios/TrueSheetFooterView.mm
+++ b/ios/TrueSheetFooterView.mm
@@ -23,6 +23,8 @@ using namespace facebook::react;
   BOOL _didInitialLayout;
   NSLayoutConstraint *_bottomConstraint;
   CGFloat _currentKeyboardOffset;
+
+  UILabel *_edgeEffectHint;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider {
@@ -34,7 +36,6 @@ using namespace facebook::react;
     static const auto defaultProps = std::make_shared<const TrueSheetFooterViewProps>();
     _props = defaultProps;
 
-    // Set background color to clear by default
     self.backgroundColor = [UIColor clearColor];
 
     _lastHeight = 0;
@@ -45,28 +46,26 @@ using namespace facebook::react;
   return self;
 }
 
+#pragma mark - Layout
+
 - (void)setupConstraintsWithHeight:(CGFloat)height {
   UIView *parentView = self.superview;
   if (!parentView) {
     return;
   }
 
-  // Remove existing constraints before applying new ones
   [LayoutUtil unpinView:self fromParentView:parentView];
   _bottomConstraint = nil;
 
   self.translatesAutoresizingMaskIntoConstraints = NO;
 
-  // Pin footer to sides of container
   [self.leadingAnchor constraintEqualToAnchor:parentView.leadingAnchor].active = YES;
   [self.trailingAnchor constraintEqualToAnchor:parentView.trailingAnchor].active = YES;
 
-  // Store bottom constraint for keyboard adjustment, preserving current keyboard offset
   _bottomConstraint = [self.bottomAnchor constraintEqualToAnchor:parentView.bottomAnchor
                                                         constant:-_currentKeyboardOffset];
   _bottomConstraint.active = YES;
 
-  // Apply height constraint
   if (height > 0) {
     [self.heightAnchor constraintEqualToConstant:height].active = YES;
   }
@@ -77,7 +76,6 @@ using namespace facebook::react;
 - (void)didMoveToSuperview {
   [super didMoveToSuperview];
 
-  // Setup footer constraints when added to container
   if (self.superview) {
     CGFloat initialHeight = self.frame.size.height;
     [self setupConstraintsWithHeight:initialHeight];
@@ -88,14 +86,11 @@ using namespace facebook::react;
            oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics {
   CGFloat height = layoutMetrics.frame.size.height;
 
-  // On initial layout, call super to let React Native position the view
-  // After that, we use Auto Layout constraints instead
   if (!_didInitialLayout) {
     [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
     _didInitialLayout = YES;
   }
 
-  // Update footer constraints when height changes
   if (height != _lastHeight) {
     [self setupConstraintsWithHeight:height];
   }
@@ -104,13 +99,56 @@ using namespace facebook::react;
 - (void)prepareForRecycle {
   [super prepareForRecycle];
 
-  // Remove footer constraints
   [LayoutUtil unpinView:self fromParentView:self.superview];
+
+  if (@available(iOS 26.0, *)) {
+    [_edgeEffectHint removeFromSuperview];
+    _edgeEffectHint = nil;
+
+    for (id<UIInteraction> interaction in [self.interactions copy]) {
+      if ([interaction isKindOfClass:[UIScrollEdgeElementContainerInteraction class]]) {
+        [self removeInteraction:interaction];
+        break;
+      }
+    }
+  }
 
   _lastHeight = 0;
   _didInitialLayout = NO;
   _bottomConstraint = nil;
   _currentKeyboardOffset = 0;
+}
+
+#pragma mark - Scroll Edge Interaction
+
+- (void)setupEdgeInteractionWithScrollView:(UIScrollView *)scrollView API_AVAILABLE(ios(26.0)) {
+  for (id<UIInteraction> interaction in [self.interactions copy]) {
+    if ([interaction isKindOfClass:[UIScrollEdgeElementContainerInteraction class]]) {
+      [self removeInteraction:interaction];
+      break;
+    }
+  }
+
+  [_edgeEffectHint removeFromSuperview];
+  _edgeEffectHint = nil;
+
+  if (!scrollView) {
+    return;
+  }
+
+  // UIScrollEdgeElementContainerInteraction requires standard UIKit element
+  // descendants (UILabel, UIControl, etc.) to trigger the edge effect.
+  // RCTViewComponentView subviews are not recognized, so we add a
+  // non-visible UILabel as an element hint.
+  _edgeEffectHint = [[UILabel alloc] initWithFrame:self.bounds];
+  _edgeEffectHint.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  _edgeEffectHint.userInteractionEnabled = NO;
+  [self addSubview:_edgeEffectHint];
+
+  UIScrollEdgeElementContainerInteraction *interaction = [[UIScrollEdgeElementContainerInteraction alloc] init];
+  interaction.scrollView = scrollView;
+  interaction.edge = UIRectEdgeBottom;
+  [self addInteraction:interaction];
 }
 
 #pragma mark - TrueSheetKeyboardObserverDelegate

--- a/ios/TrueSheetFooterView.mm
+++ b/ios/TrueSheetFooterView.mm
@@ -15,6 +15,7 @@
 #import <react/renderer/components/TrueSheetSpec/RCTComponentViewHelpers.h>
 #import "TrueSheetViewController.h"
 #import "utils/LayoutUtil.h"
+#import "utils/UIView+ScrollEdgeInteraction.h"
 
 using namespace facebook::react;
 
@@ -23,8 +24,6 @@ using namespace facebook::react;
   BOOL _didInitialLayout;
   NSLayoutConstraint *_bottomConstraint;
   CGFloat _currentKeyboardOffset;
-
-  UILabel *_edgeEffectHint;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider {
@@ -100,7 +99,6 @@ using namespace facebook::react;
   [super prepareForRecycle];
 
   [LayoutUtil unpinView:self fromParentView:self.superview];
-
   if (@available(iOS 26.0, *)) {
     [self cleanupEdgeInteraction];
   }
@@ -109,42 +107,6 @@ using namespace facebook::react;
   _didInitialLayout = NO;
   _bottomConstraint = nil;
   _currentKeyboardOffset = 0;
-}
-
-#pragma mark - Scroll Edge Interaction
-
-- (void)cleanupEdgeInteraction API_AVAILABLE(ios(26.0)) {
-  for (id<UIInteraction> interaction in [self.interactions copy]) {
-    if ([interaction isKindOfClass:[UIScrollEdgeElementContainerInteraction class]]) {
-      [self removeInteraction:interaction];
-      break;
-    }
-  }
-
-  [_edgeEffectHint removeFromSuperview];
-  _edgeEffectHint = nil;
-}
-
-- (void)setupEdgeInteractionWithScrollView:(UIScrollView *)scrollView API_AVAILABLE(ios(26.0)) {
-  [self cleanupEdgeInteraction];
-
-  if (!scrollView) {
-    return;
-  }
-
-  // UIScrollEdgeElementContainerInteraction requires standard UIKit element
-  // descendants (UILabel, UIControl, etc.) to trigger the edge effect.
-  // RCTViewComponentView subviews are not recognized, so we add a
-  // non-visible UILabel as an element hint.
-  _edgeEffectHint = [[UILabel alloc] initWithFrame:self.bounds];
-  _edgeEffectHint.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  _edgeEffectHint.userInteractionEnabled = NO;
-  [self addSubview:_edgeEffectHint];
-
-  UIScrollEdgeElementContainerInteraction *interaction = [[UIScrollEdgeElementContainerInteraction alloc] init];
-  interaction.scrollView = scrollView;
-  interaction.edge = UIRectEdgeBottom;
-  [self addInteraction:interaction];
 }
 
 #pragma mark - TrueSheetKeyboardObserverDelegate

--- a/ios/TrueSheetHeaderView.h
+++ b/ios/TrueSheetHeaderView.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak, nullable) id<TrueSheetHeaderViewDelegate> delegate;
 
+- (void)setupEdgeInteractionWithScrollView:(UIScrollView *)scrollView API_AVAILABLE(ios(26.0));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/TrueSheetHeaderView.mm
+++ b/ios/TrueSheetHeaderView.mm
@@ -19,6 +19,7 @@ using namespace facebook::react;
 
 @implementation TrueSheetHeaderView {
   CGSize _lastSize;
+  UILabel *_edgeEffectHint;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider {
@@ -41,7 +42,6 @@ using namespace facebook::react;
 
   CGSize newSize = CGSizeMake(layoutMetrics.frame.size.width, layoutMetrics.frame.size.height);
 
-  // Notify delegate when header size changes
   if (!CGSizeEqualToSize(newSize, _lastSize)) {
     _lastSize = newSize;
     [self.delegate headerViewDidChangeSize:newSize];
@@ -51,6 +51,50 @@ using namespace facebook::react;
 - (void)prepareForRecycle {
   [super prepareForRecycle];
   _lastSize = CGSizeZero;
+
+  if (@available(iOS 26.0, *)) {
+    [_edgeEffectHint removeFromSuperview];
+    _edgeEffectHint = nil;
+
+    for (id<UIInteraction> interaction in [self.interactions copy]) {
+      if ([interaction isKindOfClass:[UIScrollEdgeElementContainerInteraction class]]) {
+        [self removeInteraction:interaction];
+        break;
+      }
+    }
+  }
+}
+
+#pragma mark - Scroll Edge Interaction
+
+- (void)setupEdgeInteractionWithScrollView:(UIScrollView *)scrollView API_AVAILABLE(ios(26.0)) {
+  for (id<UIInteraction> interaction in [self.interactions copy]) {
+    if ([interaction isKindOfClass:[UIScrollEdgeElementContainerInteraction class]]) {
+      [self removeInteraction:interaction];
+      break;
+    }
+  }
+
+  [_edgeEffectHint removeFromSuperview];
+  _edgeEffectHint = nil;
+
+  if (!scrollView) {
+    return;
+  }
+
+  // UIScrollEdgeElementContainerInteraction requires standard UIKit element
+  // descendants (UILabel, UIControl, etc.) to trigger the edge effect.
+  // RCTViewComponentView subviews are not recognized, so we add a
+  // non-visible UILabel as an element hint.
+  _edgeEffectHint = [[UILabel alloc] initWithFrame:self.bounds];
+  _edgeEffectHint.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  _edgeEffectHint.userInteractionEnabled = NO;
+  [self addSubview:_edgeEffectHint];
+
+  UIScrollEdgeElementContainerInteraction *interaction = [[UIScrollEdgeElementContainerInteraction alloc] init];
+  interaction.scrollView = scrollView;
+  interaction.edge = UIRectEdgeTop;
+  [self addInteraction:interaction];
 }
 
 @end

--- a/ios/TrueSheetHeaderView.mm
+++ b/ios/TrueSheetHeaderView.mm
@@ -14,12 +14,12 @@
 #import <react/renderer/components/TrueSheetSpec/Props.h>
 #import <react/renderer/components/TrueSheetSpec/RCTComponentViewHelpers.h>
 #import "utils/LayoutUtil.h"
+#import "utils/UIView+ScrollEdgeInteraction.h"
 
 using namespace facebook::react;
 
 @implementation TrueSheetHeaderView {
   CGSize _lastSize;
-  UILabel *_edgeEffectHint;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider {
@@ -51,46 +51,9 @@ using namespace facebook::react;
 - (void)prepareForRecycle {
   [super prepareForRecycle];
   _lastSize = CGSizeZero;
-
   if (@available(iOS 26.0, *)) {
     [self cleanupEdgeInteraction];
   }
-}
-
-#pragma mark - Scroll Edge Interaction
-
-- (void)cleanupEdgeInteraction API_AVAILABLE(ios(26.0)) {
-  for (id<UIInteraction> interaction in [self.interactions copy]) {
-    if ([interaction isKindOfClass:[UIScrollEdgeElementContainerInteraction class]]) {
-      [self removeInteraction:interaction];
-      break;
-    }
-  }
-
-  [_edgeEffectHint removeFromSuperview];
-  _edgeEffectHint = nil;
-}
-
-- (void)setupEdgeInteractionWithScrollView:(UIScrollView *)scrollView API_AVAILABLE(ios(26.0)) {
-  [self cleanupEdgeInteraction];
-
-  if (!scrollView) {
-    return;
-  }
-
-  // UIScrollEdgeElementContainerInteraction requires standard UIKit element
-  // descendants (UILabel, UIControl, etc.) to trigger the edge effect.
-  // RCTViewComponentView subviews are not recognized, so we add a
-  // non-visible UILabel as an element hint.
-  _edgeEffectHint = [[UILabel alloc] initWithFrame:self.bounds];
-  _edgeEffectHint.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  _edgeEffectHint.userInteractionEnabled = NO;
-  [self addSubview:_edgeEffectHint];
-
-  UIScrollEdgeElementContainerInteraction *interaction = [[UIScrollEdgeElementContainerInteraction alloc] init];
-  interaction.scrollView = scrollView;
-  interaction.edge = UIRectEdgeTop;
-  [self addInteraction:interaction];
 }
 
 @end

--- a/ios/TrueSheetHeaderView.mm
+++ b/ios/TrueSheetHeaderView.mm
@@ -53,21 +53,13 @@ using namespace facebook::react;
   _lastSize = CGSizeZero;
 
   if (@available(iOS 26.0, *)) {
-    [_edgeEffectHint removeFromSuperview];
-    _edgeEffectHint = nil;
-
-    for (id<UIInteraction> interaction in [self.interactions copy]) {
-      if ([interaction isKindOfClass:[UIScrollEdgeElementContainerInteraction class]]) {
-        [self removeInteraction:interaction];
-        break;
-      }
-    }
+    [self cleanupEdgeInteraction];
   }
 }
 
 #pragma mark - Scroll Edge Interaction
 
-- (void)setupEdgeInteractionWithScrollView:(UIScrollView *)scrollView API_AVAILABLE(ios(26.0)) {
+- (void)cleanupEdgeInteraction API_AVAILABLE(ios(26.0)) {
   for (id<UIInteraction> interaction in [self.interactions copy]) {
     if ([interaction isKindOfClass:[UIScrollEdgeElementContainerInteraction class]]) {
       [self removeInteraction:interaction];
@@ -77,6 +69,10 @@ using namespace facebook::react;
 
   [_edgeEffectHint removeFromSuperview];
   _edgeEffectHint = nil;
+}
+
+- (void)setupEdgeInteractionWithScrollView:(UIScrollView *)scrollView API_AVAILABLE(ios(26.0)) {
+  [self cleanupEdgeInteraction];
 
   if (!scrollView) {
     return;

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -245,12 +245,17 @@ using namespace facebook::react;
 
   const auto &scrollableOpts = newProps.scrollableOptions;
   BOOL scrollingExpandsSheet = scrollableOpts.scrollingExpandsSheet;
-  BOOL hasScrollableOptions = scrollableOpts.keyboardScrollOffset > 0 || !scrollingExpandsSheet;
+  NSInteger topEdgeEffect = (NSInteger)scrollableOpts.topScrollEdgeEffect;
+  NSInteger bottomEdgeEffect = (NSInteger)scrollableOpts.bottomScrollEdgeEffect;
+  BOOL hasScrollableOptions =
+    scrollableOpts.keyboardScrollOffset > 0 || !scrollingExpandsSheet || topEdgeEffect != 0 || bottomEdgeEffect != 0;
 
   if (hasScrollableOptions) {
     ScrollableOptions *options = [[ScrollableOptions alloc] init];
     options.keyboardScrollOffset = scrollableOpts.keyboardScrollOffset;
     options.scrollingExpandsSheet = scrollingExpandsSheet;
+    options.topScrollEdgeEffect = topEdgeEffect;
+    options.bottomScrollEdgeEffect = bottomEdgeEffect;
     _scrollableOptions = options;
   } else {
     _scrollableOptions = nil;

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -248,7 +248,9 @@ using namespace facebook::react;
   NSInteger topEdgeEffect = (NSInteger)scrollableOpts.topScrollEdgeEffect;
   NSInteger bottomEdgeEffect = (NSInteger)scrollableOpts.bottomScrollEdgeEffect;
   BOOL hasScrollableOptions =
-    scrollableOpts.keyboardScrollOffset > 0 || !scrollingExpandsSheet || topEdgeEffect != 0 || bottomEdgeEffect != 0;
+    scrollableOpts.keyboardScrollOffset > 0 || !scrollingExpandsSheet ||
+    topEdgeEffect != (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden ||
+    bottomEdgeEffect != (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
 
   if (hasScrollableOptions) {
     ScrollableOptions *options = [[ScrollableOptions alloc] init];

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -247,10 +247,9 @@ using namespace facebook::react;
   BOOL scrollingExpandsSheet = scrollableOpts.scrollingExpandsSheet;
   NSInteger topEdgeEffect = (NSInteger)scrollableOpts.topScrollEdgeEffect;
   NSInteger bottomEdgeEffect = (NSInteger)scrollableOpts.bottomScrollEdgeEffect;
-  BOOL hasScrollableOptions =
-    scrollableOpts.keyboardScrollOffset > 0 || !scrollingExpandsSheet ||
-    topEdgeEffect != (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden ||
-    bottomEdgeEffect != (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
+  BOOL hasScrollableOptions = scrollableOpts.keyboardScrollOffset > 0 || !scrollingExpandsSheet ||
+                              topEdgeEffect != (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden ||
+                              bottomEdgeEffect != (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
 
   if (hasScrollableOptions) {
     ScrollableOptions *options = [[ScrollableOptions alloc] init];

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -234,7 +234,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
       [self.delegate viewControllerDidPresentAtIndex:index position:self.currentPosition detent:detent];
       [self.delegate viewControllerDidFocus];
 
-      [_grabberView updateAccessibilityValueWithIndex:index detentCount:_detents.count];
+      [self->_grabberView updateAccessibilityValueWithIndex:index detentCount:self->_detents.count];
       [self emitChangePositionDelegateWithPosition:self.currentPosition realtime:NO debug:@"did present"];
     });
 

--- a/ios/utils/UIView+ScrollEdgeInteraction.h
+++ b/ios/utils/UIView+ScrollEdgeInteraction.h
@@ -8,19 +8,15 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
-#import <React/RCTViewComponentView.h>
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol TrueSheetHeaderViewDelegate <NSObject>
-@optional
-- (void)headerViewDidChangeSize:(CGSize)size;
-@end
+@interface UIView (ScrollEdgeInteraction)
 
-@interface TrueSheetHeaderView : RCTViewComponentView
-
-@property (nonatomic, weak, nullable) id<TrueSheetHeaderViewDelegate> delegate;
+- (void)setupEdgeInteractionWithScrollView:(nullable UIScrollView *)scrollView
+                                      edge:(UIRectEdge)edge API_AVAILABLE(ios(26.0));
+- (void)cleanupEdgeInteraction API_AVAILABLE(ios(26.0));
 
 @end
 

--- a/ios/utils/UIView+ScrollEdgeInteraction.mm
+++ b/ios/utils/UIView+ScrollEdgeInteraction.mm
@@ -8,8 +8,8 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
-#import "UIView+ScrollEdgeInteraction.h"
 #import <objc/runtime.h>
+#import "UIView+ScrollEdgeInteraction.h"
 
 static const void *kEdgeEffectHintKey = &kEdgeEffectHintKey;
 

--- a/ios/utils/UIView+ScrollEdgeInteraction.mm
+++ b/ios/utils/UIView+ScrollEdgeInteraction.mm
@@ -1,0 +1,57 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import "UIView+ScrollEdgeInteraction.h"
+#import <objc/runtime.h>
+
+static const void *kEdgeEffectHintKey = &kEdgeEffectHintKey;
+
+@implementation UIView (ScrollEdgeInteraction)
+
+- (void)cleanupEdgeInteraction API_AVAILABLE(ios(26.0)) {
+  for (id<UIInteraction> interaction in [self.interactions copy]) {
+    if ([interaction isKindOfClass:[UIScrollEdgeElementContainerInteraction class]]) {
+      [self removeInteraction:interaction];
+      break;
+    }
+  }
+
+  UILabel *hint = objc_getAssociatedObject(self, kEdgeEffectHintKey);
+  [hint removeFromSuperview];
+  objc_setAssociatedObject(self, kEdgeEffectHintKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (void)setupEdgeInteractionWithScrollView:(nullable UIScrollView *)scrollView
+                                      edge:(UIRectEdge)edge API_AVAILABLE(ios(26.0)) {
+  [self cleanupEdgeInteraction];
+
+  if (!scrollView) {
+    return;
+  }
+
+  // UIScrollEdgeElementContainerInteraction requires standard UIKit element
+  // descendants (UILabel, UIControl, etc.) to trigger the edge effect.
+  // RCTViewComponentView subviews are not recognized, so we add a
+  // non-visible UILabel as an element hint.
+  UILabel *hint = [[UILabel alloc] initWithFrame:self.bounds];
+  hint.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  hint.userInteractionEnabled = NO;
+  [self addSubview:hint];
+  objc_setAssociatedObject(self, kEdgeEffectHintKey, hint, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+  UIScrollEdgeElementContainerInteraction *interaction = [[UIScrollEdgeElementContainerInteraction alloc] init];
+  interaction.scrollView = scrollView;
+  interaction.edge = edge;
+  [self addInteraction:interaction];
+}
+
+@end
+
+#endif

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -119,7 +119,7 @@ export interface ScrollableOptions {
    * The scroll edge effect applied to the top edge of the scroll view.
    *
    * @platform ios 26+
-   * @default 'automatic'
+   * @default 'hidden'
    */
   topScrollEdgeEffect?: ScrollEdgeEffect;
 
@@ -127,7 +127,7 @@ export interface ScrollableOptions {
    * The scroll edge effect applied to the bottom edge of the scroll view.
    *
    * @platform ios 26+
-   * @default 'automatic'
+   * @default 'hidden'
    */
   bottomScrollEdgeEffect?: ScrollEdgeEffect;
 }

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -89,6 +89,14 @@ export interface GrabberOptions {
 }
 
 /**
+ * Scroll edge effect style for iOS 26+.
+ * Controls the blur/gradient overlay applied to scroll view edges.
+ *
+ * @platform ios 26+
+ */
+export type ScrollEdgeEffect = 'automatic' | 'hard' | 'soft' | 'hidden';
+
+/**
  * Options for scrollable behavior.
  */
 export interface ScrollableOptions {
@@ -106,6 +114,22 @@ export interface ScrollableOptions {
    * @default true
    */
   scrollingExpandsSheet?: boolean;
+
+  /**
+   * The scroll edge effect applied to the top edge of the scroll view.
+   *
+   * @platform ios 26+
+   * @default 'automatic'
+   */
+  topScrollEdgeEffect?: ScrollEdgeEffect;
+
+  /**
+   * The scroll edge effect applied to the bottom edge of the scroll view.
+   *
+   * @platform ios 26+
+   * @default 'automatic'
+   */
+  bottomScrollEdgeEffect?: ScrollEdgeEffect;
 }
 
 /**

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -26,8 +26,8 @@ type ScrollEdgeEffect = 'automatic' | 'hard' | 'soft' | 'hidden';
 type ScrollableOptionsType = Readonly<{
   keyboardScrollOffset?: WithDefault<Double, 0>;
   scrollingExpandsSheet?: WithDefault<boolean, true>;
-  topScrollEdgeEffect?: WithDefault<ScrollEdgeEffect, 'automatic'>;
-  bottomScrollEdgeEffect?: WithDefault<ScrollEdgeEffect, 'automatic'>;
+  topScrollEdgeEffect?: WithDefault<ScrollEdgeEffect, 'hidden'>;
+  bottomScrollEdgeEffect?: WithDefault<ScrollEdgeEffect, 'hidden'>;
 }>;
 
 export interface DetentInfoEventPayload {

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -21,9 +21,13 @@ type BlurOptionsType = Readonly<{
   interaction?: WithDefault<boolean, true>;
 }>;
 
+type ScrollEdgeEffect = 'automatic' | 'hard' | 'soft' | 'hidden';
+
 type ScrollableOptionsType = Readonly<{
   keyboardScrollOffset?: WithDefault<Double, 0>;
   scrollingExpandsSheet?: WithDefault<boolean, true>;
+  topScrollEdgeEffect?: WithDefault<ScrollEdgeEffect, 'automatic'>;
+  bottomScrollEdgeEffect?: WithDefault<ScrollEdgeEffect, 'automatic'>;
 }>;
 
 export interface DetentInfoEventPayload {


### PR DESCRIPTION
## Summary

- Add `topScrollEdgeEffect` and `bottomScrollEdgeEffect` options to `scrollableOptions`
- Controls `UIScrollEdgeEffect` style (`automatic`, `hard`, `soft`, `hidden`) on scrollable sheet content
- Gated with compile-time (`RNTS_IPHONE_OS_VERSION_AVAILABLE`) and runtime (`@available`) checks
- No-op on iOS < 26

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Present a scrollable sheet with `scrollableOptions={{ topScrollEdgeEffect: 'soft' }}`
- Verify blur/gradient effect at top edge when scrolling on iOS 26+
- Test `'hidden'` disables the effect
- Verify no-op on iOS < 26

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)