### PR TITLE
fix(web): collapse non-dismissible sheet on dim tap and escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Web**: Replace `@gorhom/bottom-sheet` with vendored `vaul` renderer. Adds full event lifecycle (`onMount`, `onWill/DidPresent`, `onWill/DidDismiss`, `onDetentChange`, `onDragBegin/Change/End`, `onPositionChange`, `onWill/DidFocus`, `onWill/DidBlur`), sheet stacking with cascade, detached mode, `auto` detent, scrollable content, and honors `elevation`, `cornerRadius`, `maxContentHeight`, `draggable`, `dimmedDetentIndex`, `insetAdjustment`, `initialDetentAnimated`. ([#639](https://github.com/lodev09/react-native-true-sheet/pull/639) by [@lodev09](https://github.com/lodev09))
 
+### 🐛 Bug fixes
+
+- **Web**: Collapse non-dismissible sheet to a sensible detent on dim tap and Escape, mirroring Android. ([#675](https://github.com/lodev09/react-native-true-sheet/pull/675) by [@lodev09](https://github.com/lodev09))
+
 ## 3.10.1
 
 ### 🐛 Bug fixes

--- a/example/shared/src/screens/MapScreen.tsx
+++ b/example/shared/src/screens/MapScreen.tsx
@@ -180,6 +180,7 @@ const MapScreenInner = ({
         dimmedDetentIndex={1}
         style={styles.content}
         detached
+        dismissible={false}
         onLayout={(e: LayoutChangeEvent) => {
           log(
             `layout ${Math.round(e.nativeEvent.layout.width)}×${Math.round(e.nativeEvent.layout.height)}`

--- a/src/web/vaul/index.tsx
+++ b/src/web/vaul/index.tsx
@@ -982,7 +982,18 @@ export type ContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive
 };
 
 export const Content = React.forwardRef<HTMLDivElement, ContentProps>(
-  ({ onPointerDownOutside, style, onOpenAutoFocus, children, detachedSiblings, ...rest }, ref) => {
+  (
+    {
+      onPointerDownOutside,
+      onEscapeKeyDown,
+      style,
+      onOpenAutoFocus,
+      children,
+      detachedSiblings,
+      ...rest
+    },
+    ref
+  ) => {
     const {
       drawerRef,
       onPress,
@@ -997,6 +1008,8 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(
       isDragging,
       direction,
       snapPoints,
+      setActiveSnapPoint,
+      dismissible,
       container,
       handleOnly,
       shouldAnimate,
@@ -1296,8 +1309,42 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(
             return;
           }
 
+          // Non-dismissible + dimmed: collapse to the highest non-dimmed
+          // snap point instead of silently swallowing the dismiss attempt.
+          // Mirrors the native Android dim-tap behavior.
+          if (
+            !dismissible &&
+            hasSnapPoints &&
+            fadeFromIndex !== undefined &&
+            fadeFromIndex > 0 &&
+            typeof activeSnapPointIndex === 'number' &&
+            activeSnapPointIndex >= fadeFromIndex
+          ) {
+            e.preventDefault();
+            setActiveSnapPoint(snapPoints![fadeFromIndex - 1]!);
+            return;
+          }
+
           if (keyboardIsOpen.current) {
             keyboardIsOpen.current = false;
+          }
+        }}
+        onEscapeKeyDown={(e) => {
+          onEscapeKeyDown?.(e);
+          if (e.defaultPrevented) return;
+
+          // Non-dismissible: collapse to the first snap point (if above it)
+          // instead of silently swallowing the dismiss attempt. Mirrors the
+          // native Android back-press behavior.
+          if (!dismissible) {
+            e.preventDefault();
+            if (
+              hasSnapPoints &&
+              typeof activeSnapPointIndex === 'number' &&
+              activeSnapPointIndex > 0
+            ) {
+              setActiveSnapPoint(snapPoints![0]!);
+            }
           }
         }}
         onFocusOutside={(e) => {


### PR DESCRIPTION
## Summary

Mirror the native Android behavior on web: when `dismissible={false}`, instead of silently swallowing dismiss attempts, the sheet collapses to a sensible detent.

- **Dim tap** → collapse to the highest non-dimmed snap point (Android `viewControllerDidTapDim` → `dimmedDetentIndex - 1`).
- **Escape key** → collapse to the first snap point if currently above it (Android `handleBackPress` → detent `0`).
- **Drag-down** → already blocked at the first detent by vaul's existing `dismissible` guard; no change needed.

iOS handles this natively via `UISheetPresentationController`.

## Type of Change

- [x] Bug fix

## Test Plan

- [x] Web: open `MapScreen` (now uses `dismissible={false}`, `dimmedDetentIndex=1`); tap the dim while above index 1 → collapses to index 0; press Escape while above index 0 → collapses to index 0.
- [x] Web: with `dismissible={true}`, dim tap and Escape still close the sheet (no behavior change).
- [ ] iOS / Android unaffected (no native changes).

## Implementation Notes

Added inside the vendored vaul `Drawer.Content` rather than the wrapper so the collapse logic lives next to the existing `dismissible` guards (`onOpenChange`, drag clamp). Forwards user-supplied `onPointerDownOutside` / `onEscapeKeyDown` first and respects `defaultPrevented`.

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)