### PR TITLE
fix(android): stop bottom sheet from stealing footer & horizontal gestures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **iOS**: Fixed Mac Catalyst build issue. ([#685](https://github.com/lodev09/react-native-true-sheet/pull/685) by [@theeket](https://github.com/theeket))
 - **iOS**: Fixed footer rendering at the bottom of the content view instead of the bottom of the sheet when the footer view is recycled across present cycles. ([#688](https://github.com/lodev09/react-native-true-sheet/pull/688) by [@lucaswickstrom](https://github.com/lucaswickstrom))
 - **Android**: Fixed `resize()` being interrupted when sheet content size changes during the animation, causing the sheet to revert to the previous detent. ([#693](https://github.com/lodev09/react-native-true-sheet/pull/693) by [@lodev09](https://github.com/lodev09))
+- **Android**: Fixed horizontal child gestures inside the `footer` or sheet body being cancelled by `BottomSheetBehavior` when a touch drifted vertically past `touchSlop`. Footer touches are now latched on `ACTION_DOWN` and routed for the full stream, and horizontal-dominant gestures bypass sheet drag — matching iOS. ([#698](https://github.com/lodev09/react-native-true-sheet/pull/698) by [@lodev09](https://github.com/lodev09))
 - Fixed the Sheet Navigator breaking under Expo Router SDK 56 by importing from `@react-navigation/core` (auto-rewritten to `expo-router/react-navigation` on SDK 56, resolves normally in bare projects). The optional peer dependency changed from `@react-navigation/native` to `@react-navigation/core`. ([#695](https://github.com/lodev09/react-native-true-sheet/pull/695) by [@lodev09](https://github.com/lodev09))
 
 ### ⚠️ Breaking

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -192,6 +192,11 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   private val jsTouchDispatcher = JSTouchDispatcher(this)
   private val jsPointerDispatcher = JSPointerDispatcher(this)
 
+  // True when the active touch stream began inside the footer. Latched on
+  // ACTION_DOWN so subsequent MOVE events keep routing to the footer even if
+  // the finger drifts outside the footer's rect mid-gesture.
+  private var footerOwnsTouchStream = false
+
   private val eventDispatcher
     get() = delegate?.eventDispatcher
 
@@ -437,6 +442,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   override fun findScrollView(): ViewGroup? = containerView?.contentView?.findScrollView()
   override fun findSheetView(): TrueSheetBottomSheetView? = sheetView
+  override fun findFooterView(): View? = containerView?.footerView
 
   // =============================================================================
   // MARK: - TrueSheetDimViewDelegate
@@ -1291,25 +1297,35 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   override fun dispatchTouchEvent(event: MotionEvent): Boolean {
     val footer = containerView?.footerView
-    if (footer != null && footer.isShown) {
-      val footerLocation = ScreenUtils.getScreenLocation(footer)
-      val touchX = event.rawX.toInt()
-      val touchY = event.rawY.toInt()
+    val action = event.actionMasked
 
-      if (touchX >= footerLocation[0] &&
-        touchX <= footerLocation[0] + footer.width &&
-        touchY >= footerLocation[1] &&
-        touchY <= footerLocation[1] + footer.height
-      ) {
+    if (footer != null && footer.isShown) {
+      if (action == MotionEvent.ACTION_DOWN) {
+        val loc = ScreenUtils.getScreenLocation(footer)
+        val x = event.rawX.toInt()
+        val y = event.rawY.toInt()
+        footerOwnsTouchStream = x >= loc[0] &&
+          x <= loc[0] + footer.width &&
+          y >= loc[1] &&
+          y <= loc[1] + footer.height
+      }
+
+      if (footerOwnsTouchStream) {
+        val loc = ScreenUtils.getScreenLocation(footer)
         val localEvent = MotionEvent.obtain(event)
-        localEvent.setLocation(
-          (touchX - footerLocation[0]).toFloat(),
-          (touchY - footerLocation[1]).toFloat()
-        )
+        localEvent.setLocation(event.rawX - loc[0], event.rawY - loc[1])
         val handled = footer.dispatchTouchEvent(localEvent)
         localEvent.recycle()
+
+        if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+          footerOwnsTouchStream = false
+        }
         if (handled) return true
       }
+    }
+
+    if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+      footerOwnsTouchStream = false
     }
     return super.dispatchTouchEvent(event)
   }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -442,7 +442,6 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   override fun findScrollView(): ViewGroup? = containerView?.contentView?.findScrollView()
   override fun findSheetView(): TrueSheetBottomSheetView? = sheetView
-  override fun findFooterView(): View? = containerView?.footerView
 
   // =============================================================================
   // MARK: - TrueSheetDimViewDelegate

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetCoordinatorLayout.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetCoordinatorLayout.kt
@@ -17,7 +17,6 @@ interface TrueSheetCoordinatorLayoutDelegate {
   fun coordinatorLayoutDidChangeConfiguration()
   fun findScrollView(): ViewGroup?
   fun findSheetView(): TrueSheetBottomSheetView?
-  fun findFooterView(): android.view.View?
 }
 
 /**
@@ -36,11 +35,6 @@ class TrueSheetCoordinatorLayout(context: Context) :
   private var dragging = false
   private var initialY = 0f
   private var activePointerId = 0
-
-  // True when the active touch stream began inside the footer. Latched on
-  // ACTION_DOWN so we never let BottomSheetBehavior intercept events that
-  // belong to the footer's own gesture handling.
-  private var footerOwnsTouchStream = false
 
   // Horizontal-dominance tracking. iOS lets horizontal child gestures win over
   // the sheet's vertical pan; we mirror that by locking out BottomSheetBehavior
@@ -79,15 +73,6 @@ class TrueSheetCoordinatorLayout(context: Context) :
   override val pointerEvents: PointerEvents
     get() = PointerEvents.BOX_NONE
 
-  private fun isPointInFooter(ev: MotionEvent, footer: android.view.View): Boolean {
-    val loc = IntArray(2)
-    footer.getLocationOnScreen(loc)
-    val x = ev.rawX.toInt()
-    val y = ev.rawY.toInt()
-    return x >= loc[0] && x <= loc[0] + footer.width &&
-      y >= loc[1] && y <= loc[1] + footer.height
-  }
-
   /**
    * Clears stale `nestedScrollingChildRef` from BottomSheetBehavior.
    *
@@ -122,23 +107,10 @@ class TrueSheetCoordinatorLayout(context: Context) :
     if (action == MotionEvent.ACTION_DOWN) {
       clearStaleNestedScrollingChildRef()
 
-      // Latch footer ownership at the very top of the dispatch so
-      // BottomSheetBehavior never gets to set `ignoreEvents = false` for a
-      // touch that belongs to the footer.
-      val footer = delegate?.findFooterView()
-      footerOwnsTouchStream = footer != null && footer.isShown && isPointInFooter(ev, footer)
-
       streamInitialX = ev.rawX
       streamInitialY = ev.rawY
       streamHorizontalLocked = false
       streamDirectionDecided = false
-    }
-
-    if (footerOwnsTouchStream) {
-      if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
-        footerOwnsTouchStream = false
-      }
-      return false
     }
 
     // Decide gesture direction on first significant movement of the stream.

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetCoordinatorLayout.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetCoordinatorLayout.kt
@@ -17,6 +17,7 @@ interface TrueSheetCoordinatorLayoutDelegate {
   fun coordinatorLayoutDidChangeConfiguration()
   fun findScrollView(): ViewGroup?
   fun findSheetView(): TrueSheetBottomSheetView?
+  fun findFooterView(): android.view.View?
 }
 
 /**
@@ -35,6 +36,19 @@ class TrueSheetCoordinatorLayout(context: Context) :
   private var dragging = false
   private var initialY = 0f
   private var activePointerId = 0
+
+  // True when the active touch stream began inside the footer. Latched on
+  // ACTION_DOWN so we never let BottomSheetBehavior intercept events that
+  // belong to the footer's own gesture handling.
+  private var footerOwnsTouchStream = false
+
+  // Horizontal-dominance tracking. iOS lets horizontal child gestures win over
+  // the sheet's vertical pan; we mirror that by locking out BottomSheetBehavior
+  // interception once the first significant movement of a stream is horizontal.
+  private var streamInitialX = 0f
+  private var streamInitialY = 0f
+  private var streamHorizontalLocked = false
+  private var streamDirectionDecided = false
 
   init {
     layoutParams = LayoutParams(
@@ -65,6 +79,15 @@ class TrueSheetCoordinatorLayout(context: Context) :
   override val pointerEvents: PointerEvents
     get() = PointerEvents.BOX_NONE
 
+  private fun isPointInFooter(ev: MotionEvent, footer: android.view.View): Boolean {
+    val loc = IntArray(2)
+    footer.getLocationOnScreen(loc)
+    val x = ev.rawX.toInt()
+    val y = ev.rawY.toInt()
+    return x >= loc[0] && x <= loc[0] + footer.width &&
+      y >= loc[1] && y <= loc[1] + footer.height
+  }
+
   /**
    * Clears stale `nestedScrollingChildRef` from BottomSheetBehavior.
    *
@@ -94,8 +117,48 @@ class TrueSheetCoordinatorLayout(context: Context) :
    * See: https://github.com/facebook/react-native/pull/44099
    */
   override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
-    if (ev.actionMasked == MotionEvent.ACTION_DOWN) {
+    val action = ev.actionMasked
+
+    if (action == MotionEvent.ACTION_DOWN) {
       clearStaleNestedScrollingChildRef()
+
+      // Latch footer ownership at the very top of the dispatch so
+      // BottomSheetBehavior never gets to set `ignoreEvents = false` for a
+      // touch that belongs to the footer.
+      val footer = delegate?.findFooterView()
+      footerOwnsTouchStream = footer != null && footer.isShown && isPointInFooter(ev, footer)
+
+      streamInitialX = ev.rawX
+      streamInitialY = ev.rawY
+      streamHorizontalLocked = false
+      streamDirectionDecided = false
+    }
+
+    if (footerOwnsTouchStream) {
+      if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+        footerOwnsTouchStream = false
+      }
+      return false
+    }
+
+    // Decide gesture direction on first significant movement of the stream.
+    // If horizontal wins, lock out BottomSheetBehavior for the rest of the stream
+    // so child handlers (carousels, swipe buttons, etc.) can claim the touch.
+    if (!streamDirectionDecided && action == MotionEvent.ACTION_MOVE) {
+      val dx = kotlin.math.abs(ev.rawX - streamInitialX)
+      val dy = kotlin.math.abs(ev.rawY - streamInitialY)
+      if (dx > touchSlop || dy > touchSlop) {
+        streamDirectionDecided = true
+        streamHorizontalLocked = dx > dy
+      }
+    }
+
+    if (streamHorizontalLocked) {
+      if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+        streamHorizontalLocked = false
+        streamDirectionDecided = false
+      }
+      return false
     }
 
     val scrollView = delegate?.findScrollView()

--- a/example/shared/src/components/SwipeButton.tsx
+++ b/example/shared/src/components/SwipeButton.tsx
@@ -1,0 +1,274 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Pressable, type PressableProps, StyleSheet, Text, type ViewStyle } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { scheduleOnRN } from 'react-native-worklets';
+
+import { BLUE, DARK_GRAY, FOOTER_HEIGHT, SPACING } from '../utils';
+
+const TRACK_HEIGHT = FOOTER_HEIGHT;
+const TRACK_PADDING = SPACING / 4;
+const THUMB_SIZE = TRACK_HEIGHT - TRACK_PADDING * 2;
+const DEFAULT_COMPLETE_THRESHOLD = 0.85;
+const DEFAULT_RESET_DELAY = 800;
+const SNAP_CONFIG = {
+  duration: 180,
+  easing: Easing.out(Easing.cubic),
+};
+const FADE_CONFIG = {
+  duration: 140,
+  easing: Easing.out(Easing.cubic),
+};
+
+function getMaxDistance(trackWidth: number, trackPadding: number, thumbSize: number) {
+  'worklet';
+  return Math.max(trackWidth - trackPadding * 2 - thumbSize, 0);
+}
+
+export interface SwipeButtonProps extends Omit<PressableProps, 'onPress' | 'style' | 'children'> {
+  children?: ReactNode;
+  disabled?: boolean;
+  loading?: boolean;
+  onComplete: () => void | Promise<void>;
+  completeThreshold?: number;
+  resetOnComplete?: boolean;
+  resetDelay?: number;
+  style?: ViewStyle;
+}
+
+export const SwipeButton = ({
+  children = 'Swipe to confirm',
+  disabled = false,
+  loading = false,
+  onComplete,
+  completeThreshold = DEFAULT_COMPLETE_THRESHOLD,
+  resetOnComplete = false,
+  resetDelay = DEFAULT_RESET_DELAY,
+  style,
+  ...pressableProps
+}: SwipeButtonProps) => {
+  const translateX = useSharedValue(0);
+  const trackWidth = useSharedValue(0);
+  const trackPadding = useSharedValue(TRACK_PADDING);
+  const thumbSize = useSharedValue(THUMB_SIZE);
+  const progress = useSharedValue(0);
+  const completed = useSharedValue(false);
+  const disabledValue = useSharedValue(disabled);
+  const loadingValue = useSharedValue(loading);
+  const startX = useSharedValue(0);
+  const [presentationActive, setPresentationActive] = useState(false);
+  const visualLoading = loading || presentationActive;
+  const prevVisualLoading = useRef(visualLoading);
+  const mounted = useRef(true);
+  const resetTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const reset = useCallback(() => {
+    completed.value = false;
+    progress.value = 0;
+    translateX.value = withTiming(0, SNAP_CONFIG);
+  }, [completed, progress, translateX]);
+
+  const runComplete = useCallback(() => {
+    completed.value = true;
+
+    let completePromise: Promise<void>;
+    try {
+      completePromise = Promise.resolve(onComplete());
+    } catch (error) {
+      completePromise = Promise.reject(error);
+    }
+
+    void completePromise
+      .then(() => {
+        if (mounted.current) setPresentationActive(false);
+        if (resetOnComplete) resetTimeout.current = setTimeout(reset, resetDelay);
+      })
+      .catch((error) => {
+        if (mounted.current) setPresentationActive(false);
+        completed.value = false;
+        reset();
+        console.error('[SwipeButton] onComplete failed', error);
+      });
+  }, [completed, onComplete, reset, resetDelay, resetOnComplete]);
+
+  useEffect(() => {
+    disabledValue.value = disabled;
+  }, [disabled, disabledValue]);
+
+  useEffect(() => {
+    loadingValue.value = visualLoading;
+    const maxDistance = getMaxDistance(trackWidth.value, trackPadding.value, thumbSize.value);
+    if (visualLoading) {
+      completed.value = true;
+      progress.value = 1;
+      translateX.value = withTiming(maxDistance, SNAP_CONFIG);
+    } else if (prevVisualLoading.current) {
+      reset();
+    }
+    prevVisualLoading.current = visualLoading;
+  }, [
+    completed,
+    loadingValue,
+    progress,
+    reset,
+    thumbSize,
+    trackPadding,
+    trackWidth,
+    translateX,
+    visualLoading,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      mounted.current = false;
+      if (resetTimeout.current) clearTimeout(resetTimeout.current);
+    };
+  }, []);
+
+  const setTrackWidth = useCallback(
+    (width: number) => {
+      trackWidth.value = width;
+      if (visualLoading || completed.value) {
+        const maxDistance = getMaxDistance(width, trackPadding.value, thumbSize.value);
+        translateX.value = maxDistance;
+        progress.value = maxDistance > 0 ? 1 : 0;
+      }
+    },
+    [completed, progress, thumbSize, trackPadding, trackWidth, translateX, visualLoading]
+  );
+
+  const panGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .enabled(!disabled && !visualLoading)
+        .onBegin(() => {
+          startX.value = translateX.value;
+        })
+        .onUpdate((event) => {
+          if (disabledValue.value || loadingValue.value || completed.value) return;
+
+          const maxDistance = getMaxDistance(trackWidth.value, trackPadding.value, thumbSize.value);
+          const nextX = Math.min(Math.max(startX.value + event.translationX, 0), maxDistance);
+          translateX.value = nextX;
+          progress.value = maxDistance > 0 ? nextX / maxDistance : 0;
+        })
+        .onEnd(() => {
+          if (disabledValue.value || loadingValue.value || completed.value) return;
+
+          const maxDistance = getMaxDistance(trackWidth.value, trackPadding.value, thumbSize.value);
+          const shouldComplete =
+            maxDistance > 0 && translateX.value >= maxDistance * completeThreshold;
+
+          if (shouldComplete) {
+            completed.value = true;
+            progress.value = 1;
+            translateX.value = withTiming(maxDistance, SNAP_CONFIG, () => {
+              scheduleOnRN(runComplete);
+            });
+            return;
+          }
+
+          progress.value = 0;
+          translateX.value = withTiming(0, SNAP_CONFIG);
+        }),
+    [
+      completeThreshold,
+      completed,
+      disabled,
+      disabledValue,
+      loadingValue,
+      progress,
+      runComplete,
+      startX,
+      thumbSize,
+      trackPadding,
+      trackWidth,
+      translateX,
+      visualLoading,
+    ]
+  );
+
+  const fillStyle = useAnimatedStyle(() => ({
+    width: thumbSize.value + translateX.value,
+  }));
+
+  const thumbStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
+  }));
+
+  const labelStyle = useAnimatedStyle(() => ({
+    left: trackPadding.value + thumbSize.value,
+    right: trackPadding.value,
+    opacity: withTiming(visualLoading ? 0 : 1, FADE_CONFIG),
+  }));
+
+  return (
+    <GestureDetector gesture={panGesture}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityState={{ disabled, busy: visualLoading }}
+        disabled={disabled || visualLoading}
+        style={[styles.track, style]}
+        onLayout={(event) => setTrackWidth(event.nativeEvent.layout.width)}
+        {...pressableProps}
+      >
+        <Animated.View pointerEvents="none" style={[styles.fill, fillStyle]} />
+        <Animated.View pointerEvents="none" style={[styles.label, labelStyle]}>
+          <Text numberOfLines={1} style={styles.labelText}>
+            {children}
+          </Text>
+        </Animated.View>
+        <Animated.View style={[styles.thumb, thumbStyle]} />
+      </Pressable>
+    </GestureDetector>
+  );
+};
+
+const styles = StyleSheet.create({
+  track: {
+    width: '100%',
+    height: TRACK_HEIGHT,
+    padding: TRACK_PADDING,
+    borderRadius: TRACK_HEIGHT / 2,
+    backgroundColor: DARK_GRAY,
+    flexDirection: 'row',
+    alignItems: 'center',
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  fill: {
+    position: 'absolute',
+    left: TRACK_PADDING,
+    top: TRACK_PADDING,
+    bottom: TRACK_PADDING,
+    borderRadius: THUMB_SIZE / 2,
+    backgroundColor: BLUE,
+    overflow: 'hidden',
+    zIndex: 2,
+  },
+  label: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1,
+  },
+  labelText: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  thumb: {
+    width: THUMB_SIZE,
+    height: THUMB_SIZE,
+    borderRadius: THUMB_SIZE / 2,
+    backgroundColor: '#fff',
+    zIndex: 3,
+  },
+});

--- a/example/shared/src/components/index.ts
+++ b/example/shared/src/components/index.ts
@@ -6,3 +6,4 @@ export * from './ButtonGroup';
 export * from './Spacer';
 export * from './Input';
 export * from './Map';
+export * from './SwipeButton';

--- a/example/shared/src/components/sheets/GestureSheet.tsx
+++ b/example/shared/src/components/sheets/GestureSheet.tsx
@@ -1,13 +1,14 @@
 import { forwardRef, useRef, type Ref, useImperativeHandle } from 'react';
-import { StyleSheet, useWindowDimensions } from 'react-native';
+import { Platform, StyleSheet, useWindowDimensions } from 'react-native';
 import { TrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
 import Animated, { useAnimatedStyle, useSharedValue, withDecay } from 'react-native-reanimated';
 import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { DARK, DARK_GRAY, FOOTER_HEIGHT, GAP, SPACING, times } from '../../utils';
-import { Footer } from '../Footer';
 import { Button } from '../Button';
 import { DemoContent } from '../DemoContent';
+import { SwipeButton } from '../SwipeButton';
 
 const BOXES_COUNT = 20;
 const CONTAINER_HEIGHT = 200;
@@ -20,6 +21,9 @@ export const GestureSheet = forwardRef((props: GestureSheetProps, ref: Ref<TrueS
 
   const scrollX = useSharedValue(0);
   const dimensions = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  const isIPad = (Platform.OS === 'ios' && Platform.isPad) || Platform.OS === 'web';
+  const bottomInset = isIPad ? 0 : insets.bottom;
 
   const dismiss = async () => {
     await sheetRef.current?.dismiss();
@@ -46,7 +50,7 @@ export const GestureSheet = forwardRef((props: GestureSheetProps, ref: Ref<TrueS
 
   return (
     <TrueSheet
-      detents={['auto']}
+      detents={['auto', 0.5]}
       name="gesture"
       ref={sheetRef}
       style={styles.content}
@@ -66,10 +70,19 @@ export const GestureSheet = forwardRef((props: GestureSheetProps, ref: Ref<TrueS
           e.nativeEvent.position
         )
       }
-      footer={<Footer />}
+      footer={
+        <GestureHandlerRootView style={[styles.footerRoot, { paddingBottom: bottomInset }]}>
+          <SwipeButton onComplete={() => console.log('swipe completed!')}>
+            Swipe to confirm
+          </SwipeButton>
+        </GestureHandlerRootView>
+      }
       {...props}
     >
       <GestureHandlerRootView style={styles.gestureRoot}>
+        <SwipeButton onComplete={() => console.log('swipe completed!')}>
+          Swipe to confirm
+        </SwipeButton>
         <GestureDetector gesture={pan}>
           <Animated.View style={[styles.panContainer, animatedContainerStyle]}>
             {times(BOXES_COUNT, (i) => (
@@ -86,6 +99,11 @@ export const GestureSheet = forwardRef((props: GestureSheetProps, ref: Ref<TrueS
 const styles = StyleSheet.create({
   gestureRoot: {
     flexGrow: 1,
+  },
+  footerRoot: {
+    flexGrow: 1,
+    paddingHorizontal: SPACING,
+    paddingTop: SPACING / 2,
   },
   box: {
     alignItems: 'center',


### PR DESCRIPTION
## Summary

Fixes [#697](https://github.com/lodev09/react-native-true-sheet/issues/697). On Android, horizontal RNGH gestures inside a sheet's `footer` (and inside the sheet body) were cancelled the moment the finger drifted vertically past `touchSlop` — `BottomSheetBehavior` would intercept the stream and start dragging the sheet. iOS doesn't have this problem because UIKit prioritizes the child gesture. Two fixes:

1. **Latched footer touch routing** — `TrueSheetViewController.dispatchTouchEvent` used to do a per-event point-in-rect check before re-dispatching to the footer. Vertical drift moved the touch outside the rect mid-stream, the rerouting stopped, and the footer's RNGH handler saw a broken stream. Now the rect check happens only on `ACTION_DOWN`; the whole stream stays routed to the footer until `ACTION_UP`/`CANCEL`.
2. **Coordinator short-circuits** — `TrueSheetCoordinatorLayout.onInterceptTouchEvent` now bails (`return false`) before `BottomSheetBehavior` is asked in two cases:
   - Touch starts inside the footer (added `findFooterView()` to the delegate).
   - First significant `MOVE` of the stream is horizontal-dominant (`|dx| > |dy|`). Matches iOS, where horizontal gestures take priority over sheet drag.

Sheet's normal vertical drag is untouched outside the footer for vertical-dominant gestures.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Updated `GestureSheet` in the example to demonstrate the repro: hosts a new `SwipeButton` (horizontal `Gesture.Pan()` with no `activeOffsetX`) in both the sheet body and the `footer` prop. Before the fix, vertical drift cancelled the swipe and dragged the sheet on Android; after the fix, the swipe glides smoothly and the sheet stays still — matching iOS.

- [ ] I tested on iOS (unaffected — iOS already worked)
- [x] I tested on Android (Pixel 10 Pro XL emulator)
- [ ] I tested on Web (unaffected — Android-only fix)
- [ ] I updated the documentation (no doc change needed)
- [ ] I added a changelog entry (will follow up)

## Screenshots / Videos

_None — gesture behavior change._