### PR TITLE
fix(ios): patch RN 0.83 keyboard animation regression

### DIFF
--- a/.yarn/patches/react-native-npm-0.83.4.patch
+++ b/.yarn/patches/react-native-npm-0.83.4.patch
@@ -1,0 +1,12 @@
+diff --git a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
++++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+@@ -1614,7 +1614,7 @@
+
+ - (BOOL)canBecomeFirstResponder
+ {
+-  return YES;
++  return ReactNativeFeatureFlags::enableImperativeFocus();
+ }
+
+ - (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ### 🐛 Bug fixes
 
-- **iOS**: Patched RN 0.83 keyboard animation regression where sheet snaps without animation on keyboard dismiss. ([#632](https://github.com/lodev09/react-native-true-sheet/pull/632) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed `NoSuchMethodError` crash on Android < 11 (API 30) when presenting a sheet with grabber accessibility. ([#606](https://github.com/lodev09/react-native-true-sheet/pull/606) by [@Mohamed-kassim](https://github.com/Mohamed-kassim))
 - **iOS**: Fixed keyboard scroll positioning when sheet auto-expands from a smaller detent. ([#592](https://github.com/lodev09/react-native-true-sheet/pull/592) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed dead state after rapid present/dismiss cycles. ([#593](https://github.com/lodev09/react-native-true-sheet/pull/593) by [@lodev09](https://github.com/lodev09))
@@ -24,6 +23,7 @@
 - Add missing `layout` and `screenLayout` props to `TrueSheetNavigator`. ([#615](https://github.com/lodev09/react-native-true-sheet/pull/615) by [@bram-dc](https://github.com/bram-dc))
 - Add `truesheet-usage` AI skill and documentation for AI coding agents. ([#621](https://github.com/lodev09/react-native-true-sheet/pull/621) by [@mehradotdev](https://github.com/mehradotdev))
 - Upgrade example to Expo SDK 55 and RN 0.83. ([#630](https://github.com/lodev09/react-native-true-sheet/pull/630) by [@lodev09](https://github.com/lodev09))
+- Add RN 0.83 keyboard animation workaround to troubleshooting docs. ([#632](https://github.com/lodev09/react-native-true-sheet/pull/632) by [@lodev09](https://github.com/lodev09))
 
 ### ⚠️ Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Patched RN 0.83 keyboard animation regression where sheet snaps without animation on keyboard dismiss. ([#632](https://github.com/lodev09/react-native-true-sheet/pull/632) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed `NoSuchMethodError` crash on Android < 11 (API 30) when presenting a sheet with grabber accessibility. ([#606](https://github.com/lodev09/react-native-true-sheet/pull/606) by [@Mohamed-kassim](https://github.com/Mohamed-kassim))
 - **iOS**: Fixed keyboard scroll positioning when sheet auto-expands from a smaller detent. ([#592](https://github.com/lodev09/react-native-true-sheet/pull/592) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed dead state after rapid present/dismiss cycles. ([#593](https://github.com/lodev09/react-native-true-sheet/pull/593) by [@lodev09](https://github.com/lodev09))

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -28,6 +28,24 @@ const closeModal = async () => {
 A fix has been submitted to React Native. See [PR #55005](https://github.com/facebook/react-native/pull/55005).
 :::
 
+## Sheet Snaps Without Animation on Keyboard Dismiss (iOS)
+
+On React Native 0.83+, the sheet snaps back to its detent without animation when the keyboard is dismissed. This is caused by an upstream change in RN 0.83 where `canBecomeFirstResponder` returns `YES` on every `RCTViewComponentView`, disrupting `UISheetPresentationController`'s keyboard avoidance animation.
+
+**Workaround:**
+
+Apply a [patch](https://github.com/lodev09/react-native-true-sheet/blob/main/.yarn/patches/react-native-npm-0.83.4.patch) to `react-native` that gates `canBecomeFirstResponder` behind the `enableImperativeFocus` feature flag. For Yarn, add to your `package.json`:
+
+```json
+"resolutions": {
+  "react-native": "patch:react-native@npm%3A0.83.4#./.yarn/patches/react-native-npm-0.83.4.patch"
+}
+```
+
+:::info
+A fix has been submitted to React Native. See [PR #55908](https://github.com/facebook/react-native/pull/55908).
+:::
+
 ## Gesture Handler Not Working on Android
 
 If you're using `react-native-gesture-handler` inside the sheet and gestures are not working on Android, you need to wrap your sheet content with `GestureHandlerRootView`.

--- a/example/bare/package.json
+++ b/example/bare/package.json
@@ -17,7 +17,7 @@
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.10",
     "react": "19.2.0",
-    "react-native": "0.83.4",
+    "react-native": "patch:react-native@npm%3A0.83.4#~/.yarn/patches/react-native-npm-0.83.4.patch",
     "react-native-config": "^1.6.1",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-reanimated": "4.2.1",

--- a/example/expo/package.json
+++ b/example/expo/package.json
@@ -28,7 +28,7 @@
     "expo-web-browser": "~55.0.10",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.4",
+    "react-native": "patch:react-native@npm%3A0.83.4#~/.yarn/patches/react-native-npm-0.83.4.patch",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,7 +3606,7 @@ __metadata:
     "@react-navigation/native-stack": "npm:^7.14.10"
     "@types/react": "npm:~19.2.10"
     react: "npm:19.2.0"
-    react-native: "npm:0.83.4"
+    react-native: "patch:react-native@npm%3A0.83.4#~/.yarn/patches/react-native-npm-0.83.4.patch"
     react-native-builder-bob: "npm:^0.40.15"
     react-native-config: "npm:^1.6.1"
     react-native-gesture-handler: "npm:~2.30.0"
@@ -3639,7 +3639,7 @@ __metadata:
     expo-web-browser: "npm:~55.0.10"
     react: "npm:19.2.0"
     react-dom: "npm:19.2.0"
-    react-native: "npm:0.83.4"
+    react-native: "patch:react-native@npm%3A0.83.4#~/.yarn/patches/react-native-npm-0.83.4.patch"
     react-native-gesture-handler: "npm:~2.30.0"
     react-native-monorepo-config: "npm:^0.1.9"
     react-native-reanimated: "npm:4.2.1"
@@ -20053,6 +20053,57 @@ __metadata:
   bin:
     react-native: cli.js
   checksum: 10c0/4aad713b61ba7b3d1c5147f7330b338b976d0b234050b5aa7d6898611f7ad72ed291cfd1e1499953d0fa346f71c8843b608c5334c38debcda9c16632e6e6bfdc
+  languageName: node
+  linkType: hard
+
+"react-native@patch:react-native@npm%3A0.83.4#~/.yarn/patches/react-native-npm-0.83.4.patch":
+  version: 0.83.4
+  resolution: "react-native@patch:react-native@npm%3A0.83.4#~/.yarn/patches/react-native-npm-0.83.4.patch::version=0.83.4&hash=ee298a"
+  dependencies:
+    "@jest/create-cache-key-function": "npm:^29.7.0"
+    "@react-native/assets-registry": "npm:0.83.4"
+    "@react-native/codegen": "npm:0.83.4"
+    "@react-native/community-cli-plugin": "npm:0.83.4"
+    "@react-native/gradle-plugin": "npm:0.83.4"
+    "@react-native/js-polyfills": "npm:0.83.4"
+    "@react-native/normalize-colors": "npm:0.83.4"
+    "@react-native/virtualized-lists": "npm:0.83.4"
+    abort-controller: "npm:^3.0.0"
+    anser: "npm:^1.4.9"
+    ansi-regex: "npm:^5.0.0"
+    babel-jest: "npm:^29.7.0"
+    babel-plugin-syntax-hermes-parser: "npm:0.32.0"
+    base64-js: "npm:^1.5.1"
+    commander: "npm:^12.0.0"
+    flow-enums-runtime: "npm:^0.0.6"
+    glob: "npm:^7.1.1"
+    hermes-compiler: "npm:0.14.1"
+    invariant: "npm:^2.2.4"
+    jest-environment-node: "npm:^29.7.0"
+    memoize-one: "npm:^5.0.0"
+    metro-runtime: "npm:^0.83.3"
+    metro-source-map: "npm:^0.83.3"
+    nullthrows: "npm:^1.1.1"
+    pretty-format: "npm:^29.7.0"
+    promise: "npm:^8.3.0"
+    react-devtools-core: "npm:^6.1.5"
+    react-refresh: "npm:^0.14.0"
+    regenerator-runtime: "npm:^0.13.2"
+    scheduler: "npm:0.27.0"
+    semver: "npm:^7.1.3"
+    stacktrace-parser: "npm:^0.1.10"
+    whatwg-fetch: "npm:^3.0.0"
+    ws: "npm:^7.5.10"
+    yargs: "npm:^17.6.2"
+  peerDependencies:
+    "@types/react": ^19.1.1
+    react: ^19.2.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  bin:
+    react-native: cli.js
+  checksum: 10c0/215e2be3398b88ee5efd37e759a3739f72bb0d7705e2563b34f493f13148b50cd535d91ed7477f755e9c1ed66d780d44657ab21ce2875c22016150858ad2a8a4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

React Native 0.83 introduced an unconditional `canBecomeFirstResponder { return YES }` on every `RCTViewComponentView` ([source](https://github.com/facebook/react-native/blob/v0.83.4/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm#L1615-L1618)). This breaks `UISheetPresentationController`'s native keyboard avoidance animation — the sheet snaps back to its detent without animation when the keyboard is dismissed.

The patch gates `canBecomeFirstResponder` behind the `enableImperativeFocus` feature flag, matching the fix in the upstream PR.

**Upstream references:**
- facebook/react-native#55116
- facebook/react-native#55908

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Test Plan

- Present a sheet with a text input (no ScrollView/Footer)
- Tap input to show keyboard → sheet expands
- Dismiss keyboard → sheet should animate back smoothly (was snapping without the patch)
- Verified on RN 0.82.1 (working), RN 0.83.4 (broken), RN 0.83.4 + patch (fixed)

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)