### PR TITLE
Using dedent 'auto' does not take into account footer height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed dedent 'auto' not respecting footer height ([#620](https://github.com/lodev09/react-native-true-sheet/pull/620) by [@seanpcoyle](https://github.com/seanpcoyle))
 - **Android**: Fixed `NoSuchMethodError` crash on Android < 11 (API 30) when presenting a sheet with grabber accessibility. ([#606](https://github.com/lodev09/react-native-true-sheet/pull/606) by [@Mohamed-kassim](https://github.com/Mohamed-kassim))
 - **iOS**: Fixed keyboard scroll positioning when sheet auto-expands from a smaller detent. ([#592](https://github.com/lodev09/react-native-true-sheet/pull/592) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed dead state after rapid present/dismiss cycles. ([#593](https://github.com/lodev09/react-native-true-sheet/pull/593) by [@lodev09](https://github.com/lodev09))

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -602,8 +602,7 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
   }
 
   override fun containerViewFooterDidChangeSize(width: Int, height: Int) {
-    // Footer changes don't affect detents, only reposition it
-    viewController.positionFooter()
+    updateSheetIfNeeded()
   }
 
   // ==================== RNScreensEventObserverDelegate ====================

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -265,12 +265,16 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   // Cached values used during dismiss when container is unmounted
   private var cachedContentHeight: Int = 0
   private var cachedHeaderHeight: Int = 0
+  private var cachedFooterHeight: Int = 0
 
   override val contentHeight: Int
     get() = containerView?.contentHeight ?: cachedContentHeight
 
   override val headerHeight: Int
     get() = containerView?.headerHeight ?: cachedHeaderHeight
+
+  override val footerHeight: Int
+    get() = containerView?.footerHeight ?: cachedFooterHeight
 
   // Insets
   // Target keyboard height used for detent calculations
@@ -373,6 +377,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     wasHiddenByScreen = false
     cachedContentHeight = 0
     cachedHeaderHeight = 0
+    cachedFooterHeight = 0
     isPresentAnimating = false
     lastEmittedPositionPx = -1
     detentIndexBeforeKeyboard = -1
@@ -817,6 +822,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     containerView?.let {
       cachedContentHeight = it.contentHeight
       cachedHeaderHeight = it.headerHeight
+      cachedFooterHeight = it.footerHeight
     }
 
     interactionState = InteractionState.Reconfiguring

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
@@ -14,6 +14,7 @@ interface TrueSheetDetentCalculatorDelegate {
   val detents: MutableList<Double>
   val contentHeight: Int
   val headerHeight: Int
+  val footerHeight: Int
   val contentBottomInset: Int
   val maxContentHeight: Int?
   val keyboardInset: Int
@@ -31,6 +32,7 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
   private val detents: List<Double> get() = delegate?.detents ?: emptyList()
   private val contentHeight: Int get() = delegate?.contentHeight ?: 0
   private val headerHeight: Int get() = delegate?.headerHeight ?: 0
+  private val footerHeight: Int get() = delegate?.footerHeight ?: 0
   private val contentBottomInset: Int get() = delegate?.contentBottomInset ?: 0
   private val maxContentHeight: Int? get() = delegate?.maxContentHeight
   private val keyboardInset: Int get() = delegate?.keyboardInset ?: 0
@@ -41,7 +43,7 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
    */
   fun getDetentHeight(detent: Double, includeKeyboard: Boolean = true): Int {
     val baseHeight = if (detent == -1.0) {
-      contentHeight + headerHeight + contentBottomInset
+      contentHeight + headerHeight + footerHeight + contentBottomInset
     } else {
       if (detent <= 0.0 || detent > 1.0) {
         throw IllegalArgumentException("TrueSheet: detent fraction ($detent) must be between 0 and 1")
@@ -82,7 +84,7 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
     if (index < 0 || index >= detents.size) return 0f
     val value = detents[index]
     return if (value == -1.0) {
-      (contentHeight + headerHeight).toFloat() / screenHeight.toFloat()
+      (contentHeight + headerHeight + footerHeight).toFloat() / screenHeight.toFloat()
     } else {
       value.toFloat()
     }

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @optional
 
 - (void)containerViewHeaderDidChangeSize:(CGSize)newSize;
+- (void)containerViewFooterDidChangeSize:(CGSize)newSize;
 
 @end
 
@@ -65,6 +66,11 @@ NS_ASSUME_NONNULL_BEGIN
  * Returns the current header height
  */
 - (CGFloat)headerHeight;
+
+/**
+ * Returns the current footer height
+ */
+- (CGFloat)footerHeight;
 
 /**
  * Updates footer layout constraints if needed

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -91,6 +91,10 @@ using namespace facebook::react;
   return _headerView ? _headerView.frame.size.height : 0;
 }
 
+- (CGFloat)footerHeight {
+  return _footerView ? _footerView.frame.size.height : 0;
+}
+
 - (void)layoutFooter {
   if (_footerView) {
     CGFloat height = _footerView.frame.size.height;
@@ -179,6 +183,7 @@ using namespace facebook::react;
     }
     _footerView = (TrueSheetFooterView *)childComponentView;
     _footerView.delegate = self;
+    [self footerViewDidChangeSize:_footerView.frame.size];
   }
 }
 
@@ -195,6 +200,7 @@ using namespace facebook::react;
   }
 
   if ([childComponentView isKindOfClass:[TrueSheetFooterView class]]) {
+    [self footerViewDidChangeSize:CGSizeZero];
     _footerView.delegate = nil;
     _footerView = nil;
   }
@@ -234,6 +240,9 @@ using namespace facebook::react;
 #pragma mark - TrueSheetFooterViewDelegate
 
 - (void)footerViewDidChangeSize:(CGSize)newSize {
+  if ([self.delegate respondsToSelector:@selector(containerViewFooterDidChangeSize:)]) {
+    [self.delegate containerViewFooterDidChangeSize:newSize];
+  }
   if (@available(iOS 26.0, *)) {
     [self setupEdgeInteractions];
   }

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -384,6 +384,11 @@ using namespace facebook::react;
     _controller.headerHeight = @(headerHeight);
   }
 
+  CGFloat footerHeight = [_containerView footerHeight];
+  if (footerHeight > 0) {
+    _controller.footerHeight = @(footerHeight);
+  }
+
   if (_eventEmitter) {
     [TrueSheetLifecycleEvents emitMount:_eventEmitter];
   } else {
@@ -567,6 +572,11 @@ using namespace facebook::react;
 
 - (void)containerViewHeaderDidChangeSize:(CGSize)newSize {
   _controller.headerHeight = @(newSize.height);
+  [self setupSheetDetentsForSizeChange];
+}
+
+- (void)containerViewFooterDidChangeSize:(CGSize)newSize {
+  _controller.footerHeight = @(newSize.height);
   [self setupSheetDetentsForSizeChange];
 }
 

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -57,6 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSNumber *maxContentWidth;
 @property (nonatomic, strong, nullable) NSNumber *contentHeight;
 @property (nonatomic, strong, nullable) NSNumber *headerHeight;
+@property (nonatomic, strong, nullable) NSNumber *footerHeight;
 @property (nonatomic, strong, nullable) UIColor *backgroundColor;
 @property (nonatomic, strong, nullable) NSNumber *cornerRadius;
 @property (nonatomic, assign) BOOL grabber;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -67,6 +67,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
     _detents = @[ @0.5, @1 ];
     _contentHeight = @(0);
     _headerHeight = @(0);
+    _footerHeight = @(0);
     _grabber = YES;
     _draggable = YES;
     _scrollingExpandsSheet = YES;
@@ -561,7 +562,8 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
   NSMutableArray<UISheetPresentationControllerDetent *> *detents = [NSMutableArray array];
   [_detentCalculator clearResolvedHeights];
 
-  CGFloat autoHeight = [self.contentHeight floatValue] + [self.headerHeight floatValue];
+  CGFloat autoHeight =
+    [self.contentHeight floatValue] + [self.headerHeight floatValue] + [self.footerHeight floatValue];
 
   for (NSInteger index = 0; index < self.detents.count; index++) {
     id detent = self.detents[index];

--- a/ios/core/TrueSheetDetentCalculator.h
+++ b/ios/core/TrueSheetDetentCalculator.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSArray<NSNumber *> *detents;
 @property (nonatomic, strong, readonly, nullable) NSNumber *contentHeight;
 @property (nonatomic, strong, readonly, nullable) NSNumber *headerHeight;
+@property (nonatomic, strong, readonly, nullable) NSNumber *footerHeight;
 
 @end
 
@@ -35,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Returns the detent value (0-1 fraction) for a given index.
- For auto (-1) detents, calculates based on content + header height.
+ For auto (-1) detents, calculates based on content + header + footer height.
  */
 - (CGFloat)detentValueForIndex:(NSInteger)index;
 

--- a/ios/core/TrueSheetDetentCalculator.mm
+++ b/ios/core/TrueSheetDetentCalculator.mm
@@ -19,7 +19,8 @@
   if (index >= 0 && index < (NSInteger)detents.count) {
     CGFloat value = [detents[index] doubleValue];
     if (value == -1) {
-      CGFloat autoHeight = [self.delegate.contentHeight floatValue] + [self.delegate.headerHeight floatValue];
+      CGFloat autoHeight = [self.delegate.contentHeight floatValue] + [self.delegate.headerHeight floatValue] +
+                           [self.delegate.footerHeight floatValue];
       return autoHeight / self.delegate.screenHeight;
     }
     return value;

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -12,7 +12,13 @@ import {
   useRef,
   useState,
 } from 'react';
-import { View, StyleSheet, useColorScheme, useWindowDimensions } from 'react-native';
+import {
+  type LayoutChangeEvent,
+  View,
+  StyleSheet,
+  useColorScheme,
+  useWindowDimensions,
+} from 'react-native';
 
 import BottomSheet, {
   BottomSheetBackdrop,
@@ -155,8 +161,15 @@ const TrueSheetComponent = forwardRef<TrueSheetRefMethods, TrueSheetProps>((prop
 
   const [snapIndex, setSnapIndex] = useState(initialDetentIndex);
   const [isMounted, setIsMounted] = useState(false);
+  const [footerLayoutHeight, setFooterLayoutHeight] = useState(0);
 
   const isNonModal = stackBehavior === 'none';
+
+  const handleFooterLayout = useCallback((event: LayoutChangeEvent) => {
+    const h = event.nativeEvent.layout.height;
+
+    setFooterLayoutHeight((prev) => (prev === h ? prev : h));
+  }, []);
 
   useDerivedValue(() => {
     onPositionChange?.({
@@ -379,12 +392,15 @@ const TrueSheetComponent = forwardRef<TrueSheetRefMethods, TrueSheetProps>((prop
               style={StyleSheet.flatten([styles.footer, footerStyle])}
               {...footerProps}
             >
-              {renderSlot(footer)}
+              <View onLayout={handleFooterLayout}>{renderSlot(footer)}</View>
             </BottomSheetFooter>
           )
         : undefined,
-    [footer, footerStyle]
+    [footer, footerStyle, handleFooterLayout]
   );
+
+  const autoFooterInset =
+    hasAutoDetent && footer && footerLayoutHeight > 0 ? footerLayoutHeight : 0;
 
   // For scrollable, we render the child directly
   const ContainerComponent = scrollable ? Fragment : BottomSheetView;
@@ -457,7 +473,19 @@ const TrueSheetComponent = forwardRef<TrueSheetRefMethods, TrueSheetProps>((prop
   const sheetContent = (
     <ContainerComponent>
       {header && <View style={headerStyle}>{renderSlot(header)}</View>}
-      {scrollable ? children : <View style={style}>{children}</View>}
+      {scrollable ? (
+        autoFooterInset > 0 ? (
+          <View style={[styles.autoFooterInset, { paddingBottom: autoFooterInset }]}>
+            {children}
+          </View>
+        ) : (
+          children
+        )
+      ) : (
+        <View style={[style, autoFooterInset > 0 && { paddingBottom: autoFooterInset }]}>
+          {children}
+        </View>
+      )}
     </ContainerComponent>
   );
 
@@ -567,5 +595,9 @@ const styles = StyleSheet.create({
   },
   footer: {
     pointerEvents: 'box-none',
+  },
+  autoFooterInset: {
+    flexGrow: 1,
+    minHeight: 0,
   },
 });


### PR DESCRIPTION
## Summary

When using a dedent of 'auto', the header's height is taken into account but the footer's height is not. This pull request makes it such that the footer height is also accounted for.

The attached screenshots were captured using the basic sheet with an obnoxiously red footer. The most important part of this is to use a significantly tall footer to reproduce the issue.

The 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Tested by opening iOS, Android, and web basic sheets both before and after.

## Screenshots / Videos
### Before
<img width="301.5" height="655.5" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-29 at 21 02 32" src="https://github.com/user-attachments/assets/a7b2339e-4331-4795-9216-40046b961681" />

### After (iOS)
<img width="301.5" height="655.5" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-29 at 21 07 06" src="https://github.com/user-attachments/assets/c404f33f-2deb-4d43-942e-783f7fcc352a" />

### After (Web)
<img width="354" height="372.5" alt="image" src="https://github.com/user-attachments/assets/59314e20-3794-4a5b-be8a-0de9c2159c6a" />


## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)
