### PR TITLE
Fix Mac Catalyst build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - **Web**: Fixed detached/form sheet autopresent animation, scrollable content, footer click, and grabber drag interactions. ([#684](https://github.com/lodev09/react-native-true-sheet/pull/684) by [@lodev09](https://github.com/lodev09))
 
+- **iOS**: Fixed Mac Catalyst build issue. ([#685](https://github.com/lodev09/react-native-true-sheet/pull/685) by [@theeket](https://github.com/theeket))
+
 ### ⚠️ Breaking
 
 - Renamed `pageSizing: boolean` to `presentation: 'page' | 'form'` (default `'page'`). `presentation='form'` is absolute and ignores `maxContentWidth`. Migration: `pageSizing={true}` → `presentation='page'` (default); `pageSizing={false}` → `presentation='form'`. ([#680](https://github.com/lodev09/react-native-true-sheet/pull/680) by [@lodev09](https://github.com/lodev09))

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -739,7 +739,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
   _blurView.blurInteraction = self.blurInteraction;
   [_blurView applyBlurEffect];
 
-#if RNTS_IPHONE_OS_VERSION_AVAILABLE(26_1)
+#if RNTS_IPHONE_OS_VERSION_AVAILABLE(26_1) && !TARGET_OS_MACCATALYST
   if (@available(iOS 26.1, *)) {
     if (!self.isDesignCompatibilityMode) {
       if (self.backgroundColor) {


### PR DESCRIPTION
## Summary

Fix Mac Catalyst build failure with the following error:

```
'backgroundEffect' is unavailable: not available on macCatalyst
```

This can easily be fixed by wrapping with:
```objc
#if !TARGET_OS_MACCATALYST
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

After applying this patch, `react-native-true-sheet` works perfectly fine on Mac Catalyst as a native macOS modal, with a few platform-specific behaviors (which is perfectly fine):

* Always animated from top as native modal.
* Not dismissible regardless of the `dismissible` prop (native behavior). It can still be dismissed programmatically via `.dismiss()`.
* Always uses full window height regardless of `detents`. The height can still be adjusted using `maxContentHeight`.

## Screenshots / Videos

Before Fix:
<img width="1076" height="720" alt="01" src="https://github.com/user-attachments/assets/1a30127a-4e88-4b61-acdb-dfab289fe3b6" />

After Fix (Example):
<img width="1511" height="720" alt="02" src="https://github.com/user-attachments/assets/ec65d03a-6c7f-4d88-a69d-d58e805849f1" />


## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)
