### PR TITLE
fix: footer ignoring safe area bottom inset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- **iOS**: Fixed footer ignoring safe area insets by pinning to `safeAreaLayoutGuide.bottomAnchor` instead of `bottomAnchor`. ([#644](https://github.com/lodev09/react-native-true-sheet/pull/644) by [@isaacrowntree](https://github.com/isaacrowntree))
+- **Android**: Fixed footer rendering behind the navigation/gesture bar by accounting for `bottomInset` in `positionFooter`. ([#644](https://github.com/lodev09/react-native-true-sheet/pull/644) by [@isaacrowntree](https://github.com/isaacrowntree))
+
 ## 3.10.0
 
 ### 🎉 New features

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -964,7 +964,10 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     val sheetHeight = sheet.height
     val sheetTop = sheet.top
 
-    var footerY = (sheetHeight - sheetTop - footerHeight - currentKeyboardInset).toFloat()
+    // Subtract bottomInset so footer content doesn't render behind the navigation/gesture bar.
+    // When the keyboard is visible, currentKeyboardInset already accounts for the bottom inset.
+    val safeAreaOffset = if (currentKeyboardInset > 0) 0 else bottomInset
+    var footerY = (sheetHeight - sheetTop - footerHeight - currentKeyboardInset - safeAreaOffset).toFloat()
 
     // Adjust during dismiss animation when slideOffset is negative
     if (slideOffset != null && slideOffset < 0) {

--- a/ios/TrueSheetFooterView.mm
+++ b/ios/TrueSheetFooterView.mm
@@ -61,7 +61,9 @@ using namespace facebook::react;
   [self.leadingAnchor constraintEqualToAnchor:parentView.leadingAnchor].active = YES;
   [self.trailingAnchor constraintEqualToAnchor:parentView.trailingAnchor].active = YES;
 
-  _bottomConstraint = [self.bottomAnchor constraintEqualToAnchor:parentView.bottomAnchor
+  // Pin to safe area so footer content doesn't render behind the home indicator.
+  // When the keyboard is visible, its height already includes the safe area inset.
+  _bottomConstraint = [self.bottomAnchor constraintEqualToAnchor:parentView.safeAreaLayoutGuide.bottomAnchor
                                                         constant:-_currentKeyboardOffset];
   _bottomConstraint.active = YES;
 


### PR DESCRIPTION
## Summary
Split out from #589 per maintainer request — #589 now contains only the touch-handling fix.

Two related fixes for footer content rendering under the system safe-area chrome on notched / gesture-bar devices:

- **iOS** (`TrueSheetFooterView.mm`): pin the footer's bottom constraint to `parentView.safeAreaLayoutGuide.bottomAnchor` instead of `parentView.bottomAnchor`, so footer content sits above the home indicator. When the keyboard is visible, its height already includes the safe-area inset, so the existing keyboard offset handling still works unchanged.
- **Android** (`TrueSheetViewController.positionFooter`): subtract `bottomInset` from `footerY` when the keyboard is not visible, so footer content sits above the navigation/gesture bar. When the keyboard is visible, `currentKeyboardInset` already accounts for the bottom inset, so we skip the extra offset to avoid double-compensation.

## Repro
Run `example/` on a notched device (iPhone 15 Pro or a Pixel with gesture nav), open `BasicSheet`, observe footer content clipped behind the home indicator / gesture bar. Screenshots to follow.

## Test plan
- [ ] iOS on notched device: footer content sits above the home indicator at all detents
- [ ] iOS with keyboard visible: footer rides the keyboard without a gap or overlap
- [ ] Android on gesture-nav device: footer content sits above the gesture bar
- [ ] Android with keyboard visible: footer rides the keyboard without a gap or overlap
- [ ] No regression in `BasicSheet` / `PromptSheet` example screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)