### PR TITLE
fix(ios): apply pending footer height to fix recycled-view race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - **iOS**: Fixed Mac Catalyst build issue. ([#685](https://github.com/lodev09/react-native-true-sheet/pull/685) by [@theeket](https://github.com/theeket))
 
+- **iOS**: Fixed footer rendering at the bottom of the content view instead of the bottom of the sheet when the footer view is recycled across present cycles. ([#688](https://github.com/lodev09/react-native-true-sheet/pull/688) by [@lucaswickstrom](https://github.com/lucaswickstrom))
+
 ### ⚠️ Breaking
 
 - Renamed `pageSizing: boolean` to `presentation: 'page' | 'form'` (default `'page'`). `presentation='form'` is absolute and ignores `maxContentWidth`. Migration: `pageSizing={true}` → `presentation='page'` (default); `pageSizing={false}` → `presentation='form'`. ([#680](https://github.com/lodev09/react-native-true-sheet/pull/680) by [@lodev09](https://github.com/lodev09))

--- a/ios/TrueSheetFooterView.mm
+++ b/ios/TrueSheetFooterView.mm
@@ -21,6 +21,7 @@ using namespace facebook::react;
 
 @implementation TrueSheetFooterView {
   CGFloat _lastHeight;
+  CGFloat _pendingHeight;
   BOOL _didInitialLayout;
   NSLayoutConstraint *_bottomConstraint;
   CGFloat _currentKeyboardOffset;
@@ -38,6 +39,7 @@ using namespace facebook::react;
     self.backgroundColor = [UIColor clearColor];
 
     _lastHeight = 0;
+    _pendingHeight = 0;
     _didInitialLayout = NO;
     _bottomConstraint = nil;
     _currentKeyboardOffset = 0;
@@ -50,6 +52,11 @@ using namespace facebook::react;
 - (void)setupConstraintsWithHeight:(CGFloat)height {
   UIView *parentView = self.superview;
   if (!parentView) {
+    // On recycled views, updateLayoutMetrics can fire before the view is
+    // reparented. Remember the desired height so didMoveToSuperview applies
+    // it instead of falling back to the stale self.frame from the previous
+    // present cycle.
+    _pendingHeight = height;
     return;
   }
 
@@ -70,13 +77,14 @@ using namespace facebook::react;
   }
 
   _lastHeight = height;
+  _pendingHeight = 0;
 }
 
 - (void)didMoveToSuperview {
   [super didMoveToSuperview];
 
   if (self.superview) {
-    CGFloat initialHeight = self.frame.size.height;
+    CGFloat initialHeight = _pendingHeight > 0 ? _pendingHeight : self.frame.size.height;
     [self setupConstraintsWithHeight:initialHeight];
   }
 }
@@ -105,6 +113,7 @@ using namespace facebook::react;
   }
 
   _lastHeight = 0;
+  _pendingHeight = 0;
   _didInitialLayout = NO;
   _bottomConstraint = nil;
   _currentKeyboardOffset = 0;


### PR DESCRIPTION
## Summary

Fixes the footer rendering at the bottom of the content instead of the bottom of the sheet when `TrueSheetFooterView` is reused across present cycles. See discussion #645.

`updateLayoutMetrics` can fire before the footer is reparented, so `setupConstraintsWithHeight:` early-returns (superview is nil) and the incoming height is dropped. Then `didMoveToSuperview` falls back to `self.frame.size.height`, which on a recycled view is the stale frame from the previous present cycle, so the footer ends up anchored to the wrong edge.

Fix: stash the height as `_pendingHeight` when superview is nil, and use it in `didMoveToSuperview` instead of the stale frame. Reset in `prepareForRecycle`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Not reproducible locally. Validated in production via the equivalent yarn patch. User reports stopped after rollout.

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android (iOS-only change)
- [ ] I tested on Web (iOS-only change)
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)