### PR TITLE
fix: expose iOS footer accessibility elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Fixed nested footer accessibility elements and window accessibility restoration when footer controls are present. ([#700](https://github.com/lodev09/react-native-true-sheet/pull/700) by [@erickreutz](https://github.com/erickreutz))
 - **iOS**: Fixed sheet footer controls being hidden from XCTest and assistive technologies by exposing mounted sheet content and footer accessibility elements. ([#699](https://github.com/lodev09/react-native-true-sheet/pull/699) by [@erickreutz](https://github.com/erickreutz))
 - **iOS**: Fixed Mac Catalyst build issue. ([#685](https://github.com/lodev09/react-native-true-sheet/pull/685) by [@theeket](https://github.com/theeket))
 - **iOS**: Fixed footer rendering at the bottom of the content view instead of the bottom of the sheet when the footer view is recycled across present cycles. ([#688](https://github.com/lodev09/react-native-true-sheet/pull/688) by [@lucaswickstrom](https://github.com/lucaswickstrom))

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @optional
 
 - (void)containerViewHeaderDidChangeSize:(CGSize)newSize;
+- (void)containerViewFooterDidChangeSize:(CGSize)newSize;
 
 @end
 
@@ -70,6 +71,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Updates footer layout constraints if needed
  */
 - (void)layoutFooter;
+
+- (BOOL)hasAccessibilityFooterElements;
 
 /**
  * Setup scrollable content

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -88,9 +88,18 @@ using namespace facebook::react;
     [elements addObject:_contentView];
   }
   if (_footerView) {
-    [elements addObject:_footerView];
+    NSArray *footerElements = _footerView.accessibilityElements;
+    if (footerElements.count > 0) {
+      [elements addObjectsFromArray:footerElements];
+    } else {
+      [elements addObject:_footerView];
+    }
   }
   return elements;
+}
+
+- (BOOL)hasAccessibilityFooterElements {
+  return _footerView && _footerView.accessibilityElements.count > 0;
 }
 
 #pragma mark - Layout
@@ -251,6 +260,7 @@ using namespace facebook::react;
 #pragma mark - TrueSheetFooterViewDelegate
 
 - (void)footerViewDidChangeSize:(CGSize)newSize {
+  [self.delegate containerViewFooterDidChangeSize:newSize];
   if (@available(iOS 26.0, *)) {
     [self setupEdgeInteractions];
   }

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -88,6 +88,8 @@ using namespace facebook::react;
     [elements addObject:_contentView];
   }
   if (_footerView) {
+    // Footer hosts are layout containers; expose their children when present so
+    // VoiceOver and XCTest can target the actual footer controls.
     NSArray *footerElements = _footerView.accessibilityElements;
     if (footerElements.count > 0) {
       [elements addObjectsFromArray:footerElements];

--- a/ios/TrueSheetFooterView.mm
+++ b/ios/TrueSheetFooterView.mm
@@ -53,13 +53,19 @@ using namespace facebook::react;
 - (NSArray *)accessibilityElements {
   NSMutableArray *elements = [NSMutableArray array];
   [self collectAccessibilityElementsFromView:self into:elements];
-  return elements;
+  if (elements.count > 0) {
+    return elements;
+  }
+
+  return [super accessibilityElements];
 }
 
 - (void)collectAccessibilityElementsFromView:(UIView *)view into:(NSMutableArray *)elements {
   for (UIView *subview in view.subviews) {
     if (subview.isAccessibilityElement || subview.accessibilityLabel || subview.accessibilityIdentifier) {
       [elements addObject:subview];
+    } else if (subview.accessibilityElements.count > 0) {
+      [elements addObjectsFromArray:subview.accessibilityElements];
     } else {
       [self collectAccessibilityElementsFromView:subview into:elements];
     }

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -573,6 +573,10 @@ using namespace facebook::react;
   [self setupSheetDetentsForSizeChange];
 }
 
+- (void)containerViewFooterDidChangeSize:(CGSize)newSize {
+  [_controller setupAccessibilityContainer];
+}
+
 // When the ScrollView changes (e.g. conditional remount), re-pin the new ScrollView.
 - (void)containerViewScrollViewDidChange {
   [self setupScrollable];

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -283,6 +283,8 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 - (void)restoreWindowAccessibilityElements {
   UIWindow *window = _accessibilityWindow;
   if (window) {
+    // The active sheet may temporarily own window accessibility traversal. Only
+    // restore the previous value when this controller still owns that override.
     NSValue *ownerValue = objc_getAssociatedObject(window, &TrueSheetAccessibilityWindowOwnerKey);
     if (ownerValue && ownerValue.nonretainedObjectValue == self) {
       id previousElements = objc_getAssociatedObject(window, &TrueSheetAccessibilityWindowPreviousElementsKey);
@@ -310,6 +312,8 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   NSArray *accessibilityElements = contentElements.count > 0 ? contentElements : @[ contentView ];
   BOOL hasAccessibilityFooterElements = [contentView isKindOfClass:[TrueSheetContainerView class]] &&
                                         [(TrueSheetContainerView *)contentView hasAccessibilityFooterElements];
+  // Footer controls exposed as separate accessibility elements can be skipped
+  // by XCTest when the presented sheet is a hard modal accessibility boundary.
   BOOL isAccessibilityModal = _dimmed && !hasAccessibilityFooterElements;
 
   self.view.isAccessibilityElement = NO;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -7,6 +7,7 @@
 //
 
 #import "TrueSheetViewController.h"
+#import "TrueSheetContainerView.h"
 #import "TrueSheetContentView.h"
 #import "core/TrueSheetBlurView.h"
 #import "core/TrueSheetDetentCalculator.h"
@@ -18,6 +19,7 @@
 
 #import <React/RCTLog.h>
 #import <React/RCTScrollViewComponentView.h>
+#import <objc/runtime.h>
 #import <react/renderer/components/TrueSheetSpec/Props.h>
 
 using namespace facebook::react;
@@ -32,8 +34,14 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
   return fabs(a.position - b.position) <= 0.01 && fabs(a.detent - b.detent) <= 0.01 && fabs(a.index - b.index) <= 0.01;
 }
 
+static char TrueSheetAccessibilityWindowOwnerKey;
+static char TrueSheetAccessibilityWindowPreviousElementsKey;
+
 @interface TrueSheetViewController ()
 
+- (UIViewController *)accessibilityPresentingViewController;
+- (void)restoreWindowAccessibilityElements;
+- (void)setSheetAccessibilityElementsHidden:(BOOL)hidden;
 - (void)setAccessibilityContentElement:(UIView *)contentView;
 
 @end
@@ -56,6 +64,8 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
   __weak TrueSheetViewController *_parentSheetController;
 
   UIView *_anchorView;
+
+  __weak UIWindow *_accessibilityWindow;
 
   TrueSheetBlurView *_blurView;
   TrueSheetGrabberView *_grabberView;
@@ -97,6 +107,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
 }
 
 - (void)dealloc {
+  [self restoreWindowAccessibilityElements];
   [_transitioningTimer invalidate];
   _transitioningTimer = nil;
   [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -227,6 +238,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
 
 - (void)viewDidAppear:(BOOL)animated {
   [super viewDidAppear:animated];
+  [self setSheetAccessibilityElementsHidden:NO];
 
   if (!_isPresented) {
     [_parentSheetController.delegate viewControllerDidBlur];
@@ -244,9 +256,10 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
     });
 
     [self setupGestureRecognizer];
-    [self setupAccessibilityContainer];
     _isPresented = YES;
   }
+
+  [self setupAccessibilityContainer];
 }
 
 - (void)setupAccessibilityContainer {
@@ -258,17 +271,78 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
   [self setAccessibilityContentElement:contentView];
 }
 
+- (UIViewController *)accessibilityPresentingViewController {
+  UIViewController *presentingViewController = self.presentingViewController;
+  while ([presentingViewController isKindOfClass:[TrueSheetViewController class]] &&
+         presentingViewController.presentingViewController) {
+    presentingViewController = presentingViewController.presentingViewController;
+  }
+  return presentingViewController;
+}
+
+- (void)restoreWindowAccessibilityElements {
+  UIWindow *window = _accessibilityWindow;
+  if (window) {
+    NSValue *ownerValue = objc_getAssociatedObject(window, &TrueSheetAccessibilityWindowOwnerKey);
+    if (ownerValue && ownerValue.nonretainedObjectValue == self) {
+      id previousElements = objc_getAssociatedObject(window, &TrueSheetAccessibilityWindowPreviousElementsKey);
+      window.accessibilityElements = previousElements == [NSNull null] ? nil : previousElements;
+      objc_setAssociatedObject(window, &TrueSheetAccessibilityWindowOwnerKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+      objc_setAssociatedObject(
+        window, &TrueSheetAccessibilityWindowPreviousElementsKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    _accessibilityWindow = nil;
+  }
+}
+
+- (void)setSheetAccessibilityElementsHidden:(BOOL)hidden {
+  self.view.accessibilityElementsHidden = hidden;
+
+  UIView *presentedView = self.presentationController.presentedView;
+  if (presentedView) {
+    presentedView.accessibilityElementsHidden = hidden;
+  }
+}
+
 - (void)setAccessibilityContentElement:(UIView *)contentView {
+  NSArray *contentElements = contentView.accessibilityElements;
+  NSArray *accessibilityElements = contentElements.count > 0 ? contentElements : @[ contentView ];
+  BOOL hasAccessibilityFooterElements = [contentView isKindOfClass:[TrueSheetContainerView class]] &&
+                                        [(TrueSheetContainerView *)contentView hasAccessibilityFooterElements];
+  BOOL isAccessibilityModal = _dimmed && !hasAccessibilityFooterElements;
+
   self.view.isAccessibilityElement = NO;
   self.view.accessibilityViewIsModal = YES;
-  self.view.accessibilityElements = @[ contentView ];
+  self.view.accessibilityElements = accessibilityElements;
 
   UIView *presentedView = self.presentationController.presentedView;
   if (presentedView) {
     presentedView.isAccessibilityElement = NO;
-    presentedView.accessibilityViewIsModal = YES;
-    presentedView.accessibilityElements = @[ contentView ];
+    presentedView.accessibilityViewIsModal = isAccessibilityModal;
+    presentedView.accessibilityElements = accessibilityElements;
+
+    UIWindow *window = self.view.window;
+    UIViewController *presentingViewController = [self accessibilityPresentingViewController];
+    if (window && presentingViewController.view) {
+      if (!_accessibilityWindow) {
+        _accessibilityWindow = window;
+        id previousElements = objc_getAssociatedObject(window, &TrueSheetAccessibilityWindowPreviousElementsKey);
+        if (!previousElements) {
+          previousElements = window.accessibilityElements ?: [NSNull null];
+          objc_setAssociatedObject(window, &TrueSheetAccessibilityWindowPreviousElementsKey, previousElements,
+            OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+      }
+      objc_setAssociatedObject(window, &TrueSheetAccessibilityWindowOwnerKey, [NSValue valueWithNonretainedObject:self],
+        OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+      window.accessibilityElements =
+        isAccessibilityModal ? @[ presentedView ] : @[ presentingViewController.view, presentedView ];
+      return;
+    }
   }
+
+  [self restoreWindowAccessibilityElements];
 }
 
 - (void)emitWillDismissEvents {
@@ -283,6 +357,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
 
 - (void)emitDidDismissEvents {
   if (self.isBeingDismissed) {
+    [self restoreWindowAccessibilityElements];
     _isPresented = NO;
     _isWillDismissEmitted = NO;
 
@@ -290,6 +365,7 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
     _anchorView = nil;
 
     [_parentSheetController.delegate viewControllerDidFocus];
+    [_parentSheetController setSheetAccessibilityElementsHidden:NO];
     [_parentSheetController setupAccessibilityContainer];
     _parentSheetController = nil;
 
@@ -300,6 +376,8 @@ static BOOL TrueSheetPositionStateEquals(TrueSheetPositionState a, TrueSheetPosi
 
 - (void)viewWillDisappear:(BOOL)animated {
   [super viewWillDisappear:animated];
+  [self restoreWindowAccessibilityElements];
+  [self setSheetAccessibilityElementsHidden:YES];
 
   // Dispatch to allow pan gesture to set _isDragging before checking
   // handleTransitionTracker will emit when sheet is transitioning to dismiss


### PR DESCRIPTION
## Summary

Fixes iOS footer accessibility traversal for nested footer controls by exposing footer child accessibility elements through the sheet container, recalculating the sheet accessibility container after footer layout changes, and restoring the previous window accessibility elements when the sheet dismisses.

This builds on #699 for cases where footer controls need to remain reachable by XCTest and assistive technologies while the sheet is presented.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Ran `PATH="$(dirname "$(xcrun --find clang-format)"):$PATH" scripts/objclint.sh`.
Ran `git diff --check`.
Validated the equivalent patch in Lugg iOS app E2E coverage.

## Screenshots / Videos

N/A

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)
