### PR TITLE
fix(web): clip Drawer.Content children to rounded top corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Web**: Collapse non-dismissible sheet to a sensible detent on dim tap and Escape, mirroring Android. ([#675](https://github.com/lodev09/react-native-true-sheet/pull/675) by [@lodev09](https://github.com/lodev09))
 - **Web**: Float the grabber over content like native iOS/Android instead of pushing the header down and inflating the `auto` detent. ([#676](https://github.com/lodev09/react-native-true-sheet/pull/676) by [@lodev09](https://github.com/lodev09))
 - **Web**: Size the form sheet (`pageSizing={false}`) to fit content, clamped between half the viewport and `viewport − 2 × detachedOffset`, instead of a fixed 50% cap. ([#677](https://github.com/lodev09/react-native-true-sheet/pull/677) by [@lodev09](https://github.com/lodev09))
+- **Web**: Clip sheet content to the rounded top corners so children with their own background don't bleed past the radius. ([#678](https://github.com/lodev09/react-native-true-sheet/pull/678) by [@lodev09](https://github.com/lodev09))
 
 ## 3.10.1
 

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -607,6 +607,9 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       borderTopLeftRadius: effectiveCornerRadius,
       borderTopRightRadius: effectiveCornerRadius,
       backgroundColor: backgroundColor as string,
+      // Clip children to the rounded top so headers/content with their own
+      // background don't bleed past the corners.
+      overflow: 'hidden',
       // Lift content above iOS home indicator / bottom safe area when enabled.
       paddingBottom: insetAdjustment === 'automatic' ? 'env(safe-area-inset-bottom, 0px)' : 0,
     }),


### PR DESCRIPTION
## Summary

Without `overflow: hidden` on `Drawer.Content`, children with their own background (e.g. a header with `backgroundColor: 'red'`) paint past the sheet's `borderTopLeftRadius`/`Right` and fill in the rounded corners. Adding the clip lets the rounded shape stay clean.

The drop-shadow elevation is unaffected — it's applied via `filter` on the detached wrapper (not `Drawer.Content`), so it traces the post-render silhouette which is unchanged. If anything the shadow now traces the radius more cleanly.

## Type of Change

- [x] Bug fix

## Test Plan

- [x] Web: place a header with `backgroundColor: 'red'` at the top of a sheet → red is clipped to the rounded corners.
- [x] Web: elevation/drop-shadow still renders correctly around the rounded silhouette.
- [ ] iOS / Android: unaffected (no native changes).

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)