### PR TITLE
fix(web): center form sheet using measured drawer height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - **iOS**: Fixed footer rendering at the bottom of the content view instead of the bottom of the sheet when the footer view is recycled across present cycles. ([#688](https://github.com/lodev09/react-native-true-sheet/pull/688) by [@lucaswickstrom](https://github.com/lucaswickstrom))
 
+- **Web**: Center `presentation='form'` sheet vertically when content is short instead of resting against the bottom. ([#692](https://github.com/lodev09/react-native-true-sheet/pull/692) by [@lodev09](https://github.com/lodev09))
+
 ### ⚠️ Breaking
 
 - Renamed `pageSizing: boolean` to `presentation: 'page' | 'form'` (default `'page'`). `presentation='form'` is absolute and ignores `maxContentWidth`. Migration: `pageSizing={true}` → `presentation='page'` (default); `pageSizing={false}` → `presentation='form'`. ([#680](https://github.com/lodev09/react-native-true-sheet/pull/680) by [@lodev09](https://github.com/lodev09))

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -750,9 +750,19 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     return Math.max(min, Math.min(measuredContentHeight, max));
   }, [maxContentHeight, isFormSheet, windowHeight, detachedOffset, measuredContentHeight]);
 
-  const effectiveDetachedOffset = isFormSheet
-    ? Math.max(0, (windowHeight - (effectiveMaxContentHeight ?? 0)) / 2)
-    : detachedOffset;
+  // Center the form sheet using the actual visible drawer height. Vaul
+  // auto-sizes to content (capped by `maxContentHeight`), so when content is
+  // shorter than `effectiveMaxContentHeight`'s min-clamped floor, using that
+  // for the offset would push a small sheet below the viewport center.
+  const effectiveDetachedOffset = useMemo(() => {
+    if (!isFormSheet) return detachedOffset;
+    const max = Math.max(0, windowHeight - 2 * detachedOffset);
+    const visibleHeight =
+      measuredContentHeight > 0
+        ? Math.min(measuredContentHeight, max)
+        : (effectiveMaxContentHeight ?? 0);
+    return Math.max(0, (windowHeight - visibleHeight) / 2);
+  }, [isFormSheet, windowHeight, detachedOffset, measuredContentHeight, effectiveMaxContentHeight]);
 
   // The wrapper holds all horizontal sizing/anchoring so its rounded-bottom
   // clip (when detached) aligns with the drawer's horizontal bounds on


### PR DESCRIPTION
## Summary

`presentation='form'` form sheet sat below viewport center when its content was short. The bottom offset was computed from `effectiveMaxContentHeight`, which is min-clamped to `windowHeight * 0.5`, but vaul auto-sizes the drawer to actual content (cap-only), so the offset assumed a taller card than was rendered.

Now centers using the actual visible drawer height (`measuredContentHeight` clamped to the available max), with a fallback to `effectiveMaxContentHeight` before the first measurement.

## Type of Change

- [x] Bug fix

## Test Plan

- [x] Form sheet with very short content stays vertically centered on web
- [x] Form sheet with content > viewport still caps and centers correctly
- [x] `presentation='page'` unaffected

## Checklist

- [x] I tested on Web
- [ ] I added a changelog entry