### PR TITLE
fix(navigation): support Expo Router SDK 56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **iOS**: Fixed Mac Catalyst build issue. ([#685](https://github.com/lodev09/react-native-true-sheet/pull/685) by [@theeket](https://github.com/theeket))
 - **iOS**: Fixed footer rendering at the bottom of the content view instead of the bottom of the sheet when the footer view is recycled across present cycles. ([#688](https://github.com/lodev09/react-native-true-sheet/pull/688) by [@lucaswickstrom](https://github.com/lucaswickstrom))
 - **Android**: Fixed `resize()` being interrupted when sheet content size changes during the animation, causing the sheet to revert to the previous detent. ([#693](https://github.com/lodev09/react-native-true-sheet/pull/693) by [@lodev09](https://github.com/lodev09))
+- Fixed the Sheet Navigator breaking under Expo Router SDK 56 by importing from `@react-navigation/core` (auto-rewritten to `expo-router/react-navigation` on SDK 56, resolves normally in bare projects). The optional peer dependency changed from `@react-navigation/native` to `@react-navigation/core`. ([#695](https://github.com/lodev09/react-native-true-sheet/pull/695) by [@lodev09](https://github.com/lodev09))
 
 ### ⚠️ Breaking
 

--- a/docs/docs/guides/navigation.mdx
+++ b/docs/docs/guides/navigation.mdx
@@ -232,7 +232,8 @@ import {
   type TrueSheetNavigationOptions,
   type TrueSheetNavigationState,
 } from '@lodev09/react-native-true-sheet/navigation';
-import type { ParamListBase } from '@react-navigation/native';
+
+type ParamListBase = Record<string, object | undefined>;
 
 const { Navigator } = createTrueSheetNavigator();
 
@@ -260,6 +261,10 @@ export default function SheetLayout() {
 ```
 
 See [Expo Router docs](https://docs.expo.dev/router/introduction/) for more information.
+
+:::note
+The Sheet Navigator works with Expo Router SDK 56+ without installing `@react-navigation/native`. Under SDK 56, Expo Router no longer allows app code to import directly from `@react-navigation/*` — import navigation types/utilities from `expo-router` (or `expo-router/react-navigation`) instead. See the [Expo Router SDK 55 → 56 migration guide](https://docs.expo.dev/router/migrate/sdk-55-to-56/).
+:::
 
 ## Navigating from Sheets
 

--- a/docs/docs/guides/navigation.mdx
+++ b/docs/docs/guides/navigation.mdx
@@ -12,7 +12,7 @@ TrueSheet integrates with React Navigation out of the box. It just works!
 
 ## How?
 
-You can use the [Sheet Navigator](#sheet-navigator) to present screens as sheets, or simply [navigate from within sheets](#navigating-from-sheets) using your existing navigation setup.
+You can use the [Sheet Navigator](#sheet-navigator) to present screens as sheets (also works with [Expo Router](#expo-router)), or simply [navigate from within sheets](#navigating-from-sheets) using your existing navigation setup.
 
 ## Sheet Navigator
 
@@ -212,9 +212,9 @@ function DetailsSheet() {
 
 See [Lifecycle Events](../reference/events) for more details.
 
-### Expo Router
+## Expo Router
 
-TrueSheet works with Expo Router using `withLayoutContext`.
+The [Sheet Navigator](#sheet-navigator) works with Expo Router using `withLayoutContext`. All [navigator features](#sheet-navigator) above (screen options, reanimated, dynamic header/footer, listeners) apply here too.
 
 ```
 app/

--- a/example/expo/metro.config.js
+++ b/example/expo/metro.config.js
@@ -20,6 +20,13 @@ const baseConfig = withMetroConfig(getDefaultConfig(__dirname), {
 const originalResolveRequest = baseConfig.resolver.resolveRequest;
 
 baseConfig.resolver.resolveRequest = (context, moduleName, platform) => {
+  // Mirror Expo CLI's rewrite of @react-navigation/core -> expo-router/react-navigation.
+  // The CLI only applies this to imports originating from node_modules; here the library
+  // is resolved from source, so do it explicitly to exercise the real consumer path.
+  if (moduleName === '@react-navigation/core') {
+    return context.resolveRequest(context, 'expo-router/react-navigation', platform);
+  }
+
   // Handle subpath exports for the main package (e.g., @lodev09/react-native-true-sheet/reanimated)
   if (moduleName.startsWith(pkg.name + '/')) {
     context = {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@react-native/babel-preset": "^0.85.3",
     "@react-native/eslint-config": "^0.85.3",
     "@react-native/jest-preset": "^0.85.3",
+    "@react-navigation/core": "^7.13.7",
     "@react-navigation/native": "^7.1.6",
     "@release-it/conventional-changelog": "^11.0.0",
     "@testing-library/react-native": "^13.3.3",
@@ -125,7 +126,7 @@
   "peerDependencies": {
     "@radix-ui/react-dialog": ">=1",
     "@radix-ui/react-presence": ">=1",
-    "@react-navigation/native": ">=7",
+    "@react-navigation/core": ">=7",
     "react": "*",
     "react-native": "*",
     "react-native-reanimated": ">=4",
@@ -138,7 +139,7 @@
     "@radix-ui/react-presence": {
       "optional": true
     },
-    "@react-navigation/native": {
+    "@react-navigation/core": {
       "optional": true
     },
     "react-native-reanimated": {

--- a/src/navigation/TrueSheetRouter.ts
+++ b/src/navigation/TrueSheetRouter.ts
@@ -7,7 +7,7 @@ import {
   type StackActionType,
   StackActions,
   type StackRouterOptions,
-} from '@react-navigation/native';
+} from '@react-navigation/core';
 
 import type { TrueSheetNavigationState } from './types';
 

--- a/src/navigation/TrueSheetView.tsx
+++ b/src/navigation/TrueSheetView.tsx
@@ -1,4 +1,4 @@
-import type { ParamListBase } from '@react-navigation/native';
+import type { ParamListBase } from '@react-navigation/core';
 
 import type {
   TrueSheetDescriptorMap,

--- a/src/navigation/createTrueSheetNavigator.tsx
+++ b/src/navigation/createTrueSheetNavigator.tsx
@@ -5,7 +5,7 @@ import {
   type StaticConfig,
   type TypedNavigator,
   useNavigationBuilder,
-} from '@react-navigation/native';
+} from '@react-navigation/core';
 
 import { TrueSheetRouter, type TrueSheetRouterOptions } from './TrueSheetRouter';
 import { TrueSheetView } from './TrueSheetView';

--- a/src/navigation/screen/types.ts
+++ b/src/navigation/screen/types.ts
@@ -1,4 +1,4 @@
-import type { ParamListBase } from '@react-navigation/native';
+import type { ParamListBase } from '@react-navigation/core';
 
 import type { TrueSheetProps } from '../../TrueSheet.types';
 import type {

--- a/src/navigation/screen/useSheetScreenState.ts
+++ b/src/navigation/screen/useSheetScreenState.ts
@@ -23,7 +23,7 @@ import type {
   TrueSheetNavigationProp,
 } from '../types';
 import { TrueSheetActions } from '../TrueSheetRouter';
-import type { ParamListBase } from '@react-navigation/native';
+import type { ParamListBase } from '@react-navigation/core';
 
 type EmitFn = TrueSheetNavigationHelpers['emit'];
 

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -7,7 +7,7 @@ import type {
   ParamListBase,
   RouteProp,
   StackActionHelpers,
-} from '@react-navigation/native';
+} from '@react-navigation/core';
 
 import type {
   DetentInfoEventPayload,

--- a/src/navigation/useTrueSheetNavigation.ts
+++ b/src/navigation/useTrueSheetNavigation.ts
@@ -1,4 +1,4 @@
-import { useNavigation, type ParamListBase } from '@react-navigation/native';
+import { useNavigation, type ParamListBase } from '@react-navigation/core';
 
 import type { TrueSheetNavigationProp } from './types';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,6 +6149,7 @@ __metadata:
     "@react-native/babel-preset": "npm:^0.85.3"
     "@react-native/eslint-config": "npm:^0.85.3"
     "@react-native/jest-preset": "npm:^0.85.3"
+    "@react-navigation/core": "npm:^7.13.7"
     "@react-navigation/native": "npm:^7.1.6"
     "@release-it/conventional-changelog": "npm:^11.0.0"
     "@testing-library/react-native": "npm:^13.3.3"
@@ -6175,7 +6176,7 @@ __metadata:
   peerDependencies:
     "@radix-ui/react-dialog": ">=1"
     "@radix-ui/react-presence": ">=1"
-    "@react-navigation/native": ">=7"
+    "@react-navigation/core": ">=7"
     react: "*"
     react-native: "*"
     react-native-reanimated: ">=4"
@@ -6185,7 +6186,7 @@ __metadata:
       optional: true
     "@radix-ui/react-presence":
       optional: true
-    "@react-navigation/native":
+    "@react-navigation/core":
       optional: true
     react-native-reanimated:
       optional: true


### PR DESCRIPTION
## Summary

The Sheet Navigator integration broke under Expo Router SDK 56: expo-router's metro resolver throws on `@react-navigation/*` imports. This switches the integration to import from `@react-navigation/core`, which:

- **Expo Router SDK 56+**: Expo CLI auto-rewrites `@react-navigation/core` imports (from `node_modules`) to `expo-router/react-navigation`, so the navigator works without installing `@react-navigation/native`.
- **Bare projects**: `@react-navigation/core` resolves normally as a transitive dep of `@react-navigation/native`.

Changes:
- `src/navigation/*`: import from `@react-navigation/core` instead of `@react-navigation/native`.
- `package.json`: optional peer dep `@react-navigation/native` → `@react-navigation/core`.
- `example/expo/metro.config.js`: the example links the lib from source (not `node_modules`), so Expo's auto-rewrite doesn't trigger there — added an explicit `@react-navigation/core` → `expo-router/react-navigation` redirect to mirror the real consumer path.
- `docs/docs/guides/navigation.mdx`: the Expo Router example no longer imports `ParamListBase` from `@react-navigation/native` (app-code react-navigation imports throw under SDK 56) — uses a local type alias, plus an SDK 56 note linking the migration guide.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Test Plan

- `yarn typecheck` — clean (root + examples)
- `yarn jest` — 43/43 pass
- `yarn eslint` — clean
- `expo export --platform ios` on `example/expo` — bundles cleanly (1610 modules), no react-navigation throw

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)