### PR TITLE
fix(web): size form sheet to content height when pageSizing=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - **Web**: Collapse non-dismissible sheet to a sensible detent on dim tap and Escape, mirroring Android. ([#675](https://github.com/lodev09/react-native-true-sheet/pull/675) by [@lodev09](https://github.com/lodev09))
 - **Web**: Float the grabber over content like native iOS/Android instead of pushing the header down and inflating the `auto` detent. ([#676](https://github.com/lodev09/react-native-true-sheet/pull/676) by [@lodev09](https://github.com/lodev09))
+- **Web**: Size the form sheet (`pageSizing={false}`) to fit content, clamped between half the viewport and `viewport − 2 × detachedOffset`, instead of a fixed 50% cap. ([#677](https://github.com/lodev09/react-native-true-sheet/pull/677) by [@lodev09](https://github.com/lodev09))
 
 ## 3.10.1
 

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -641,8 +641,21 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   // vertically.
   const isFormSheet = isLandscapeOrTablet && maxContentWidth == null && !pageSizing;
 
-  const effectiveMaxContentHeight =
-    maxContentHeight ?? (isFormSheet ? windowHeight * DEFAULT_FORM_SHEET_HEIGHT_RATIO : undefined);
+  // Vaul measures the auto-size wrapper's offsetHeight (always, post fork).
+  // Track it here so the form sheet can size its card to fit content,
+  // clamped between a minimum ratio of the viewport and a maximum derived
+  // from `detachedOffset` (the breathing room left at top + bottom of the
+  // floating card).
+  const [measuredContentHeight, setMeasuredContentHeight] = useState(0);
+
+  const effectiveMaxContentHeight = useMemo<number | undefined>(() => {
+    if (maxContentHeight !== undefined) return maxContentHeight;
+    if (!isFormSheet) return undefined;
+    const min = windowHeight * DEFAULT_FORM_SHEET_HEIGHT_RATIO;
+    const max = Math.max(min, windowHeight - 2 * detachedOffset);
+    if (measuredContentHeight <= 0) return min;
+    return Math.max(min, Math.min(measuredContentHeight, max));
+  }, [maxContentHeight, isFormSheet, windowHeight, detachedOffset, measuredContentHeight]);
 
   const effectiveDetachedOffset = isFormSheet
     ? Math.max(0, (windowHeight - (effectiveMaxContentHeight ?? 0)) / 2)
@@ -737,6 +750,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       maxContentHeight={effectiveMaxContentHeight}
       initialAnimated={initialDetentAnimated}
       detachedWrapperStyle={wrapperStyle}
+      onContentHeightChange={setMeasuredContentHeight}
       activeSnapPoint={activeSnapPoint}
       setActiveSnapPoint={handleSetActiveSnapPoint}
       {...snapPointsProps}

--- a/src/web/vaul/index.tsx
+++ b/src/web/vaul/index.tsx
@@ -186,6 +186,12 @@ export type DialogProps = {
    * the sheet appears at its target detent instantly. Defaults to `true`.
    */
   initialAnimated?: boolean;
+  /**
+   * Fires when the auto-size wrapper's measured content height changes.
+   * Useful for callers that want to size the surrounding card to fit
+   * content (e.g. iPad-style form sheets).
+   */
+  onContentHeightChange?: (height: number) => void;
 } & (WithFadeFromProps | WithoutFadeFromProps);
 
 export function Root({
@@ -226,6 +232,7 @@ export function Root({
   detachedWrapperStyle,
   maxContentHeight,
   initialAnimated = true,
+  onContentHeightChange,
 }: DialogProps) {
   const [isOpen = false, setIsOpen] = useControllableState({
     defaultProp: defaultOpen,
@@ -261,6 +268,14 @@ export function Root({
   const drawerWidthRef = React.useRef(drawerRef.current?.getBoundingClientRect().width || 0);
   const initialDrawerHeight = React.useRef(0);
   const [contentHeight, setContentHeight] = React.useState(0);
+
+  const onContentHeightChangeRef = React.useRef(onContentHeightChange);
+  React.useEffect(() => {
+    onContentHeightChangeRef.current = onContentHeightChange;
+  });
+  React.useEffect(() => {
+    onContentHeightChangeRef.current?.(contentHeight);
+  }, [contentHeight]);
 
   const onSnapPointChange = React.useCallback((activeSnapPointIndex: number) => {
     // Change openTime ref when we reach the last snap point to prevent dragging for 500ms incase it's scrollable.
@@ -1021,20 +1036,17 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(
       detachedRadius,
       detachedWrapperStyle: detachedWrapperStyleProp,
     } = useDrawerContext();
-    const hasAutoSnapPoint = React.useMemo(
-      () => !!snapPoints?.some((p) => p === 'auto'),
-      [snapPoints]
-    );
-
-    // When 'auto' is used as a snap point, we need the natural content height.
-    // The drawer itself may be styled to a fixed viewport height, so we measure
-    // an inner wrapper instead. Ref callback starts the observer as soon as the
-    // node mounts (Radix Presence defers the portal mount past useEffect).
+    // Always measure the inner wrapper's natural height. The drawer itself may
+    // be styled to a fixed viewport height, so we measure an inner wrapper
+    // instead. Ref callback starts the observer as soon as the node mounts
+    // (Radix Presence defers the portal mount past useEffect). The measurement
+    // drives the 'auto' snap point and is also exposed via
+    // `onContentHeightChange` for callers that size the surrounding card.
     const autoRoRef = React.useRef<ResizeObserver | null>(null);
     const setAutoSizeNode = React.useCallback(
       (node: HTMLDivElement | null) => {
         autoRoRef.current?.disconnect();
-        if (!node || !hasAutoSnapPoint) {
+        if (!node) {
           autoRoRef.current = null;
           return;
         }
@@ -1044,7 +1056,7 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(
         ro.observe(node);
         autoRoRef.current = ro;
       },
-      [hasAutoSnapPoint, setContentHeight]
+      [setContentHeight]
     );
 
     const isBelowFade =
@@ -1392,13 +1404,9 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(
           }
         }}
       >
-        {hasAutoSnapPoint ? (
-          <div ref={setAutoSizeNode} data-vaul-auto-size-wrapper="" style={autoSizeWrapperStyle}>
-            {children}
-          </div>
-        ) : (
-          children
-        )}
+        <div ref={setAutoSizeNode} data-vaul-auto-size-wrapper="" style={autoSizeWrapperStyle}>
+          {children}
+        </div>
       </DialogPrimitive.Content>
     );
 


### PR DESCRIPTION
## Summary

The form sheet (`pageSizing={false}` on tablet/landscape) was hard-coded to half the viewport via `DEFAULT_FORM_SHEET_HEIGHT_RATIO`, which clipped taller content and left a lot of empty space when content was small. This PR makes the card adapt to the measured content height, clamped between:

- **min** = `windowHeight * DEFAULT_FORM_SHEET_HEIGHT_RATIO` (0.5 floor — never smaller than half the viewport).
- **max** = `windowHeight - 2 * detachedOffset` (ceiling from the `detachedOffset` prop or its default — guarantees breathing room top + bottom).

User-supplied `maxContentHeight` still wins. Vertical centering (`effectiveDetachedOffset = (windowHeight - cardHeight) / 2`) keeps the card centered as it grows or shrinks.

## Implementation

- Added `onContentHeightChange?: (height: number) => void` to vaul's `Drawer.Root`. An effect calls the callback whenever the internal `contentHeight` changes.
- Removed the `hasAutoSnapPoint` gate inside `Drawer.Content`: the auto-size wrapper now renders + observes unconditionally. Snap math still only consumes `contentHeight` for the `'auto'` branch, so non-`'auto'` detents are unaffected.
- `TrueSheet.web.tsx` tracks `measuredContentHeight` via the new callback and clamps it to compute `effectiveMaxContentHeight`.

## Type of Change

- [x] Bug fix

## Test Plan

- [x] Web (tablet/landscape, `pageSizing={false}`): card grows from min (50%) to max (`viewport - 2*detachedOffset`) as content changes; centers vertically.
- [x] Content taller than viewport: card caps at max, retains `detachedOffset` top + bottom margin.
- [x] Content shorter than 50% viewport: card stays at 50% (visual floor preserved).
- [x] User-supplied `maxContentHeight`: respected as before.
- [x] Mobile / `pageSizing={true}`: unaffected.
- [x] `'auto'` detent: unaffected (still measures the same wrapper).
- [ ] iOS / Android: unaffected (no native changes).

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)