### PR TITLE
add support to render legacy sheet for ios 26+ devices

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -211,6 +211,11 @@ class TrueSheetViewManager :
     // iOS-specific prop - no-op on Android
   }
 
+  @ReactProp(name = "preferLegacyStyle", defaultBoolean = false)
+  override fun setPreferLegacyStyle(view: TrueSheetView, value: Boolean) {
+    // iOS-specific prop - no-op on Android
+  }
+
   @ReactProp(name = "elevation", defaultDouble = -1.0)
   override fun setElevation(view: TrueSheetView, elevation: Double) {
     view.setSheetElevation(elevation.toFloat())

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -231,6 +231,7 @@ using namespace facebook::react;
   }
 
   _controller.pageSizing = newProps.pageSizing;
+  _controller.preferLegacyStyle = newProps.preferLegacyStyle;
   _controller.dismissible = newProps.dismissible;
   _controller.draggable = newProps.draggable;
   _controller.dimmed = newProps.dimmed;

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -61,6 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSNumber *cornerRadius;
 @property (nonatomic, assign) BOOL grabber;
 @property (nonatomic, strong, nullable) GrabberOptions *grabberOptions;
+@property (nonatomic, assign) BOOL preferLegacyStyle;
 @property (nonatomic, assign) BOOL draggable;
 @property (nonatomic, assign) BOOL dimmed;
 @property (nonatomic, strong, nullable) NSNumber *dimmedDetentIndex;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -74,6 +74,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
     _dimmed = YES;
     _dimmedDetentIndex = @(0);
     _pageSizing = YES;
+    _preferLegacyStyle = NO;
     _lastEmittedPositionState = (TrueSheetPositionState){0, 0, 0};
     _isDragging = NO;
     _isPresented = NO;
@@ -726,8 +727,12 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
 
 - (void)setupBackground {
   auto effectiveBackgroundBlur = self.backgroundBlur;
-  if (@available(iOS 26.0, *)) {
-    // iOS 26+ has default liquid glass effect
+  if (!self.preferLegacyStyle) {
+    if (@available(iOS 26.0, *)) {
+      // iOS 26+ has default liquid glass effect
+    } else if (effectiveBackgroundBlur == TrueSheetViewBackgroundBlur::None && !self.backgroundColor) {
+      effectiveBackgroundBlur = TrueSheetViewBackgroundBlur::SystemMaterial;
+    }
   } else if (effectiveBackgroundBlur == TrueSheetViewBackgroundBlur::None && !self.backgroundColor) {
     effectiveBackgroundBlur = TrueSheetViewBackgroundBlur::SystemMaterial;
   }

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -450,6 +450,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
       scrollable = false,
       scrollableOptions,
       pageSizing = true,
+      preferLegacyStyle = false,
       children,
       style,
       header,
@@ -505,6 +506,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
         scrollable={scrollable}
         scrollableOptions={scrollableOptions}
         pageSizing={pageSizing}
+        preferLegacyStyle={preferLegacyStyle}
         insetAdjustment={insetAdjustment}
         onMount={this.onMount}
         onWillPresent={this.onWillPresent}

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -364,6 +364,15 @@ export interface TrueSheetProps extends ViewProps {
   pageSizing?: boolean;
 
   /**
+   * When `true`, uses the pre–iOS 26 material background path instead of the default
+   * liquid glass sheet appearance on iOS 26 and later.
+   *
+   * @platform ios
+   * @default false
+   */
+  preferLegacyStyle?: boolean;
+
+  /**
    * The blur effect style on iOS.
    * Blends with `backgroundColor` when provided.
    *

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -88,6 +88,7 @@ export interface NativeProps extends ViewProps {
   anchor?: WithDefault<'left' | 'center' | 'right', 'center'>;
   anchorOffset?: WithDefault<Double, 16>;
   insetAdjustment?: WithDefault<'automatic' | 'never', 'automatic'>;
+  preferLegacyStyle?: WithDefault<boolean, false>;
 
   // Blur options
   blurOptions?: BlurOptionsType;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -137,6 +137,7 @@ export type TrueSheetNavigationSheetProps = Pick<
   | 'maxContentWidth'
   | 'scrollable'
   | 'pageSizing'
+  | 'preferLegacyStyle'
   | 'header'
   | 'headerStyle'
   | 'footer'


### PR DESCRIPTION
## Summary

Adds an optional **`preferLegacyStyle`** prop (default `false`) so sheets on **iOS 26+** can opt out of the default liquid glass background and use the same material-style background path as earlier iOS versions. The prop is wired through Fabric (`TrueSheetViewNativeComponent`), `TrueSheet`, and `TrueSheetViewController` (`setupBackground`). **Android** exposes a no-op setter so codegen stays consistent, matching other iOS-only props like `pageSizing`. **`TrueSheetNavigationSheetProps`** includes the new prop so navigator screens can pass it.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- [ ] Build iOS app with New Architecture and confirm no codegen / compile errors after `preferLegacyStyle` is added to the native spec.
- [ ] On **iOS 26+** simulator or device: present a sheet with default props and confirm default appearance (liquid glass path unchanged when `preferLegacyStyle` is omitted or `false`).
- [ ] On **iOS 26+**: set `preferLegacyStyle={true}` on the same sheet and confirm background uses the legacy material path (no liquid glass).
- [ ] On **iOS &lt; 26**: quick smoke test that sheet background behavior is unchanged.
- [ ] **Android**: smoke test that presenting a sheet still works (prop is a no-op).
- [ ] If using **TrueSheet** navigator: pass `preferLegacyStyle` via screen options and confirm it reaches the native view.

## Screenshots / Videos


## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web (N/A for this change unless you use web stubs—confirm sheet still loads)
- [x] I updated the documentation (if needed) (`preferLegacyStyle` is documented in `TrueSheet.types.ts` JSDoc)