### PR TITLE
fix(web): emit will/did focus on initial present and will/did blur on dismiss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **Web**: Float the grabber over content like native iOS/Android instead of pushing the header down and inflating the `auto` detent. ([#676](https://github.com/lodev09/react-native-true-sheet/pull/676) by [@lodev09](https://github.com/lodev09))
 - **Web**: Size the form sheet (`pageSizing={false}`) to fit content, clamped between half the viewport and `viewport − 2 × detachedOffset`, instead of a fixed 50% cap. ([#677](https://github.com/lodev09/react-native-true-sheet/pull/677) by [@lodev09](https://github.com/lodev09))
 - **Web**: Clip sheet content to the rounded top corners so children with their own background don't bleed past the radius. ([#678](https://github.com/lodev09/react-native-true-sheet/pull/678) by [@lodev09](https://github.com/lodev09))
+- **Web**: Fire `onWillFocus`/`onDidFocus` on initial present and `onWillBlur`/`onDidBlur` on dismiss, mirroring native iOS ordering (`willBlur` before `willDismiss`, `didBlur` before `didDismiss`). ([#679](https://github.com/lodev09/react-native-true-sheet/pull/679) by [@lodev09](https://github.com/lodev09))
 
 ## 3.10.1
 

--- a/example/shared/src/components/Header.tsx
+++ b/example/shared/src/components/Header.tsx
@@ -17,7 +17,7 @@ export const Header = ({ children, style, ...rest }: HeaderProps) => {
 const styles = StyleSheet.create({
   container: {
     height: Platform.select({ ios: HEADER_HEIGHT, default: HEADER_HEIGHT + SPACING }),
-    paddingTop: Platform.select({ ios: 0, default: SPACING * 2 }),
+    paddingTop: Platform.select({ ios: undefined, default: SPACING * 2 }),
     justifyContent: 'center',
     padding: SPACING,
   },

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -370,8 +370,15 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
 
     const present = !wasOpen && isOpen;
     if (present) {
+      // Pair willFocus with willPresent on initial present — mirrors native
+      // iOS where viewWillAppear dispatches both. The descendant-stack focus
+      // effect handles subsequent gained/lost transitions.
       onWillPresentRef.current?.({ nativeEvent: computeDetentInfo() } as WillPresentEvent);
+      onWillFocusRef.current?.({ nativeEvent: null } as WillFocusEvent);
     } else if (wasOpen && !isOpen) {
+      // Pair willBlur with willDismiss on dismiss — mirrors native iOS
+      // emitWillDismissEvents (blur fires before dismiss).
+      onWillBlurRef.current?.({ nativeEvent: null } as WillBlurEvent);
       onWillDismissRef.current?.({ nativeEvent: null } as WillDismissEvent);
     } else {
       return undefined;
@@ -380,7 +387,9 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     const fireDone = () => {
       if (present) {
         onDidPresentRef.current?.({ nativeEvent: computeDetentInfo() } as DidPresentEvent);
+        onDidFocusRef.current?.({ nativeEvent: null } as DidFocusEvent);
       } else {
+        onDidBlurRef.current?.({ nativeEvent: null } as DidBlurEvent);
         onDidDismissRef.current?.({ nativeEvent: null } as DidDismissEvent);
       }
     };


### PR DESCRIPTION
## Summary

The web implementation only fired focus/blur on descendant-stack edges (gained/lost), so initial present and direct dismiss were invisible to consumers tracking which sheet is the "currently topmost / focused" one.

Mirror native iOS:

- `viewWillAppear` dispatches `willPresent` and `willFocus`; `viewDidAppear` pairs `didPresent` with `didFocus`.
- `emitWillDismissEvents` fires `willBlur` **before** `willDismiss`; `emitDidDismissEvents` fires `didBlur` before `didDismiss`.

Order on web now matches:

- **Present**: `willPresent → willFocus → (settle) → didPresent → didFocus`
- **Dismiss**: `willBlur → willDismiss → (settle) → didBlur → didDismiss`

The existing descendant-stack focus effect is unchanged — parent regaining focus when a child dismisses, and parent blurring when a child opens, still flow through that path.

## Type of Change

- [x] Bug fix

## Test Plan

- [x] Web: top-level sheet present fires `willFocus` / `didFocus` alongside `willPresent` / `didPresent`.
- [x] Web: top-level sheet dismiss fires `willBlur` / `didBlur` alongside `willDismiss` / `didDismiss`, with `willBlur` before `willDismiss`.
- [x] Web: nested present / dismiss still flows through the descendant-stack focus effect (parent gains/loses focus correctly).
- [ ] iOS / Android: unaffected (no native changes).

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)