### PR TITLE
fix(ios): blur flicker when dismissing sheet with backgroundBlur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Fixed blur flicker/flash at the bottom when dismissing sheet with `backgroundBlur` enabled. ([#633](https://github.com/lodev09/react-native-true-sheet/pull/633) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed `NoSuchMethodError` crash on Android < 11 (API 30) when presenting a sheet with grabber accessibility. ([#606](https://github.com/lodev09/react-native-true-sheet/pull/606) by [@Mohamed-kassim](https://github.com/Mohamed-kassim))
 - **iOS**: Fixed keyboard scroll positioning when sheet auto-expands from a smaller detent. ([#592](https://github.com/lodev09/react-native-true-sheet/pull/592) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed dead state after rapid present/dismiss cycles. ([#593](https://github.com/lodev09/react-native-true-sheet/pull/593) by [@lodev09](https://github.com/lodev09))

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -200,6 +200,8 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear:animated];
 
+  _blurView.alpha = 1;
+
   if (!_isPresented) {
     UIViewController *presenter = self.presentingViewController;
     if ([presenter isKindOfClass:[TrueSheetViewController class]]) {
@@ -474,6 +476,12 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
 
     if (self.currentPosition >= self.screenHeight) {
       CGFloat position = fmax(_lastEmittedPositionState.position, layerPosition);
+
+      // Hide blur at the end of dismiss to prevent UIVisualEffectView
+      // from causing a flicker/flash at the bottom edge of the sheet.
+      if (self.screenHeight - position < 1) {
+        _blurView.alpha = 0;
+      }
 
       [self emitWillDismissEvents];
       [self emitChangePositionDelegateWithPosition:position realtime:YES debug:@"transition out"];


### PR DESCRIPTION
## Summary

Hide `UIVisualEffectView` at the end of the dismiss transition to prevent a flicker/flash at the bottom edge of the sheet.

Fixes #614

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

1. Present a sheet with `backgroundBlur` enabled and `detents={['auto']}`
2. Dismiss via backdrop tap, programmatic dismiss, and swipe down
3. Verify no flicker at the bottom edge during dismiss animation

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)