### PR TITLE
fix(ios): smooth sheet position jump when keyboard dismisses with focus outside sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - **iOS**: Fixed Mac Catalyst build issue. ([#685](https://github.com/lodev09/react-native-true-sheet/pull/685) by [@theeket](https://github.com/theeket))
 - **iOS**: Fixed footer rendering at the bottom of the content view instead of the bottom of the sheet when the footer view is recycled across present cycles. ([#688](https://github.com/lodev09/react-native-true-sheet/pull/688) by [@lucaswickstrom](https://github.com/lucaswickstrom))
+- **iOS**: Fixed sheet position jump when the keyboard dismisses after the first responder has moved out of the sheet. ([#696](https://github.com/lodev09/react-native-true-sheet/pull/696) by [@Pekaz](https://github.com/Pekaz))
 - **Android**: Fixed `resize()` being interrupted when sheet content size changes during the animation, causing the sheet to revert to the previous detent. ([#693](https://github.com/lodev09/react-native-true-sheet/pull/693) by [@lodev09](https://github.com/lodev09))
 - Fixed the Sheet Navigator breaking under Expo Router SDK 56 by importing from `@react-navigation/core` (auto-rewritten to `expo-router/react-navigation` on SDK 56, resolves normally in bare projects). The optional peer dependency changed from `@react-navigation/native` to `@react-navigation/core`. ([#695](https://github.com/lodev09/react-native-true-sheet/pull/695) by [@lodev09](https://github.com/lodev09))
 

--- a/ios/core/TrueSheetKeyboardObserver.mm
+++ b/ios/core/TrueSheetKeyboardObserver.mm
@@ -12,9 +12,18 @@
 #import "../TrueSheetViewController.h"
 #import "../utils/UIView+FirstResponder.h"
 
+static const CGFloat kMinSmoothingOffset = 1.0;
+static const NSTimeInterval kFallbackAnimationDuration = 0.25;
+
 @implementation TrueSheetKeyboardObserver {
   NSHashTable<id<TrueSheetKeyboardObserverDelegate>> *_delegates;
   CGFloat _currentHeight;
+  BOOL _isKeyboardVisibleForSheet;
+  BOOL _isSmoothingKeyboardHide;
+  BOOL _isHandlingHide;
+  __weak UIView *_smoothingPresentedView;
+  CGAffineTransform _smoothingOriginalTransform;
+  NSUInteger _smoothingToken;
 }
 
 - (CGFloat)currentHeight {
@@ -24,6 +33,7 @@
 - (instancetype)init {
   if (self = [super init]) {
     _delegates = [NSHashTable weakObjectsHashTable];
+    _smoothingOriginalTransform = CGAffineTransformIdentity;
   }
   return self;
 }
@@ -38,13 +48,32 @@
 
 - (void)start {
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(keyboardWillChangeFrame:)
+                                           selector:@selector(handleKeyboardNotification:)
                                                name:UIKeyboardWillChangeFrameNotification
+                                             object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(handleKeyboardNotification:)
+                                               name:UIKeyboardWillHideNotification
                                              object:nil];
 }
 
 - (void)stop {
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillChangeFrameNotification object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillHideNotification object:nil];
+
+  ++_smoothingToken;
+  UIView *presented = _smoothingPresentedView;
+  if (presented && _isSmoothingKeyboardHide) {
+    [presented.layer removeAllAnimations];
+    presented.transform = _smoothingOriginalTransform;
+  }
+
+  _currentHeight = 0;
+  _isKeyboardVisibleForSheet = NO;
+  _isSmoothingKeyboardHide = NO;
+  _isHandlingHide = NO;
+  _smoothingPresentedView = nil;
+  _smoothingOriginalTransform = CGAffineTransformIdentity;
 }
 
 - (void)dealloc {
@@ -59,12 +88,82 @@
   return firstResponder != nil;
 }
 
-- (void)keyboardWillChangeFrame:(NSNotification *)notification {
-  if (_viewController && !_viewController.isTopmostPresentedController) {
+- (void)smoothKeyboardHideWithDuration:(NSTimeInterval)duration curve:(UIViewAnimationOptions)curve {
+  if (_isSmoothingKeyboardHide || !_viewController) {
     return;
   }
 
-  if (![self isFirstResponderWithinSheet]) {
+  UIView *presented = _viewController.presentationController.presentedView;
+  if (!presented) {
+    return;
+  }
+
+  // presentationLayer is nil when no animation is in flight; in that case the
+  // model frame already matches what's on screen, so the offset below resolves to 0.
+  CALayer *presentationLayer = presented.layer.presentationLayer;
+  CGFloat visualY = presentationLayer ? presentationLayer.frame.origin.y : presented.frame.origin.y;
+
+  _isSmoothingKeyboardHide = YES;
+  _smoothingPresentedView = presented;
+  _smoothingOriginalTransform = presented.transform;
+  NSUInteger token = ++_smoothingToken;
+
+  __weak __typeof(self) weakSelf = self;
+  __weak UIView *weakPresented = presented;
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    __strong __typeof(weakSelf) strongSelf = weakSelf;
+    if (!strongSelf || strongSelf->_smoothingToken != token) {
+      return;
+    }
+
+    UIView *strongPresented = weakPresented;
+    if (!strongPresented) {
+      strongSelf->_isSmoothingKeyboardHide = NO;
+      strongSelf->_smoothingPresentedView = nil;
+      return;
+    }
+
+    [strongPresented layoutIfNeeded];
+    CGFloat snappedY = strongPresented.frame.origin.y;
+    CGFloat offset = visualY - snappedY;
+    if (fabs(offset) < kMinSmoothingOffset) {
+      strongSelf->_isSmoothingKeyboardHide = NO;
+      strongSelf->_smoothingPresentedView = nil;
+      return;
+    }
+
+    CGAffineTransform original = strongSelf->_smoothingOriginalTransform;
+    CGAffineTransform translated =
+      CGAffineTransformConcat(original, CGAffineTransformMakeTranslation(0, offset));
+    strongPresented.transform = translated;
+
+    UIViewAnimationOptions opts =
+      curve | UIViewAnimationOptionBeginFromCurrentState
+      | UIViewAnimationOptionOverrideInheritedDuration
+      | UIViewAnimationOptionOverrideInheritedCurve
+      | UIViewAnimationOptionAllowUserInteraction;
+
+    NSTimeInterval animationDuration = duration > 0 ? duration : kFallbackAnimationDuration;
+    [UIView animateWithDuration:animationDuration
+                          delay:0
+                        options:opts
+                     animations:^{
+                       strongPresented.transform = original;
+                     }
+                     completion:^(__unused BOOL finished) {
+                       __strong __typeof(weakSelf) innerSelf = weakSelf;
+                       if (!innerSelf || innerSelf->_smoothingToken != token) {
+                         return;
+                       }
+                       innerSelf->_isSmoothingKeyboardHide = NO;
+                       innerSelf->_smoothingPresentedView = nil;
+                     }];
+  });
+}
+
+- (void)handleKeyboardNotification:(NSNotification *)notification {
+  if (_viewController && !_viewController.isTopmostPresentedController) {
     return;
   }
 
@@ -80,13 +179,45 @@
 
   CGRect keyboardFrameInWindow = [window convertRect:keyboardFrame fromWindow:nil];
   CGFloat keyboardHeight = MAX(0, window.bounds.size.height - keyboardFrameInWindow.origin.y);
+  BOOL isHideNotification = [notification.name isEqualToString:UIKeyboardWillHideNotification];
+  BOOL isKeyboardHiding = isHideNotification || keyboardHeight <= 0;
+  BOOL firstResponderWithinSheet = [self isFirstResponderWithinSheet];
+  BOOL wasKeyboardVisibleForSheet = _isKeyboardVisibleForSheet || _currentHeight > 0;
+  BOOL shouldEmitShow = !isKeyboardHiding
+    && keyboardHeight > 0
+    && (firstResponderWithinSheet || wasKeyboardVisibleForSheet);
+  BOOL shouldEmitHide = isKeyboardHiding
+    && (wasKeyboardVisibleForSheet || firstResponderWithinSheet);
+
+  if (!shouldEmitShow && !shouldEmitHide) {
+    return;
+  }
+
+  // iOS posts UIKeyboardWillChangeFrameNotification and UIKeyboardWillHideNotification
+  // for the same dismissal; dedupe within a single runloop tick.
+  if (shouldEmitHide) {
+    if (_isHandlingHide) {
+      return;
+    }
+    _isHandlingHide = YES;
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      __strong __typeof(weakSelf) strongSelf = weakSelf;
+      if (strongSelf) {
+        strongSelf->_isHandlingHide = NO;
+      }
+    });
+
+    [self smoothKeyboardHideWithDuration:duration curve:curve];
+  }
 
   _currentHeight = keyboardHeight;
+  _isKeyboardVisibleForSheet = !isKeyboardHiding;
 
   for (id<TrueSheetKeyboardObserverDelegate> delegate in _delegates) {
-    if (keyboardHeight > 0) {
+    if (shouldEmitShow) {
       [delegate keyboardWillShow:keyboardHeight duration:duration curve:curve];
-    } else {
+    } else if (shouldEmitHide) {
       [delegate keyboardWillHide:duration curve:curve];
     }
   }

--- a/ios/core/TrueSheetKeyboardObserver.mm
+++ b/ios/core/TrueSheetKeyboardObserver.mm
@@ -100,8 +100,7 @@ static const NSTimeInterval kFallbackAnimationDuration = 0.25;
 
   // presentationLayer is nil when no animation is in flight; in that case the
   // model frame already matches what's on screen, so the offset below resolves to 0.
-  CALayer *presentationLayer = presented.layer.presentationLayer;
-  CGFloat visualY = presentationLayer ? presentationLayer.frame.origin.y : presented.frame.origin.y;
+  CGFloat visualY = presented.frame.origin.y;
 
   _isSmoothingKeyboardHide = YES;
   _smoothingPresentedView = presented;


### PR DESCRIPTION
## Summary

Fix a visual glitch where the sheet would abruptly jump when the keyboard dismissed after the first responder had already moved out of the sheet (e.g. tapping outside the input area).

Two issues were combined:

1. The early-return checked only `isFirstResponderWithinSheet`, so any keyboard hide that arrived *after* focus had left the sheet was dropped entirely. Delegates never received `keyboardWillHide`, leaving the sheet in a stale "keyboard-visible" state.

2. Relying on `UIKeyboardWillChangeFrameNotification` alone occasionally missed the hide signal in this scenario.

### Changes

- Subscribe to `UIKeyboardWillHideNotification` in addition to `UIKeyboardWillChangeFrameNotification`.
- Track whether the sheet itself was holding the keyboard (`_isKeyboardVisibleForSheet`) so hide events still propagate after the first responder has moved out.
- Add a `smoothKeyboardHide…` helper that absorbs the position offset between the sheet's current frame and its snapped detent target via a `CGAffineTransform` translation, animated with the keyboard's duration and curve.
- Only emit `keyboardWillHide` to delegates when the sheet was actually involved with the keyboard, avoiding spurious layout work for unrelated hide notifications.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- [x] Focus a `TextInput` inside the sheet, then tap outside the input. keyboard dismisses smoothly without the sheet jumping

## Screenshots / Videos

- Before

https://github.com/user-attachments/assets/48efd885-30fe-43e9-94a5-2d69777367ef

- After

https://github.com/user-attachments/assets/4e39dc3b-039c-42ce-a2d6-ed393c177a69

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)
