### PR TITLE
feat(ios): expose UIGlassEffect clear variant via new `backgroundGlass` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🎉 New features
+
+- **iOS**: Add `backgroundGlass` prop to opt into iOS 26's clear Liquid Glass variant (`UIGlassEffectStyleClear`). ([#665](https://github.com/lodev09/react-native-true-sheet/pull/665) by [@michelemarri](https://github.com/michelemarri))
+
 ### 🐛 Bug fixes
 
 - **Android**: Fixed focused input in sheet causing auto-focus on main screen input after dismiss. ([#649](https://github.com/lodev09/react-native-true-sheet/pull/649) by [@lodev09](https://github.com/lodev09))

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -191,6 +191,11 @@ class TrueSheetViewManager :
     // iOS-specific prop - no-op on Android
   }
 
+  @ReactProp(name = "backgroundGlass")
+  override fun setBackgroundGlass(view: TrueSheetView, value: String?) {
+    // iOS-specific prop (liquid glass) - no-op on Android
+  }
+
   @ReactProp(name = "blurOptions")
   override fun setBlurOptions(view: TrueSheetView, options: ReadableMap?) {
     // iOS-specific prop - no-op on Android

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -187,6 +187,9 @@ using namespace facebook::react;
   // Blur tint
   _controller.backgroundBlur = newProps.backgroundBlur;
 
+  // Liquid Glass style (iOS 26+)
+  _controller.backgroundGlass = newProps.backgroundGlass;
+
   // Blur options
   const auto &blurOpts = newProps.blurOptions;
   _controller.blurIntensity = blurOpts.intensity >= 0 ? @(blurOpts.intensity) : nil;

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -65,6 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL dimmed;
 @property (nonatomic, strong, nullable) NSNumber *dimmedDetentIndex;
 @property (nonatomic, assign) facebook::react::TrueSheetViewBackgroundBlur backgroundBlur;
+@property (nonatomic, assign) facebook::react::TrueSheetViewBackgroundGlass backgroundGlass;
 @property (nonatomic, strong, nullable) NSNumber *blurIntensity;
 @property (nonatomic, assign) BOOL blurInteraction;
 @property (nonatomic, assign) BOOL pageSizing;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -746,7 +746,16 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
         self.sheet.backgroundEffect = [UIColorEffect effectWithColor:self.backgroundColor];
       } else if (hasBlur) {
         self.sheet.backgroundEffect = [UIColorEffect effectWithColor:[UIColor clearColor]];
+      } else if (self.backgroundGlass == facebook::react::TrueSheetViewBackgroundGlass::Clear) {
+        // Clear glass variant (iOS 26+). Higher transparency, no luminosity
+        // veil. Designed for media-rich backgrounds; typically paired with
+        // an explicit dimming/blur layer for content legibility.
+        UIGlassEffect *glass = [UIGlassEffect effectWithStyle:UIGlassEffectStyleClear];
+        glass.interactive = YES;
+        self.sheet.backgroundEffect = glass;
       } else {
+        // Default: let the system apply iOS 26's standard Liquid Glass
+        // (UIGlassEffectStyleRegular under the hood).
         self.sheet.backgroundEffect = nil;
       }
       return;

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -441,6 +441,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
       initialDetentAnimated = true,
       dimmedDetentIndex,
       backgroundBlur,
+      backgroundGlass,
       blurOptions,
       cornerRadius,
       maxContentHeight,
@@ -487,6 +488,7 @@ export class TrueSheet extends PureComponent<TrueSheetProps, TrueSheetState> {
         style={styles.sheetView}
         detents={resolvedDetents}
         backgroundBlur={backgroundBlur}
+        backgroundGlass={backgroundGlass}
         blurOptions={blurOptions}
         backgroundColor={backgroundColor}
         cornerRadius={cornerRadius}

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -194,6 +194,16 @@ export type InsetAdjustment =
   | 'never';
 
 /**
+ * iOS 26+ Liquid Glass style.
+ *
+ * - 'regular': Standard glass with luminosity veil for readability (default).
+ * - 'clear': High-transparency glass for media-rich backgrounds.
+ *
+ * @platform ios 26+
+ */
+export type BackgroundGlass = 'regular' | 'clear';
+
+/**
  * Blur style mapped to native values in IOS.
  *
  * @platform ios
@@ -370,6 +380,15 @@ export interface TrueSheetProps extends ViewProps {
    * @platform ios
    */
   backgroundBlur?: BackgroundBlur;
+
+  /**
+   * iOS 26+ Liquid Glass style. Ignored when `backgroundColor` or
+   * `backgroundBlur` is set, or on pre-iOS 26 runtimes.
+   *
+   * @platform ios 26+
+   * @default 'regular'
+   */
+  backgroundGlass?: BackgroundGlass;
 
   /**
    * Options for customizing the blur effect.

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -85,6 +85,10 @@ export interface NativeProps extends ViewProps {
     'none'
   >;
 
+  // iOS 26+ Liquid Glass style. Ignored when backgroundColor or
+  // backgroundBlur is set, or on pre-iOS 26 runtimes.
+  backgroundGlass?: WithDefault<'regular' | 'clear', 'regular'>;
+
   anchor?: WithDefault<'left' | 'center' | 'right', 'center'>;
   anchorOffset?: WithDefault<Double, 16>;
   insetAdjustment?: WithDefault<'automatic' | 'never', 'automatic'>;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -132,6 +132,7 @@ export type TrueSheetNavigationSheetProps = Pick<
   | 'dimmed'
   | 'dimmedDetentIndex'
   | 'backgroundBlur'
+  | 'backgroundGlass'
   | 'blurOptions'
   | 'maxContentHeight'
   | 'maxContentWidth'


### PR DESCRIPTION
Closes #663

Adds a new `backgroundGlass?: 'regular' | 'clear'` prop on `<TrueSheet>` so apps can opt into iOS 26's `UIGlassEffectStyleClear` variant. Naming mirrors the existing `backgroundColor` / `backgroundBlur` props per your suggestion in the issue thread.

## API

```tsx
<TrueSheet detents={[0.5, 0.9]} backgroundGlass="clear">
  {/* ... */}
</TrueSheet>
```

- **'regular'** (default): existing behavior — system-default Liquid Glass (`.regular` style, with luminosity veil for content legibility)
- **'clear'**: new option → `UIGlassEffect(style: .clear, isInteractive: true)`. High transparency, minimal adaptivity, designed for media-rich backdrops where the app provides its own dimming/blur layer

## Precedence

Follows the existing pattern — `backgroundColor` wins over `backgroundBlur`, which wins over `backgroundGlass`. The new prop only kicks in when neither of the other two is set, on iOS 26.1+, and `UIDesignRequiresCompatibility` is not opted-in.

## Scope

- `src/fabric/TrueSheetViewNativeComponent.ts` — Fabric spec
- `src/TrueSheet.types.ts` — public TS types (new `BackgroundGlass` type + prop)
- `src/TrueSheet.tsx` — destructure + forward to native
- `src/navigation/types.ts` — add to `TrueSheetNavigationSheetProps` Pick list
- `ios/TrueSheetViewController.h` — new `@property`
- `ios/TrueSheetView.mm` — wire `newProps.backgroundGlass → _controller.backgroundGlass`
- `ios/TrueSheetViewController.mm` — use it in `setupBackground`
- `android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt` — no-op `setBackgroundGlass` stub (iOS-only prop)

~44 lines added, zero deletions. Fully additive: no behavior change for existing users, `default 'regular'` preserves current Liquid Glass appearance. Android gets a no-op `setBackgroundGlass` stub so the Fabric prop is a clean cross-platform no-op there.

## Testing

Used via `patch-package` in our app — **x72**, an Italian fantasy-football app for Serie A — on iOS 26 devices, ahead of our App Store launch. The `backgroundGlass="clear"` variant backs a sheet presented over a custom animated pitch canvas, where the system's regular glass veil was washing out the background. No regressions on existing sheets that don't set the prop.

**Note — clear glass is subtle by design.** `UIGlassEffectStyleClear` is near-transparent with no luminosity veil, so over a plain/solid background it can look identical to `.regular` (or to no effect at all). It only reads as different when there's rich/media content *behind* the sheet **and** the app supplies its own dimming/blur layer — the use case Apple's HIG calls out for clear glass. In our app we pair it with a thin `BlurView` + a team-color gradient over the pitch; without such a backdrop the prop is effectively a visual no-op. (I suspect this is behind the "doesn't render" reports — happy to share a side-by-side screenshot.)

## Out of scope (follow-up)

A `backgroundGlassAppearance` / forced-dark option is intentionally left out here to keep this PR minimal and additive — better suited to a follow-up `backgroundGlassOptions` prop, per the thread discussion. Overriding the interface style is orthogonal to the clear/regular choice.

Thanks for the library and the quick turnaround on the issue!
