### PR TITLE
fix(android): use ViewCompat.setStateDescription for API < 30 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 🐛 Bug fixes
 
+- **Android**: Fixed `NoSuchMethodError` crash on Android < 11 (API 30) when presenting a sheet with grabber accessibility. ([#606](https://github.com/lodev09/react-native-true-sheet/pull/606) by [@Mohamed-kassim](https://github.com/Mohamed-kassim))
 - **iOS**: Fixed keyboard scroll positioning when sheet auto-expands from a smaller detent. ([#592](https://github.com/lodev09/react-native-true-sheet/pull/592) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed dead state after rapid present/dismiss cycles. ([#593](https://github.com/lodev09/react-native-true-sheet/pull/593) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fixed position change not emitting when detent or index changed. ([#584](https://github.com/lodev09/react-native-true-sheet/pull/584) by [@lodev09](https://github.com/lodev09))

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetGrabberView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetGrabberView.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.FrameLayout
 import androidx.core.graphics.ColorUtils
+import androidx.core.view.ViewCompat
 import com.facebook.react.uimanager.PixelUtil.dpToPx
 
 /**
@@ -131,12 +132,13 @@ class TrueSheetGrabberView(context: Context, private val options: GrabberOptions
   }
 
   fun updateAccessibilityValue(index: Int, detentCount: Int) {
-    stateDescription = when {
+    val description: CharSequence? = when {
       index < 0 || detentCount <= 0 -> null
       index >= detentCount - 1 -> "Expanded"
       index == 0 -> "Collapsed"
       else -> "Detent ${index + 1} of $detentCount"
     }
+    ViewCompat.setStateDescription(this, description)
   }
 
   private fun getAdaptiveColor(baseColor: Int? = null): Int {


### PR DESCRIPTION
## Problem

`TrueSheetGrabberView.updateAccessibilityValue()` calls `View.stateDescription` directly, which was added in **API 30 (Android 11)**. On Android 10 and below, this causes a fatal `NoSuchMethodError` crash on every sheet present:

```
NoSuchMethodError: No virtual method setStateDescription(Ljava/lang/CharSequence;)V
in class Lcom/lodev09/truesheet/core/TrueSheetGrabberView;
```

Introduced in #587 (v3.10.0-beta.0), still present in v3.10.0-beta.2.

## Fix

Replace the direct `stateDescription = ...` assignment with `ViewCompat.setStateDescription(this, description)`, which handles the API check internally (no-op on API < 30, delegates to the platform method on API 30+).

## Impact

In our production app (Tarteel, ~1M users), this caused **100+ affected users and 389+ crash events within 1 hours** of shipping a release with v3.10.0-beta.1.