### PR TITLE
fix(web): float the grabber over content like native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - **Web**: Collapse non-dismissible sheet to a sensible detent on dim tap and Escape, mirroring Android. ([#675](https://github.com/lodev09/react-native-true-sheet/pull/675) by [@lodev09](https://github.com/lodev09))
+- **Web**: Float the grabber over content like native iOS/Android instead of pushing the header down and inflating the `auto` detent. ([#676](https://github.com/lodev09/react-native-true-sheet/pull/676) by [@lodev09](https://github.com/lodev09))
 
 ## 3.10.1
 

--- a/example/shared/src/components/Header.tsx
+++ b/example/shared/src/components/Header.tsx
@@ -16,8 +16,8 @@ export const Header = ({ children, style, ...rest }: HeaderProps) => {
 
 const styles = StyleSheet.create({
   container: {
-    height: Platform.select({ android: HEADER_HEIGHT + SPACING, default: HEADER_HEIGHT }),
-    paddingTop: Platform.select({ android: SPACING * 2 }),
+    height: Platform.select({ ios: HEADER_HEIGHT, default: HEADER_HEIGHT + SPACING }),
+    paddingTop: Platform.select({ ios: 0, default: SPACING * 2 }),
     justifyContent: 'center',
     padding: SPACING,
   },

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -698,14 +698,22 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     dropShadow,
   ]);
 
+  // Absolute-position the grabber so it overlays the content top-edge
+  // instead of consuming flow height — mirrors native iOS/Android, where
+  // the grabber sits in the rounded corner zone above the content and
+  // doesn't push the header down or inflate the 'auto' detent measurement.
   const handleStyle = useMemo<React.CSSProperties>(
     () => ({
+      position: 'absolute',
+      top: grabberOptions?.topMargin ?? DEFAULT_GRABBER_TOP_MARGIN,
+      left: '50%',
+      transform: 'translateX(-50%)',
       height: grabberHeight,
       width: grabberOptions?.width ?? DEFAULT_GRABBER_WIDTH,
       borderRadius: grabberOptions?.cornerRadius ?? grabberHeight / 2,
       backgroundColor: (grabberOptions?.color ?? defaultGrabberColor) as string,
       opacity: 1,
-      marginTop: grabberOptions?.topMargin ?? DEFAULT_GRABBER_TOP_MARGIN,
+      zIndex: 1,
     }),
     [grabberOptions, grabberHeight, defaultGrabberColor]
   );

--- a/src/web/constants.ts
+++ b/src/web/constants.ts
@@ -10,4 +10,4 @@ export const DEFAULT_GRABBER_COLOR_LIGHT = 'rgba(0, 0, 0, 0.3)';
 export const DEFAULT_GRABBER_COLOR_DARK = 'rgba(255, 255, 255, 0.3)';
 export const DEFAULT_GRABBER_WIDTH = 32;
 export const DEFAULT_GRABBER_HEIGHT = 4;
-export const DEFAULT_GRABBER_TOP_MARGIN = 16;
+export const DEFAULT_GRABBER_TOP_MARGIN = 8;


### PR DESCRIPTION
## Summary

The web grabber was rendered in normal flow (`marginTop` only), pushing the header down by ~`grabberHeight + topMargin` and inflating the `'auto'` detent measurement. Native iOS/Android both float the grabber over the rounded top zone — content/header sit at the sheet's top edge and the grabber overlays them.

This PR mirrors that:

- Absolute-position the grabber relative to `Drawer.Content` (the positioned ancestor), centered horizontally via `left: 50%` + `translateX(-50%)`.
- Drops the grabber from flow height — `'auto'` detent now measures only `header + content`, matching native.
- Visual top position lands at `topMargin` from the sheet's top edge — same as Android (`TrueSheetGrabberView.kt:67-94` resolves the visible pill top to `topMargin`dp from the sheet top).
- Defaults `DEFAULT_GRABBER_TOP_MARGIN` to `8` to better match the rounded top spacing on web.
- Vaul's hit-area span (`style.css:168-176`, `max(100%, 44px)`) still works since the grabber div is now its containing block.

Updates the example `Header` to apply the Android-style `paddingTop` on web — the grabber now overlaps the header top edge there too.

## Type of Change

- [x] Bug fix

## Test Plan

- [x] Web: grabber visually overlays the top of `Drawer.Content`; doesn't push header down.
- [x] Web: `'auto'` detent height matches content (no longer inflated by grabber).
- [x] Web: tap target still expands to 44px around the visible pill.
- [ ] iOS / Android unaffected (no native changes).

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)