### PR TITLE
fix(web): detached/form slide-in, scroll, footer click, grabber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Web**: New `vaul`-based renderer replacing `@gorhom/bottom-sheet`, with full feature parity. ([#639](https://github.com/lodev09/react-native-true-sheet/pull/639), [#675](https://github.com/lodev09/react-native-true-sheet/pull/675), [#676](https://github.com/lodev09/react-native-true-sheet/pull/676), [#677](https://github.com/lodev09/react-native-true-sheet/pull/677), [#678](https://github.com/lodev09/react-native-true-sheet/pull/678), [#679](https://github.com/lodev09/react-native-true-sheet/pull/679) by [@lodev09](https://github.com/lodev09))
 
+### 🐛 Bug fixes
+
+- **Web**: Fixed detached/form sheet autopresent animation, scrollable content, footer click, and grabber drag interactions. ([#684](https://github.com/lodev09/react-native-true-sheet/pull/684) by [@lodev09](https://github.com/lodev09))
+
 ### ⚠️ Breaking
 
 - Renamed `pageSizing: boolean` to `presentation: 'page' | 'form'` (default `'page'`). `presentation='form'` is absolute and ignores `maxContentWidth`. Migration: `pageSizing={true}` → `presentation='page'` (default); `pageSizing={false}` → `presentation='form'`. ([#680](https://github.com/lodev09/react-native-true-sheet/pull/680) by [@lodev09](https://github.com/lodev09))

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -76,7 +76,6 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     footer,
     footerStyle,
     scrollable = false,
-    scrollableOptions,
     presentation = 'page',
     detached = false,
     detachedOffset = DEFAULT_DETACHED_OFFSET,
@@ -771,7 +770,6 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       onRelease={handleRelease}
       dismissible={dismissible}
       draggable={draggable}
-      handleOnly={scrollable && scrollableOptions?.scrollingExpandsSheet === false}
       repositionInputs={false}
       modal={dimmed}
       nested={isNested}

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -754,7 +754,10 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       borderRadius: grabberOptions?.cornerRadius ?? grabberHeight / 2,
       backgroundColor: (grabberOptions?.color ?? defaultGrabberColor) as string,
       opacity: 1,
-      zIndex: 1,
+      // Above absolute-positioned headers (which often use zIndex:1 to overlay
+      // scroll content) so the grabber stays draggable — critical when
+      // `handleOnly` mode means only the grabber can drag the sheet.
+      zIndex: 2,
     }),
     [grabberOptions, grabberHeight, defaultGrabberColor]
   );

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -790,17 +790,31 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
         >
           <Drawer.Title style={visuallyHiddenStyle}>Sheet</Drawer.Title>
           {grabber && <Drawer.Handle style={handleStyle} />}
-          {header && (
-            <View style={headerStyle}>
-              {isValidElement(header) ? header : createElement(header)}
-            </View>
-          )}
           {scrollable ? (
-            <div style={scrollableContainerStyle}>
-              <View style={style}>{children}</View>
+            // vaul wraps children in `[data-vaul-auto-size-wrapper]` (display:
+            // flow-root) which doesn't honor descendant flex layout. Use an
+            // absolute fill sized to the visible portion (via vaul's
+            // `--snap-point-height` var) so the inner flex column has a
+            // definite height for the scroll container's flex:1 to fill.
+            <div style={scrollableLayoutStyle}>
+              {header && (
+                <View style={headerStyle}>
+                  {isValidElement(header) ? header : createElement(header)}
+                </View>
+              )}
+              <div style={scrollableContainerStyle}>
+                <View style={style}>{children}</View>
+              </div>
             </div>
           ) : (
-            <View style={style}>{children}</View>
+            <>
+              {header && (
+                <View style={headerStyle}>
+                  {isValidElement(header) ? header : createElement(header)}
+                </View>
+              )}
+              <View style={style}>{children}</View>
+            </>
           )}
         </Drawer.Content>
       </Drawer.Portal>
@@ -812,6 +826,16 @@ const overlayStyle: React.CSSProperties = {
   position: 'fixed',
   inset: 0,
   backgroundColor: 'rgba(0, 0, 0, 0.5)',
+};
+
+const scrollableLayoutStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  height: 'calc(100% - var(--snap-point-height, 0px))',
+  display: 'flex',
+  flexDirection: 'column',
 };
 
 const scrollableContainerStyle: React.CSSProperties = {

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -171,6 +171,17 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     // in another screen's tree when navigating) should not close the drawer.
     if (portalContainer && !portalContainer.contains(target)) {
       e.preventDefault();
+      return;
+    }
+    // The footer is rendered via vaul's `detachedSiblings` as a sibling of
+    // Drawer.Content inside [data-vaul-detached-wrapper], so Radix treats
+    // clicks on it as "outside" the content. Don't dismiss for clicks that
+    // landed inside the wrapper.
+    if (target instanceof Element) {
+      const wrapper = drawerContentRef.current?.closest('[data-vaul-detached-wrapper]');
+      if (wrapper && wrapper.contains(target)) {
+        e.preventDefault();
+      }
     }
   };
 

--- a/src/web/vaul/index.tsx
+++ b/src/web/vaul/index.tsx
@@ -1251,7 +1251,10 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(
     // Translate the wrapper off-screen on dismiss so the whole card slides out
     // as one. The reset-then-target pattern on open forces the browser to
     // record a starting value so the transition actually animates.
-    const wasOpenRef = React.useRef(isOpen);
+    // Start at `false` so a mount with `isOpen=true` (autopresent via
+    // `initialDetentIndex`) is detected as a false→true transition and runs
+    // the slide-up animation instead of snapping straight to rest.
+    const wasOpenRef = React.useRef(false);
     React.useEffect(() => {
       if (!drawerRef.current) {
         wasOpenRef.current = isOpen;
@@ -1269,10 +1272,6 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(
           wrapper.style.transform = `translate3d(0, ${viewportH}px, 0)`;
           // eslint-disable-next-line no-void
           void wrapper.offsetHeight;
-          wrapper.style.transition = transition;
-          wrapper.style.transform = 'translate3d(0, 0, 0)';
-        } else if (isOpen && !wrapper.style.transform) {
-          // Fresh mount with open=true — ensure the wrapper starts at rest.
           wrapper.style.transition = transition;
           wrapper.style.transform = 'translate3d(0, 0, 0)';
         }


### PR DESCRIPTION
## Summary

A handful of web-only fixes for detached/form-mode sheets:

- **Slide-in on autopresent**: `Content`'s `wasOpenRef` started as `isOpen`, so a mount with `initialDetentIndex` set saw no transition and snapped straight to rest. Initialize to `false` so the first render is detected as a false→true transition and runs the slide-up animation.
- **Scrollable content not scrolling**: vaul wraps content in `[data-vaul-auto-size-wrapper]` (`display: flow-root`), which doesn't propagate height to descendant flex children. Wrap the scrollable branch's header + scroll container in an absolute-positioned flex column sized to `calc(100% - var(--snap-point-height, 0px))` so the inner `flex: 1` scroll area has a definite height.
- **Footer click dismissing the sheet**: the footer renders as a vaul `detachedSiblings` sibling of `Drawer.Content`, so Radix treats clicks on it as outside. Detect clicks inside `[data-vaul-detached-wrapper]` in `handleDismiss` and `preventDefault()`.
- **Grabber not draggable under header**: bump grabber `zIndex` from 1 → 2 so absolute-positioned headers (which commonly use `zIndex: 1`) don't cover it — important when only the grabber can drag.
- **Drop `scrollingExpandsSheet` → `handleOnly` mapping**: removed, no longer needed after the scroll fix.

## Type of Change

- [x] Bug fix

## Test Plan

- [ ] Tested on Web (detached/form mode autopresent slide-in)
- [ ] Tested on Web (scrollable content scrolls inside the sheet)
- [ ] Tested on Web (footer click does not dismiss)
- [ ] Tested on Web (grabber draggable with overlaid header)

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)