### PR TITLE
fix(android): clear focus on dismiss to prevent auto-focus transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- **Android**: Fixed focused input in sheet causing auto-focus on main screen input after dismiss. ([#649](https://github.com/lodev09/react-native-true-sheet/pull/649) by [@lodev09](https://github.com/lodev09))
+
 ## 3.10.0
 
 ### 🎉 New features

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -757,6 +757,11 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   private fun dismissKeyboard() {
     isKeyboardDismissProgrammatic = true
     KeyboardUtils.dismiss(reactContext)
+
+    // Clear focus from any focused view within the sheet to prevent
+    // Android from auto-focusing the next focusable view on the main
+    // screen when the sheet is removed from the hierarchy.
+    sheetView?.findFocus()?.clearFocus()
   }
 
   fun handleBackPress() {

--- a/example/shared/src/components/sheets/BasicSheet.tsx
+++ b/example/shared/src/components/sheets/BasicSheet.tsx
@@ -9,6 +9,7 @@ import { Button } from '../Button';
 import { ButtonGroup } from '../ButtonGroup';
 import { Spacer } from '../Spacer';
 import { Header } from '../Header';
+import { Input } from '../Input';
 
 interface BasicSheetProps extends TrueSheetProps {
   onNavigateToModal?: () => void;
@@ -119,6 +120,7 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
         <Button text="Auto" onPress={() => resize(0)} />
       </ButtonGroup>
       <Spacer />
+      <Input />
       <ButtonGroup>
         <Button text="Child Sheet" onPress={presentChild} />
         <Button text="PromptSheet" onPress={presentPromptSheet} />


### PR DESCRIPTION
## Summary

- Clear focus from the sheet's focused view during keyboard dismissal to prevent Android from auto-focusing the next focusable view on the main screen when the sheet is removed from the hierarchy.

Closes #647

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Open a sheet with a TextInput
- Focus the TextInput (keyboard appears)
- Dismiss the sheet
- Verify the TextInput on the main screen does NOT receive focus

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)