### PR TITLE
refactor(ios): use codegen enum types instead of NSInteger casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 💡 Others
 
+- **iOS**: Use codegen enum types instead of `NSInteger` casts for better type safety. ([#612](https://github.com/lodev09/react-native-true-sheet/pull/612) by [@lodev09](https://github.com/lodev09))
 - Add docs versioning with automated release script. ([#586](https://github.com/lodev09/react-native-true-sheet/pull/586) by [@lodev09](https://github.com/lodev09))
 
 ### ⚠️ Breaking

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# React Native True Sheet
+# React Native TrueSheet
 
 [![CI](https://github.com/lodev09/react-native-true-sheet/actions/workflows/checks.yml/badge.svg)](https://github.com/lodev09/react-native-true-sheet/actions/workflows/checks.yml)
 [![NPM Downloads](https://img.shields.io/npm/d18m/%40lodev09%2Freact-native-true-sheet)](https://www.npmjs.com/package/@lodev09/react-native-true-sheet)

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -10,6 +10,7 @@
 
 #import <React/RCTViewComponentView.h>
 #import <UIKit/UIKit.h>
+#import <react/renderer/components/TrueSheetSpec/Props.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,8 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) CGFloat keyboardScrollOffset;
 @property (nonatomic, assign) BOOL scrollingExpandsSheet;
-@property (nonatomic, assign) NSInteger topScrollEdgeEffect;
-@property (nonatomic, assign) NSInteger bottomScrollEdgeEffect;
+@property (nonatomic, assign) facebook::react::TrueSheetViewTopScrollEdgeEffect topScrollEdgeEffect;
+@property (nonatomic, assign) facebook::react::TrueSheetViewBottomScrollEdgeEffect bottomScrollEdgeEffect;
 
 @end
 
@@ -48,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Inset adjustment mode for scrollable content
  */
-@property (nonatomic, assign) NSInteger insetAdjustment;
+@property (nonatomic, assign) facebook::react::TrueSheetViewInsetAdjustment insetAdjustment;
 
 /**
  * Options for scrollable behavior

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -35,8 +35,8 @@ using namespace facebook::react;
   if (self = [super init]) {
     _keyboardScrollOffset = 0;
     _scrollingExpandsSheet = YES;
-    _topScrollEdgeEffect = (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
-    _bottomScrollEdgeEffect = (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
+    _topScrollEdgeEffect = TrueSheetViewTopScrollEdgeEffect::Hidden;
+    _bottomScrollEdgeEffect = TrueSheetViewBottomScrollEdgeEffect::Hidden;
   }
   return self;
 }
@@ -113,7 +113,7 @@ using namespace facebook::react;
 - (void)setupScrollable {
   if (_scrollableSet && _contentView) {
     CGFloat bottomInset = 0;
-    if (_insetAdjustment == (NSInteger)TrueSheetViewInsetAdjustment::Automatic) {
+    if (_insetAdjustment == TrueSheetViewInsetAdjustment::Automatic) {
       bottomInset = [WindowUtil keyWindow].safeAreaInsets.bottom;
     }
     [_contentView setupScrollable:_scrollableEnabled bottomInset:bottomInset];
@@ -129,13 +129,13 @@ using namespace facebook::react;
     return;
   }
 
-  NSInteger topEffect =
-    _scrollableOptions ? _scrollableOptions.topScrollEdgeEffect : (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
-  NSInteger bottomEffect = _scrollableOptions ? _scrollableOptions.bottomScrollEdgeEffect
-                                              : (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
+  auto topEffect =
+    _scrollableOptions ? _scrollableOptions.topScrollEdgeEffect : TrueSheetViewTopScrollEdgeEffect::Hidden;
+  auto bottomEffect = _scrollableOptions ? _scrollableOptions.bottomScrollEdgeEffect
+                                         : TrueSheetViewBottomScrollEdgeEffect::Hidden;
 
-  BOOL topHidden = topEffect == (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
-  BOOL bottomHidden = bottomEffect == (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
+  BOOL topHidden = topEffect == TrueSheetViewTopScrollEdgeEffect::Hidden;
+  BOOL bottomHidden = bottomEffect == TrueSheetViewBottomScrollEdgeEffect::Hidden;
 
   RCTScrollViewComponentView *scrollViewComponent = [_contentView findScrollView];
   UIScrollView *scrollView = scrollViewComponent.scrollView;

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -211,32 +211,34 @@ using namespace facebook::react;
 
   if (@available(iOS 26.0, *)) {
     UIScrollView *scrollView = _pinnedScrollView.scrollView;
-    NSInteger topEffect = options ? options.topScrollEdgeEffect : (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden;
-    NSInteger bottomEffect =
-      options ? options.bottomScrollEdgeEffect : (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
+    auto topEffect = options ? options.topScrollEdgeEffect : TrueSheetViewTopScrollEdgeEffect::Hidden;
+    auto bottomEffect =
+      options ? options.bottomScrollEdgeEffect : TrueSheetViewBottomScrollEdgeEffect::Hidden;
 
     [self applyEdgeEffect:topEffect toEdge:scrollView.topEdgeEffect];
-    [self applyEdgeEffect:bottomEffect toEdge:scrollView.bottomEdgeEffect];
+    [self applyEdgeEffect:(TrueSheetViewTopScrollEdgeEffect)bottomEffect
+                   toEdge:scrollView.bottomEdgeEffect];
   }
 #endif
 }
 
 #if RNTS_IPHONE_OS_VERSION_AVAILABLE(26_0)
-- (void)applyEdgeEffect:(NSInteger)effect toEdge:(UIScrollEdgeEffect *)edgeEffect API_AVAILABLE(ios(26.0)) {
+- (void)applyEdgeEffect:(TrueSheetViewTopScrollEdgeEffect)effect
+                 toEdge:(UIScrollEdgeEffect *)edgeEffect API_AVAILABLE(ios(26.0)) {
   switch (effect) {
-    case (NSInteger)TrueSheetViewTopScrollEdgeEffect::Automatic:
+    case TrueSheetViewTopScrollEdgeEffect::Automatic:
       edgeEffect.hidden = NO;
       edgeEffect.style = UIScrollEdgeEffectStyle.automaticStyle;
       break;
-    case (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hard:
+    case TrueSheetViewTopScrollEdgeEffect::Hard:
       edgeEffect.hidden = NO;
       edgeEffect.style = UIScrollEdgeEffectStyle.hardStyle;
       break;
-    case (NSInteger)TrueSheetViewTopScrollEdgeEffect::Soft:
+    case TrueSheetViewTopScrollEdgeEffect::Soft:
       edgeEffect.hidden = NO;
       edgeEffect.style = UIScrollEdgeEffectStyle.softStyle;
       break;
-    case (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden:
+    case TrueSheetViewTopScrollEdgeEffect::Hidden:
       edgeEffect.hidden = YES;
       break;
   }

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -51,7 +51,7 @@ using namespace facebook::react;
   UIView *_snapshotView;
   CGSize _lastStateSize;
   NSInteger _initialDetentIndex;
-  NSInteger _insetAdjustment;
+  TrueSheetViewInsetAdjustment _insetAdjustment;
   BOOL _scrollable;
   ScrollableOptions *_scrollableOptions;
   BOOL _initialDetentAnimated;
@@ -185,7 +185,7 @@ using namespace facebook::react;
   _controller.backgroundColor = RCTUIColorFromSharedColor(newProps.backgroundColor);
 
   // Blur tint
-  _controller.backgroundBlur = (NSInteger)newProps.backgroundBlur;
+  _controller.backgroundBlur = newProps.backgroundBlur;
 
   // Blur options
   const auto &blurOpts = newProps.blurOptions;
@@ -202,7 +202,7 @@ using namespace facebook::react;
   _controller.maxContentWidth = newProps.maxContentWidth != 0.0 ? @(newProps.maxContentWidth) : nil;
 
   // Anchor
-  _controller.anchor = (NSInteger)newProps.anchor;
+  _controller.anchor = newProps.anchor;
 
   _controller.grabber = newProps.grabber;
 
@@ -245,11 +245,11 @@ using namespace facebook::react;
 
   const auto &scrollableOpts = newProps.scrollableOptions;
   BOOL scrollingExpandsSheet = scrollableOpts.scrollingExpandsSheet;
-  NSInteger topEdgeEffect = (NSInteger)scrollableOpts.topScrollEdgeEffect;
-  NSInteger bottomEdgeEffect = (NSInteger)scrollableOpts.bottomScrollEdgeEffect;
+  auto topEdgeEffect = scrollableOpts.topScrollEdgeEffect;
+  auto bottomEdgeEffect = scrollableOpts.bottomScrollEdgeEffect;
   BOOL hasScrollableOptions = scrollableOpts.keyboardScrollOffset > 0 || !scrollingExpandsSheet ||
-                              topEdgeEffect != (NSInteger)TrueSheetViewTopScrollEdgeEffect::Hidden ||
-                              bottomEdgeEffect != (NSInteger)TrueSheetViewBottomScrollEdgeEffect::Hidden;
+                              topEdgeEffect != TrueSheetViewTopScrollEdgeEffect::Hidden ||
+                              bottomEdgeEffect != TrueSheetViewBottomScrollEdgeEffect::Hidden;
 
   if (hasScrollableOptions) {
     ScrollableOptions *options = [[ScrollableOptions alloc] init];
@@ -264,7 +264,7 @@ using namespace facebook::react;
 
   _controller.scrollingExpandsSheet = scrollingExpandsSheet;
 
-  _insetAdjustment = (NSInteger)newProps.insetAdjustment;
+  _insetAdjustment = newProps.insetAdjustment;
   _controller.insetAdjustment = _insetAdjustment;
 
   [self setupScrollable];

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <react/renderer/components/TrueSheetSpec/Props.h>
 #import "core/TrueSheetDetentCalculator.h"
 #import "core/TrueSheetGrabberView.h"
 
@@ -63,12 +64,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL draggable;
 @property (nonatomic, assign) BOOL dimmed;
 @property (nonatomic, strong, nullable) NSNumber *dimmedDetentIndex;
-@property (nonatomic, assign) NSInteger backgroundBlur;
+@property (nonatomic, assign) facebook::react::TrueSheetViewBackgroundBlur backgroundBlur;
 @property (nonatomic, strong, nullable) NSNumber *blurIntensity;
 @property (nonatomic, assign) BOOL blurInteraction;
 @property (nonatomic, assign) BOOL pageSizing;
-@property (nonatomic, assign) NSInteger anchor;
-@property (nonatomic, assign) NSInteger insetAdjustment;
+@property (nonatomic, assign) facebook::react::TrueSheetViewAnchor anchor;
+@property (nonatomic, assign) facebook::react::TrueSheetViewInsetAdjustment insetAdjustment;
 @property (nonatomic, assign) BOOL scrollingExpandsSheet;
 @property (nonatomic, assign) BOOL dismissible;
 @property (nonatomic, assign) BOOL isPresented;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -87,7 +87,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
     _isTrackingPositionFromLayout = NO;
 
     _blurInteraction = YES;
-    _insetAdjustment = (NSInteger)TrueSheetViewInsetAdjustment::Automatic;
+    _insetAdjustment = TrueSheetViewInsetAdjustment::Automatic;
     _detentCalculator = [[TrueSheetDetentCalculator alloc] init];
     _detentCalculator.delegate = self;
   }
@@ -128,7 +128,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
 }
 
 - (CGFloat)detentBottomAdjustmentForHeight:(CGFloat)height {
-  if (_insetAdjustment == (NSInteger)TrueSheetViewInsetAdjustment::Automatic) {
+  if (_insetAdjustment == TrueSheetViewInsetAdjustment::Automatic) {
     return 0;
   }
 
@@ -717,16 +717,16 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
 }
 
 - (void)setupBackground {
-  NSInteger effectiveBackgroundBlur = self.backgroundBlur;
+  auto effectiveBackgroundBlur = self.backgroundBlur;
   if (@available(iOS 26.0, *)) {
     // iOS 26+ has default liquid glass effect
-  } else if (effectiveBackgroundBlur == (NSInteger)TrueSheetViewBackgroundBlur::None && !self.backgroundColor) {
-    effectiveBackgroundBlur = (NSInteger)TrueSheetViewBackgroundBlur::SystemMaterial;
+  } else if (effectiveBackgroundBlur == TrueSheetViewBackgroundBlur::None && !self.backgroundColor) {
+    effectiveBackgroundBlur = TrueSheetViewBackgroundBlur::SystemMaterial;
   }
 
-  BOOL hasBlur = effectiveBackgroundBlur != (NSInteger)TrueSheetViewBackgroundBlur::None;
+  BOOL hasBlur = effectiveBackgroundBlur != TrueSheetViewBackgroundBlur::None;
 
-  _blurView.backgroundBlur = hasBlur ? effectiveBackgroundBlur : (NSInteger)TrueSheetViewBackgroundBlur::None;
+  _blurView.backgroundBlur = hasBlur ? effectiveBackgroundBlur : TrueSheetViewBackgroundBlur::None;
   _blurView.blurIntensity = self.blurIntensity;
   _blurView.blurInteraction = self.blurInteraction;
   [_blurView applyBlurEffect];
@@ -825,7 +825,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
 }
 
 - (BOOL)isAnchored {
-  return self.anchor == (NSInteger)TrueSheetViewAnchor::Left || self.anchor == (NSInteger)TrueSheetViewAnchor::Right;
+  return self.anchor == TrueSheetViewAnchor::Left || self.anchor == TrueSheetViewAnchor::Right;
 }
 
 - (void)setupAnchorViewInView:(UIView *)parentView {
@@ -846,7 +846,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
   [parentView addSubview:_anchorView];
 
   NSLayoutAnchor *horizontalAnchor =
-    self.anchor == (NSInteger)TrueSheetViewAnchor::Right ? parentView.trailingAnchor : parentView.leadingAnchor;
+    self.anchor == TrueSheetViewAnchor::Right ? parentView.trailingAnchor : parentView.leadingAnchor;
 
   [NSLayoutConstraint activateConstraints:@[
     [_anchorView.bottomAnchor constraintEqualToAnchor:parentView.bottomAnchor],

--- a/ios/core/TrueSheetBlurView.h
+++ b/ios/core/TrueSheetBlurView.h
@@ -7,12 +7,13 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <react/renderer/components/TrueSheetSpec/Props.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface TrueSheetBlurView : UIVisualEffectView
 
-@property (nonatomic, assign) NSInteger backgroundBlur;
+@property (nonatomic, assign) facebook::react::TrueSheetViewBackgroundBlur backgroundBlur;
 @property (nonatomic, strong, nullable) NSNumber *blurIntensity;
 @property (nonatomic, assign) BOOL blurInteraction;
 

--- a/ios/core/TrueSheetBlurView.mm
+++ b/ios/core/TrueSheetBlurView.mm
@@ -48,7 +48,7 @@ using namespace facebook::react;
 - (void)applyBlurEffect {
   self.userInteractionEnabled = self.blurInteraction;
 
-  if (self.backgroundBlur == (NSInteger)TrueSheetViewBackgroundBlur::None) {
+  if (self.backgroundBlur == TrueSheetViewBackgroundBlur::None) {
     [self clearAnimator];
     self.effect = nil;
     return;

--- a/ios/utils/BlurUtil.h
+++ b/ios/utils/BlurUtil.h
@@ -9,12 +9,13 @@
 #ifdef RCT_NEW_ARCH_ENABLED
 
 #import <UIKit/UIKit.h>
+#import <react/renderer/components/TrueSheetSpec/Props.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BlurUtil : NSObject
 
-+ (UIBlurEffectStyle)blurEffectStyleFromEnum:(NSInteger)blur;
++ (UIBlurEffectStyle)blurEffectStyleFromEnum:(facebook::react::TrueSheetViewBackgroundBlur)blur;
 
 @end
 

--- a/ios/utils/BlurUtil.mm
+++ b/ios/utils/BlurUtil.mm
@@ -16,8 +16,8 @@ using namespace facebook::react;
 
 @implementation BlurUtil
 
-+ (UIBlurEffectStyle)blurEffectStyleFromEnum:(NSInteger)blur {
-  switch ((TrueSheetViewBackgroundBlur)blur) {
++ (UIBlurEffectStyle)blurEffectStyleFromEnum:(TrueSheetViewBackgroundBlur)blur {
+  switch (blur) {
     case TrueSheetViewBackgroundBlur::Dark:
       return UIBlurEffectStyleDark;
     case TrueSheetViewBackgroundBlur::ExtraLight:


### PR DESCRIPTION
## Summary

- Replace `NSInteger` properties and casts with codegen C++ enum types (`TrueSheetViewBackgroundBlur`, `TrueSheetViewAnchor`, `TrueSheetViewInsetAdjustment`, etc.) across iOS native code for better type safety.
- Fix README branding: "True Sheet" → "TrueSheet".

## Type of Change

- [x] Documentation update

## Test Plan

- Build iOS and verify sheet presentation, blur, anchor, scroll edge effects all work as before.

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)