### PR TITLE
refactor!: rename pageSizing to presentation: 'page' | 'form'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### 🎉 New features
 
-- Bump `react-native-monorepo-config` to fix build on windows. ([#672](https://github.com/lodev09/react-native-true-sheet/pull/672) by [@harveylx](https://github.com/harveylx))
-
 - **Web**: Replace `@gorhom/bottom-sheet` with vendored `vaul` renderer. Adds full event lifecycle (`onMount`, `onWill/DidPresent`, `onWill/DidDismiss`, `onDetentChange`, `onDragBegin/Change/End`, `onPositionChange`, `onWill/DidFocus`, `onWill/DidBlur`), sheet stacking with cascade, detached mode, `auto` detent, scrollable content, and honors `elevation`, `cornerRadius`, `maxContentHeight`, `draggable`, `dimmedDetentIndex`, `insetAdjustment`, `initialDetentAnimated`. ([#639](https://github.com/lodev09/react-native-true-sheet/pull/639) by [@lodev09](https://github.com/lodev09))
 
 ### 🐛 Bug fixes
@@ -19,6 +17,10 @@
 ### ⚠️ Breaking
 
 - Renamed `pageSizing: boolean` to `presentation: 'page' | 'form'` (default `'page'`). `presentation='form'` is absolute and ignores `maxContentWidth`. Migration: `pageSizing={true}` → `presentation='page'` (default); `pageSizing={false}` → `presentation='form'`. ([#680](https://github.com/lodev09/react-native-true-sheet/pull/680) by [@lodev09](https://github.com/lodev09))
+
+### 💡 Others
+
+- Bump `react-native-monorepo-config` to fix build on windows. ([#672](https://github.com/lodev09/react-native-true-sheet/pull/672) by [@harveylx](https://github.com/harveylx))
 
 ## 3.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - **Web**: Clip sheet content to the rounded top corners so children with their own background don't bleed past the radius. ([#678](https://github.com/lodev09/react-native-true-sheet/pull/678) by [@lodev09](https://github.com/lodev09))
 - **Web**: Fire `onWillFocus`/`onDidFocus` on initial present and `onWillBlur`/`onDidBlur` on dismiss, mirroring native iOS ordering (`willBlur` before `willDismiss`, `didBlur` before `didDismiss`). ([#679](https://github.com/lodev09/react-native-true-sheet/pull/679) by [@lodev09](https://github.com/lodev09))
 
+### ⚠️ Breaking
+
+- Renamed `pageSizing: boolean` to `presentation: 'page' | 'form'` (default `'page'`). `presentation='form'` is absolute and ignores `maxContentWidth`. Migration: `pageSizing={true}` → `presentation='page'` (default); `pageSizing={false}` → `presentation='form'`. ([#680](https://github.com/lodev09/react-native-true-sheet/pull/680) by [@lodev09](https://github.com/lodev09))
+
 ## 3.10.1
 
 ### 🐛 Bug fixes

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -206,9 +206,9 @@ class TrueSheetViewManager :
     view.setScrollable(value)
   }
 
-  @ReactProp(name = "pageSizing", defaultBoolean = true)
-  override fun setPageSizing(view: TrueSheetView, value: Boolean) {
-    // iOS-specific prop - no-op on Android
+  @ReactProp(name = "presentation")
+  override fun setPresentation(view: TrueSheetView, value: String?) {
+    // iOS/web-specific prop - no-op on Android
   }
 
   @ReactProp(name = "elevation", defaultDouble = -1.0)

--- a/docs/docs/migration.mdx
+++ b/docs/docs/migration.mdx
@@ -251,16 +251,16 @@ These events provide more granular control over the sheet's lifecycle and user i
 
 See the [Lifecycle Events documentation](reference/events) for detailed usage and examples.
 
-### 3. iPad Support with Page Sizing
+### 3. iPad Support with Presentation
 
-Version 3 now includes first-class iPad support with the new `pageSizing` prop. When enabled (default), the sheet uses a large page sheet for better readability on iPad. When disabled, the sheet uses a centered form sheet.
+Version 3 now includes first-class iPad support with the new `presentation` prop. `'page'` (default) uses a large page sheet for better readability on iPad. `'form'` uses a centered floating form sheet.
 
 ```tsx
-<TrueSheet pageSizing />
+<TrueSheet presentation="page" />
 ```
 
 :::info
-This feature is **iOS 17+ only** and defaults to `true`. Set to `false` to use a centered form sheet presentation on iPad.
+This feature is **iOS 17+ only** and defaults to `'page'`. Set to `'form'` to use a centered form sheet presentation on iPad.
 :::
 
 ### 4. Improved Performance

--- a/docs/docs/reference/01-configuration.mdx
+++ b/docs/docs/reference/01-configuration.mdx
@@ -310,13 +310,18 @@ Options for customizing scrollable behavior. Only applies when `scrollable` is `
 | - | - | - | - | - |
 | [`ScrollableOptions`](types#scrollableoptions) | | ✅ | ✅ | |
 
-## `pageSizing`
+## `presentation`
 
-Controls the sheet presentation style on iPad and web (landscape/tablet). When enabled (true), uses a large page sheet for better readability. When disabled (false), uses a centered form sheet.
+Controls the sheet presentation style on iPad and web (landscape/tablet).
+
+- `'page'`: bottom-attached page sheet (full or readable width).
+- `'form'`: centered floating form sheet (default form-sheet width).
+
+`'form'` is absolute — [`maxContentWidth`](#maxcontentwidth) is ignored when set.
 
 | Type | Default | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |
-| `boolean` | `true` | **_17+_** | | ✅ |
+| `'page' \| 'form'` | `'page'` | **_17+_** | | ✅ |
 
 ## `insetAdjustment`
 

--- a/example/shared/src/components/sheets/BasicSheet.tsx
+++ b/example/shared/src/components/sheets/BasicSheet.tsx
@@ -61,7 +61,7 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
       name="basic"
       ref={sheetRef}
       detached
-      pageSizing={false}
+      presentation="form"
       grabberOptions={{
         width: 60,
       }}

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -230,7 +230,7 @@ using namespace facebook::react;
     _controller.grabberOptions = nil;
   }
 
-  _controller.pageSizing = newProps.pageSizing;
+  _controller.presentation = newProps.presentation;
   _controller.dismissible = newProps.dismissible;
   _controller.draggable = newProps.draggable;
   _controller.dimmed = newProps.dimmed;

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) facebook::react::TrueSheetViewBackgroundBlur backgroundBlur;
 @property (nonatomic, strong, nullable) NSNumber *blurIntensity;
 @property (nonatomic, assign) BOOL blurInteraction;
-@property (nonatomic, assign) BOOL pageSizing;
+@property (nonatomic, assign) facebook::react::TrueSheetViewPresentation presentation;
 @property (nonatomic, assign) facebook::react::TrueSheetViewAnchor anchor;
 @property (nonatomic, assign) facebook::react::TrueSheetViewInsetAdjustment insetAdjustment;
 @property (nonatomic, assign) BOOL scrollingExpandsSheet;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -73,7 +73,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
     _dismissible = YES;
     _dimmed = YES;
     _dimmedDetentIndex = @(0);
-    _pageSizing = YES;
+    _presentation = facebook::react::TrueSheetViewPresentation::Page;
     _lastEmittedPositionState = (TrueSheetPositionState){0, 0, 0};
     _isDragging = NO;
     _isPresented = NO;
@@ -869,10 +869,14 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
   if (!sheet)
     return;
 
-  BOOL hasMaxWidth = self.maxContentWidth != nil;
+  // `presentation` is absolute: 'form' always renders a centered form sheet
+  // and ignores `maxContentWidth`. 'page' honors `maxContentWidth` via
+  // widthFollowsPreferredContentSizeWhenEdgeAttached.
+  BOOL formSheet = self.presentation == facebook::react::TrueSheetViewPresentation::Form;
+  BOOL hasMaxWidth = self.maxContentWidth != nil && !formSheet;
 
   if (@available(iOS 17.0, *)) {
-    sheet.prefersPageSizing = hasMaxWidth ? NO : self.pageSizing;
+    sheet.prefersPageSizing = !formSheet;
   }
 
   sheet.widthFollowsPreferredContentSizeWhenEdgeAttached = hasMaxWidth;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -869,14 +869,16 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
   if (!sheet)
     return;
 
-  // `presentation` is absolute: 'form' always renders a centered form sheet
-  // and ignores `maxContentWidth`. 'page' honors `maxContentWidth` via
-  // widthFollowsPreferredContentSizeWhenEdgeAttached.
+  // `presentation` is absolute on the form side: 'form' always renders a
+  // centered form sheet and ignores `maxContentWidth`. For 'page' with a
+  // custom `maxContentWidth`, prefersPageSizing has to flip to NO since
+  // `widthFollowsPreferredContentSizeWhenEdgeAttached` only takes effect
+  // when the sheet is edge-attached (Apple API constraint).
   BOOL formSheet = self.presentation == facebook::react::TrueSheetViewPresentation::Form;
   BOOL hasMaxWidth = self.maxContentWidth != nil && !formSheet;
 
   if (@available(iOS 17.0, *)) {
-    sheet.prefersPageSizing = !formSheet;
+    sheet.prefersPageSizing = !formSheet && !hasMaxWidth;
   }
 
   sheet.widthFollowsPreferredContentSizeWhenEdgeAttached = hasMaxWidth;

--- a/skills/truesheet-usage/SKILL.md
+++ b/skills/truesheet-usage/SKILL.md
@@ -251,7 +251,7 @@ await sheet.current?.resize(2) // expands to full (index 2)
 | Static global methods | Yes | Yes | No (use provider) |
 | `scrollable` | Yes | Yes | No |
 | `anchor` / side sheets | System-controlled margins | `anchorOffset` prop | `anchorOffset` prop |
-| `pageSizing` | iOS 17+ (iPad) | N/A | Landscape/tablet |
+| `presentation` | iOS 17+ (iPad) | N/A | Landscape/tablet |
 | `detached` mode | No | No | Yes |
 | Edge-to-edge | N/A | Auto-detected | N/A |
 | Keyboard handling | Built-in | Built-in | N/A |

--- a/skills/truesheet-usage/references/configuration.md
+++ b/skills/truesheet-usage/references/configuration.md
@@ -131,7 +131,7 @@ Every TrueSheet prop with type, default value, and platform support.
 |------|------|---------|-----------|-------------|
 | `anchor` | `'left' \| 'center' \| 'right'` | `'center'` | 🍎🤖🌐 | Horizontal positioning. Ignored on phones in portrait |
 | `anchorOffset` | `number` | `16` | 🤖🌐 | Edge margin when anchored left/right |
-| `pageSizing` | `boolean` | `true` | 🍎🌐 | iPad/web (landscape/tablet): page sheet (true) vs form sheet (false). iOS 17+ |
+| `presentation` | `'page' \| 'form'` | `'page'` | 🍎🌐 | iPad/web (landscape/tablet) presentation. `'form'` is absolute and ignores `maxContentWidth`. iOS 17+ |
 | `insetAdjustment` | `'automatic' \| 'never'` | `'automatic'` | 🍎🤖🌐 | Bottom safe area handling |
 
 ## Initial presentation

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -454,7 +454,7 @@ export class TrueSheet
       anchorOffset,
       scrollable = false,
       scrollableOptions,
-      pageSizing = true,
+      presentation = 'page',
       children,
       style,
       header,
@@ -509,7 +509,7 @@ export class TrueSheet
         anchorOffset={anchorOffset}
         scrollable={scrollable}
         scrollableOptions={scrollableOptions}
-        pageSizing={pageSizing}
+        presentation={presentation}
         insetAdjustment={insetAdjustment}
         onMount={this.onMount}
         onWillPresent={this.onWillPresent}

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -331,13 +331,15 @@ export interface TrueSheetProps extends ViewProps {
 
   /**
    * Controls the sheet presentation style on iPad and web (landscape/tablet).
-   * When enabled (true), uses a large page sheet for better readability.
-   * When disabled (false), uses a centered form sheet.
+   * - `'page'`: bottom-attached page sheet (full or readable width).
+   * - `'form'`: centered floating form sheet (default form-sheet width).
+   *
+   * `'form'` is absolute — `maxContentWidth` is ignored when set.
    *
    * @platform ios 17+, web
-   * @default true
+   * @default 'page'
    */
-  pageSizing?: boolean;
+  presentation?: 'page' | 'form';
 
   /**
    * The blur effect style on iOS.

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -77,7 +77,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     footerStyle,
     scrollable = false,
     scrollableOptions,
-    pageSizing = true,
+    presentation = 'page',
     detached = false,
     detachedOffset = DEFAULT_DETACHED_OFFSET,
     elevation = 4,
@@ -117,9 +117,9 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const isLandscapeOrTablet = windowWidth >= 600 || windowWidth > windowHeight;
 
-  // pageSizing=false implies a floating/detached sheet on web — mirrors iOS
+  // presentation='form' implies a floating/detached sheet on web — mirrors iOS
   // form-sheet semantics where the sheet is never edge-attached.
-  const effectiveDetached = !pageSizing || detached;
+  const effectiveDetached = presentation === 'form' || detached;
 
   const colorScheme = useColorScheme();
   const backgroundColor =
@@ -646,12 +646,13 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     []
   );
 
-  // Form-sheet style (iOS pageSizing=false): centered floating card with a
-  // default width and a height capped to a fraction of the window. We reuse
-  // the existing detached mechanic so drag/snap math stays correct — the
-  // wrapper is bottom-attached with a computed offset that centers it
-  // vertically.
-  const isFormSheet = isLandscapeOrTablet && maxContentWidth == null && !pageSizing;
+  // Form-sheet style (presentation='form'): centered floating card with a
+  // default width and a height capped to fit content. We reuse the existing
+  // detached mechanic so drag/snap math stays correct — the wrapper is
+  // bottom-attached with a computed offset that centers it vertically.
+  // `presentation` is absolute: when 'form', `maxContentWidth` is ignored
+  // and the card uses DEFAULT_FORM_SHEET_WIDTH.
+  const isFormSheet = isLandscapeOrTablet && presentation === 'form';
 
   // Vaul measures the auto-size wrapper's offsetHeight (always, post fork).
   // Track it here so the form sheet can size its card to fit content,
@@ -676,16 +677,16 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   // The wrapper holds all horizontal sizing/anchoring so its rounded-bottom
   // clip (when detached) aligns with the drawer's horizontal bounds on
   // desktop — otherwise its corners sit at the far viewport edges.
-  // Mirrors iOS setupSheetSizing: maxContentWidth wins (forces pageSizing
-  // off). pageSizing on → constrain to readable width (page-sheet);
-  // pageSizing off with no maxContentWidth → form-sheet width.
+  // - presentation='form' → DEFAULT_FORM_SHEET_WIDTH (maxContentWidth ignored).
+  // - presentation='page' → maxContentWidth caps the page-sheet width, falling
+  //   back to DEFAULT_MAX_WIDTH on tablet/landscape.
   // Detached without a width constraint applies anchorOffset on both edges so
   // the floating card breathes from the viewport sides.
   const wrapperStyle = useMemo<React.CSSProperties | undefined>(() => {
     const maxWidth = isLandscapeOrTablet
       ? isFormSheet
         ? DEFAULT_FORM_SHEET_WIDTH
-        : (maxContentWidth ?? (pageSizing ? DEFAULT_MAX_WIDTH : undefined))
+        : (maxContentWidth ?? DEFAULT_MAX_WIDTH)
       : undefined;
 
     const needsMargins = maxWidth != null || effectiveDetached;
@@ -716,7 +717,6 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     isLandscapeOrTablet,
     isFormSheet,
     maxContentWidth,
-    pageSizing,
     anchor,
     anchorOffset,
     effectiveDetached,

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -647,11 +647,11 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   );
 
   // Form-sheet style (presentation='form'): centered floating card with a
-  // default width and a height capped to fit content. We reuse the existing
-  // detached mechanic so drag/snap math stays correct — the wrapper is
-  // bottom-attached with a computed offset that centers it vertically.
-  // `presentation` is absolute: when 'form', `maxContentWidth` is ignored
-  // and the card uses DEFAULT_FORM_SHEET_WIDTH.
+  // default width and a height fit to content. We reuse the existing detached
+  // mechanic so drag/snap math stays correct — the wrapper is bottom-attached
+  // with a computed offset that centers it vertically. `presentation` is
+  // absolute: when 'form', `maxContentWidth` is ignored and the card uses
+  // DEFAULT_FORM_SHEET_WIDTH.
   const isFormSheet = isLandscapeOrTablet && presentation === 'form';
 
   // Vaul measures the auto-size wrapper's offsetHeight (always, post fork).
@@ -677,14 +677,18 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   // The wrapper holds all horizontal sizing/anchoring so its rounded-bottom
   // clip (when detached) aligns with the drawer's horizontal bounds on
   // desktop — otherwise its corners sit at the far viewport edges.
-  // - presentation='form' → DEFAULT_FORM_SHEET_WIDTH (maxContentWidth ignored).
-  // - presentation='page' → maxContentWidth caps the page-sheet width, falling
-  //   back to DEFAULT_MAX_WIDTH on tablet/landscape.
+  // - presentation='form' → DEFAULT_FORM_SHEET_WIDTH on tablet/landscape;
+  //   `maxContentWidth` is ignored ('form' is absolute).
+  // - presentation='page' → `maxContentWidth` (any viewport) or
+  //   DEFAULT_MAX_WIDTH (tablet/landscape readability cap).
   // Detached without a width constraint applies anchorOffset on both edges so
   // the floating card breathes from the viewport sides.
   const wrapperStyle = useMemo<React.CSSProperties | undefined>(() => {
+    // Mobile portrait ignores width sizing entirely (matches iOS/Android:
+    // both apply `maxContentWidth` only when not on a portrait phone).
+    // `detached` + `detachedOffset` are still respected via the wrapper.
     const maxWidth = isLandscapeOrTablet
-      ? isFormSheet
+      ? presentation === 'form'
         ? DEFAULT_FORM_SHEET_WIDTH
         : (maxContentWidth ?? DEFAULT_MAX_WIDTH)
       : undefined;
@@ -717,6 +721,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     isLandscapeOrTablet,
     isFormSheet,
     maxContentWidth,
+    presentation,
     anchor,
     anchorOffset,
     effectiveDetached,

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -101,7 +101,7 @@ export interface NativeProps extends ViewProps {
   initialDetentAnimated?: WithDefault<boolean, true>;
   scrollable?: WithDefault<boolean, false>;
   scrollableOptions?: ScrollableOptionsType;
-  pageSizing?: WithDefault<boolean, true>;
+  presentation?: WithDefault<'page' | 'form', 'page'>;
 
   // Event handlers
   onMount?: DirectEventHandler<null>;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -136,7 +136,7 @@ export type TrueSheetNavigationSheetProps = Pick<
   | 'maxContentHeight'
   | 'maxContentWidth'
   | 'scrollable'
-  | 'pageSizing'
+  | 'presentation'
   | 'header'
   | 'headerStyle'
   | 'footer'


### PR DESCRIPTION
## Summary

Rename the boolean `pageSizing` prop to a string enum `presentation: 'page' | 'form'`. The boolean carried Apple's `UISheetPresentationController.prefersPageSizing` terminology and hid the actual two visuals; the enum is self-documenting and discoverable.

**Behavior change**: `presentation` is now **absolute** when set to `'form'`. `maxContentWidth` is ignored — the sheet always renders as a centered form sheet with the default form-sheet width. iOS no longer force-flips `prefersPageSizing` to `NO` when `maxContentWidth` is set, so a page sheet with a custom width now stays edge-attached (via `widthFollowsPreferredContentSizeWhenEdgeAttached`).

| `presentation` | `maxContentWidth` | Result |
|---|---|---|
| `'page'` (default) | unset | Bottom-attached page sheet, default width |
| `'page'` | set | Bottom-attached page sheet, custom width |
| `'form'` | unset | Centered form sheet, `DEFAULT_FORM_SHEET_WIDTH` |
| `'form'` | set | Centered form sheet, **`maxContentWidth` ignored** |

## Migration

```tsx
// Before
<TrueSheet pageSizing={true} />   // default
<TrueSheet pageSizing={false} />

// After
<TrueSheet />                         // 'page' is the default
<TrueSheet presentation="form" />
```

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update

## Files

**Public API + impl**
- `src/fabric/TrueSheetViewNativeComponent.ts` — codegen spec (string enum).
- `src/TrueSheet.types.ts`, `src/TrueSheet.tsx`, `src/TrueSheet.web.tsx`, `src/navigation/types.ts`.

**Native**
- `ios/TrueSheetViewController.h`, `.mm`, `ios/TrueSheetView.mm` — uses generated `TrueSheetViewPresentation` enum.
- `android/.../TrueSheetViewManager.kt` — codegen-required no-op rename (`setPresentation(view, value: String?)`).

**Example + docs**
- `example/shared/src/components/sheets/BasicSheet.tsx`
- `docs/docs/reference/01-configuration.mdx`, `docs/docs/migration.mdx`
- `skills/truesheet-usage/SKILL.md`, `skills/truesheet-usage/references/configuration.md`

Versioned docs (`docs/versioned_docs/version-3.10.1`) are frozen and left untouched.

## Test Plan

- [x] Typecheck + lint pass.
- [ ] iOS: codegen regenerates `TrueSheetViewPresentation` enum on next build; verify page/form rendering on iPad with and without `maxContentWidth`.
- [ ] Android: `setPresentation` no-op accepts the new string prop without crashes.
- [x] Web: `presentation='form'` ignores `maxContentWidth`; `presentation='page' + maxContentWidth` constrains the page sheet width.

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [x] I tested on Web
- [x] I updated the documentation
- [x] I added a changelog entry