### PR TITLE
fix(android): emit didFocus after parent translate animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug fixes
 
+- **Android**: Emit `onDidFocus` after the parent's translate-up animation completes when a stacked child sheet is dismissed. ([#666](https://github.com/lodev09/react-native-true-sheet/pull/666) by [@lodev09](https://github.com/lodev09))
 - **Android**: Fixed focused input in sheet causing auto-focus on main screen input after dismiss. ([#649](https://github.com/lodev09/react-native-true-sheet/pull/649) by [@lodev09](https://github.com/lodev09))
 
 ## 3.10.0

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -479,9 +479,9 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
    * Resets this sheet's translation and restores dragging when it becomes topmost.
    * Parent recalculates its translation based on this sheet's position.
    */
-  fun resetTranslation() {
+  fun resetTranslation(onTranslateEnd: (() -> Unit)? = null) {
     viewController.sheetView?.behavior?.isDraggable = viewController.draggable
-    viewController.translateSheet(0)
+    viewController.translateSheet(0, onEnd = onTranslateEnd)
 
     // Parent should recalculate its translation based on this sheet's position
     val mySheetTop = viewController.detentCalculator.getSheetTopForDetentIndex(viewController.currentDetentIndex)
@@ -510,7 +510,7 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     eventDispatcher?.dispatchEvent(WillDismissEvent(surfaceId, id))
   }
 
-  override fun viewControllerDidDismiss(hadParent: Boolean) {
+  override fun viewControllerDidDismiss(parent: TrueSheetView?) {
     // Detach coordinator from the root container view
     viewController.coordinatorLayout?.let { rootContainerView?.removeView(it) }
     rootContainerView = null
@@ -520,7 +520,14 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     val surfaceId = UIManagerHelper.getSurfaceId(this)
     eventDispatcher?.dispatchEvent(DidDismissEvent(surfaceId, id))
 
-    TrueSheetStackManager.unregisterSheet(this, hadParent)
+    TrueSheetStackManager.unregisterSheet(this)
+
+    parent?.resetTranslation {
+      val parentController = parent.viewController
+      if (parentController.isPresented && !parentController.isBeingDismissed) {
+        parent.viewControllerDidFocus()
+      }
+    }
   }
 
   override fun viewControllerDidChangeDetent(index: Int, position: Float, detent: Float) {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -50,7 +50,7 @@ interface TrueSheetViewControllerDelegate {
   fun viewControllerWillPresent(index: Int, position: Float, detent: Float)
   fun viewControllerDidPresent(index: Int, position: Float, detent: Float)
   fun viewControllerWillDismiss()
-  fun viewControllerDidDismiss(hadParent: Boolean)
+  fun viewControllerDidDismiss(parent: TrueSheetView?)
   fun viewControllerDidChangeDetent(index: Int, position: Float, detent: Float)
   fun viewControllerDidDragBegin(index: Int, position: Float, detent: Float)
   fun viewControllerDidDragChange(index: Int, position: Float, detent: Float)
@@ -1163,12 +1163,11 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   }
 
   private fun emitDidDismissEvents() {
-    val hadParent = parentSheetView != null
-    parentSheetView?.viewControllerDidFocus()
+    val parent = parentSheetView
     parentSheetView = null
 
     delegate?.viewControllerDidBlur()
-    delegate?.viewControllerDidDismiss(hadParent)
+    delegate?.viewControllerDidDismiss(parent)
 
     dismissPromise?.invoke()
     dismissPromise = null
@@ -1224,7 +1223,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     }
   }
 
-  fun translateSheet(translationY: Int) {
+  fun translateSheet(translationY: Int, onEnd: (() -> Unit)? = null) {
     val sheet = sheetView ?: return
 
     sheet.animate()
@@ -1234,6 +1233,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
         val effectiveTop = sheet.top + sheet.translationY.toInt()
         emitChangePositionDelegate(effectiveTop)
       }
+      .withEndAction { onEnd?.invoke() }
       .start()
   }
 

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetStackManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetStackManager.kt
@@ -48,15 +48,12 @@ object TrueSheetStackManager {
   }
 
   /**
-   * Unregisters a sheet from the stack and resets parent translation if needed.
+   * Unregisters a sheet from the stack.
    */
   @JvmStatic
-  fun unregisterSheet(sheetView: TrueSheetView, hadParent: Boolean) {
+  fun unregisterSheet(sheetView: TrueSheetView) {
     synchronized(presentedSheetStack) {
       presentedSheetStack.remove(sheetView)
-      if (hadParent) {
-        presentedSheetStack.lastOrNull()?.resetTranslation()
-      }
     }
   }
 


### PR DESCRIPTION
## Summary

On Android, when a child sheet is dismissed in a stack, the parent's `onDidFocus` was firing immediately at the end of the child's dismiss animation — *before* the parent's translate-up animation began. It now fires after the parent's translate animation completes, so JS sees the focus event when the parent has visually settled back into place.

Refactored the dismiss flow so event orchestration lives in `TrueSheetView.viewControllerDidDismiss` instead of leaking into `resetTranslation`:

- `translateSheet` accepts an optional `onEnd` callback wired through `withEndAction`
- `resetTranslation` stays pure — translate + cascade only
- `StackManager.unregisterSheet` is just a registry op (no return value)
- The actual `parent` reference is passed through the delegate (was `hadParent: Boolean`), so cross-container scenarios target the correct sheet for both translation and the focus event
- Guarded with `isPresented && !isBeingDismissed` so cascade dismiss (parent dismissing while child dismisses on top of it) doesn't fire focus on a dying parent

## Type of Change

- [x] Bug fix

## Test Plan

- [x] Stacked sheet dismiss → parent's `onDidFocus` fires after parent slides back up
- [x] Single sheet dismiss → no `onDidFocus` event (unchanged)
- [x] `dismissAll` cascade → no spurious `onDidFocus` on dying parents

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web