### PR TITLE
Enhance resize function to track detent index changes

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -705,14 +705,22 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   fun resize(detentIndex: Int) {
     if (!isPresented) return
-
     // Commit the new index so keyboardWillHide restores to it instead of the stale one
     if (detentIndexBeforeKeyboard >= 0) {
       detentIndexBeforeKeyboard = detentIndex
     }
-
     setupDimmedBackground()
+    
+    val oldIndex = currentDetentIndex
+    currentDetentIndex = detentIndex
+    
     setStateForDetentIndex(detentIndex)
+    
+    if (oldIndex != detentIndex) {
+      val (index, position, detent) = getDetentInfoWithValue(detentIndex)
+      delegate?.viewControllerDidChangeDetent(index, position, detent)
+      sheetView?.updateGrabberAccessibilityValue(index, detents.size)
+    }
     resizePromise?.invoke()
     resizePromise = null
   }


### PR DESCRIPTION
fix(android): prevent TrueSheet collapse to detent 0 on dynamic content layout changes

## Summary

<!-- Describe what this PR does and why -->

## Type of Change

- [✅ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

[repro](https://github.com/allthetime/true_sheet_android_resize_collapse_bug)

## Checklist

- [✅ ] I tested on iOS
- [ ✅] I tested on Android
- [ ] I tested on Web *code only touches one android native file)*
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)
