### PR TITLE
fix(android): preserve resize target when content size changes mid-animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - **iOS**: Fixed Mac Catalyst build issue. ([#685](https://github.com/lodev09/react-native-true-sheet/pull/685) by [@theeket](https://github.com/theeket))
 - **iOS**: Fixed footer rendering at the bottom of the content view instead of the bottom of the sheet when the footer view is recycled across present cycles. ([#688](https://github.com/lodev09/react-native-true-sheet/pull/688) by [@lucaswickstrom](https://github.com/lucaswickstrom))
+- **Android**: Fixed `resize()` being interrupted when sheet content size changes during the animation, causing the sheet to revert to the previous detent. ([#693](https://github.com/lodev09/react-native-true-sheet/pull/693) by [@lodev09](https://github.com/lodev09))
 
 ### ⚠️ Breaking
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -153,6 +153,11 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   var currentDetentIndex: Int = -1
     private set
 
+  // Target detent index during an in-flight resize animation. -1 when idle.
+  // Used by setupSheetDetents so a layout-driven reconfigure during the
+  // animation doesn't snap the sheet back to the stale currentDetentIndex.
+  private var pendingDetentIndex: Int = -1
+
   private var interactionState: InteractionState = InteractionState.Idle
   internal var isBeingDismissed = false
     private set
@@ -376,6 +381,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     isPresentAnimating = false
     lastEmittedPositionPx = -1
     detentIndexBeforeKeyboard = -1
+    pendingDetentIndex = -1
     isKeyboardDismissProgrammatic = false
     focusedViewBeforeBlur = null
     shouldAnimatePresent = true
@@ -568,6 +574,10 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   private fun handleStateSettled(sheetView: View, newState: Int) {
     if (interactionState is InteractionState.Reconfiguring) return
 
+    // Sheet has reached a stable state — any in-flight resize target is now stale,
+    // whether settled at the target, interrupted by drag, or superseded.
+    pendingDetentIndex = -1
+
     val index = detentCalculator.getDetentIndexForState(newState) ?: return
     val position = getPositionDpForView(sheetView)
     val detentInfo = DetentInfo(index, position)
@@ -711,6 +721,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
       detentIndexBeforeKeyboard = detentIndex
     }
 
+    pendingDetentIndex = detentIndex
     setupDimmedBackground()
     setStateForDetentIndex(detentIndex)
     resizePromise?.invoke()
@@ -859,7 +870,10 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     updateStateDimensions(expandedOffset)
 
     if (isPresented && applyState) {
-      setStateForDetentIndex(currentDetentIndex)
+      // Prefer the pending target while a resize animation is in flight so a
+      // layout-driven reconfigure doesn't revert to the stale currentDetentIndex.
+      val targetIndex = if (pendingDetentIndex >= 0) pendingDetentIndex else currentDetentIndex
+      setStateForDetentIndex(targetIndex)
     }
 
     interactionState = InteractionState.Idle
@@ -1019,7 +1033,9 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
       delegate = object : TrueSheetKeyboardObserverDelegate {
         override fun keyboardWillShow(height: Int) {
           if (!shouldHandleKeyboard()) return
-          detentIndexBeforeKeyboard = currentDetentIndex
+          // If a resize is in flight, restore to its target — not the stale current
+          detentIndexBeforeKeyboard = if (pendingDetentIndex >= 0) pendingDetentIndex else currentDetentIndex
+          pendingDetentIndex = -1
           setupSheetDetents()
           currentDetentIndex = detents.size - 1
           setStateForDetentIndex(currentDetentIndex)
@@ -1097,6 +1113,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   private fun handleDragBegin(sheetView: View) {
     detentIndexBeforeKeyboard = -1
+    pendingDetentIndex = -1
 
     val position = getPositionDpForView(sheetView)
     val detent = detentCalculator.getDetentValueForIndex(currentDetentIndex)


### PR DESCRIPTION
## Summary

If content swaps inside the sheet while `resize()` is animating, the sheet snaps back to the previous detent on Android instead of completing the resize.

**Root cause:** `resize(detentIndex)` triggers a BottomSheet animation but only updates `currentDetentIndex` later, in `handleStateSettled`, once the animation lands. If a content layout change fires mid-flight, `containerViewContentDidChangeSize` → `updateSheetIfNeeded()` posts `setupSheetDetentsForSizeChange()`, which calls `setStateForDetentIndex(currentDetentIndex)` — but `currentDetentIndex` is still the pre-resize value, so the in-flight animation is interrupted and the sheet reverts.

**Fix:** Track the resize target in a new private `pendingDetentIndex`. `setupSheetDetents` uses it (when set) instead of the stale `currentDetentIndex`. Cleared on settle, drag begin, keyboard show, and cleanup so it can never go stale.

Bonus: `keyboardWillShow` while a resize is in flight now saves the resize target as the restore index instead of the stale pre-resize current — restoring to the right place on keyboard hide.

Repro: https://github.com/allthetime/true_sheet_android_resize_collapse_bug
Fixes #689

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- [x] Reproduced on Android with the linked repro: resize(1) + simultaneous content height swap → sheet now completes the resize instead of collapsing
- [x] Verified normal `resize()` flow still works (no in-flight content change)
- [x] Verified drag still overrides an in-flight resize
- [x] iOS unaffected (no changes)

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)