### PR TITLE
fix: expose iOS sheet accessibility content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Fixed sheet footer controls being hidden from XCTest and assistive technologies by exposing mounted sheet content and footer accessibility elements. ([#699](https://github.com/lodev09/react-native-true-sheet/pull/699) by [@erickreutz](https://github.com/erickreutz))
 - **iOS**: Fixed Mac Catalyst build issue. ([#685](https://github.com/lodev09/react-native-true-sheet/pull/685) by [@theeket](https://github.com/theeket))
 - **iOS**: Fixed footer rendering at the bottom of the content view instead of the bottom of the sheet when the footer view is recycled across present cycles. ([#688](https://github.com/lodev09/react-native-true-sheet/pull/688) by [@lucaswickstrom](https://github.com/lucaswickstrom))
 - **Android**: Fixed `resize()` being interrupted when sheet content size changes during the animation, causing the sheet to revert to the previous detent. ([#693](https://github.com/lodev09/react-native-true-sheet/pull/693) by [@lodev09](https://github.com/lodev09))

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -72,8 +72,25 @@ using namespace facebook::react;
     _headerView = nil;
     _footerView = nil;
     _scrollableSet = NO;
+    self.isAccessibilityElement = NO;
   }
   return self;
+}
+
+#pragma mark - Accessibility
+
+- (NSArray *)accessibilityElements {
+  NSMutableArray *elements = [NSMutableArray array];
+  if (_headerView) {
+    [elements addObject:_headerView];
+  }
+  if (_contentView) {
+    [elements addObject:_contentView];
+  }
+  if (_footerView) {
+    [elements addObject:_footerView];
+  }
+  return elements;
 }
 
 #pragma mark - Layout

--- a/ios/TrueSheetFooterView.mm
+++ b/ios/TrueSheetFooterView.mm
@@ -37,6 +37,7 @@ using namespace facebook::react;
     _props = defaultProps;
 
     self.backgroundColor = [UIColor clearColor];
+    self.isAccessibilityElement = NO;
 
     _lastHeight = 0;
     _pendingHeight = 0;
@@ -45,6 +46,24 @@ using namespace facebook::react;
     _currentKeyboardOffset = 0;
   }
   return self;
+}
+
+#pragma mark - Accessibility
+
+- (NSArray *)accessibilityElements {
+  NSMutableArray *elements = [NSMutableArray array];
+  [self collectAccessibilityElementsFromView:self into:elements];
+  return elements;
+}
+
+- (void)collectAccessibilityElementsFromView:(UIView *)view into:(NSMutableArray *)elements {
+  for (UIView *subview in view.subviews) {
+    if (subview.isAccessibilityElement || subview.accessibilityLabel || subview.accessibilityIdentifier) {
+      [elements addObject:subview];
+    } else {
+      [self collectAccessibilityElementsFromView:subview into:elements];
+    }
+  }
 }
 
 #pragma mark - Layout

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -373,6 +373,9 @@ using namespace facebook::react;
   [_controller.view addSubview:_containerView];
   [LayoutUtil pinView:_containerView toParentView:_controller.view edges:UIRectEdgeAll];
   [_controller.view bringSubviewToFront:_containerView];
+  _containerView.accessibilityViewIsModal = YES;
+  _controller.accessibilityContentView = _containerView;
+  [_controller setupAccessibilityContainer];
 
   CGFloat contentHeight = [_containerView contentHeight];
   if (contentHeight > 0) {

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -75,9 +75,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL isPresented;
 @property (nonatomic, assign) NSInteger activeDetentIndex;
 @property (nonatomic, readonly) BOOL isTopmostPresentedController;
+@property (nonatomic, weak, nullable) UIView *accessibilityContentView;
 
 @property (nonatomic, readonly) CGFloat screenHeight;
 
+- (void)setupAccessibilityContainer;
 - (void)applyActiveDetent;
 - (void)setupActiveDetentWithIndex:(NSInteger)index;
 - (void)resizeToDetentIndex:(NSInteger)index;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -34,6 +34,8 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
 
 @interface TrueSheetViewController ()
 
+- (void)setAccessibilityContentElement:(UIView *)contentView;
+
 @end
 
 @implementation TrueSheetViewController {
@@ -207,6 +209,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
     if ([presenter isKindOfClass:[TrueSheetViewController class]]) {
       _parentSheetController = (TrueSheetViewController *)presenter;
       [_parentSheetController.delegate viewControllerWillBlur];
+      [_parentSheetController setAccessibilityContentElement:self.accessibilityContentView ?: self.view];
     }
 
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -241,7 +244,30 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
     });
 
     [self setupGestureRecognizer];
+    [self setupAccessibilityContainer];
     _isPresented = YES;
+  }
+}
+
+- (void)setupAccessibilityContainer {
+  UIView *contentView = self.accessibilityContentView;
+  if (!contentView) {
+    return;
+  }
+
+  [self setAccessibilityContentElement:contentView];
+}
+
+- (void)setAccessibilityContentElement:(UIView *)contentView {
+  self.view.isAccessibilityElement = NO;
+  self.view.accessibilityViewIsModal = YES;
+  self.view.accessibilityElements = @[ contentView ];
+
+  UIView *presentedView = self.presentationController.presentedView;
+  if (presentedView) {
+    presentedView.isAccessibilityElement = NO;
+    presentedView.accessibilityViewIsModal = YES;
+    presentedView.accessibilityElements = @[ contentView ];
   }
 }
 
@@ -264,6 +290,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
     _anchorView = nil;
 
     [_parentSheetController.delegate viewControllerDidFocus];
+    [_parentSheetController setupAccessibilityContainer];
     _parentSheetController = nil;
 
     [self.delegate viewControllerDidBlur];


### PR DESCRIPTION
## Summary

Fix iOS sheet accessibility traversal so the presented sheet wrapper exposes the mounted content view, and footer controls nested inside the footer host view remain reachable by XCTest and assistive technologies.

## Type of Change

Bug fix.

## Test Plan

Ran `PATH="$(dirname $(xcrun --find clang-format)):$PATH" scripts/objclint.sh`.
Ran `corepack yarn typecheck`.
Ran `corepack yarn test --maxWorkers=2`.

## Screenshots / Videos

N/A

## Checklist

Tested on iOS through Lugg app Maestro/XCTest coverage.
Android and Web are unaffected; this only changes iOS native accessibility traversal.
Added changelog entry.