### PR TITLE
fix(ios): keep footer accessibility live after footer/content remounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Fixed footer accessibility elements going stale when a footer or content subtree remounts while the sheet stays presented (e.g. swapping a footer button on a state change), which hid the new controls from XCTest and assistive technologies. ([#702](https://github.com/lodev09/react-native-true-sheet/pull/702) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fixed nested footer accessibility elements and window accessibility restoration when footer controls are present. ([#700](https://github.com/lodev09/react-native-true-sheet/pull/700) by [@erickreutz](https://github.com/erickreutz))
 - **iOS**: Fixed sheet footer controls being hidden from XCTest and assistive technologies by exposing mounted sheet content and footer accessibility elements. ([#699](https://github.com/lodev09/react-native-true-sheet/pull/699) by [@erickreutz](https://github.com/erickreutz))
 - **iOS**: Fixed Mac Catalyst build issue. ([#685](https://github.com/lodev09/react-native-true-sheet/pull/685) by [@theeket](https://github.com/theeket))

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -308,13 +308,24 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 }
 
 - (void)setAccessibilityContentElement:(UIView *)contentView {
-  NSArray *contentElements = contentView.accessibilityElements;
-  NSArray *accessibilityElements = contentElements.count > 0 ? contentElements : @[ contentView ];
   BOOL hasAccessibilityFooterElements = [contentView isKindOfClass:[TrueSheetContainerView class]] &&
                                         [(TrueSheetContainerView *)contentView hasAccessibilityFooterElements];
   // Footer controls exposed as separate accessibility elements can be skipped
   // by XCTest when the presented sheet is a hard modal accessibility boundary.
   BOOL isAccessibilityModal = _dimmed && !hasAccessibilityFooterElements;
+
+  // At a hard modal boundary XCTest skips nested elements, so flatten the
+  // container's children into the array. Otherwise expose the container itself:
+  // its accessibilityElements getter recomputes live, so a footer/content subtree
+  // that remounts (e.g. swapping a footer button on a state change) stays
+  // discoverable instead of leaving this snapshot pointing at destroyed views.
+  NSArray *accessibilityElements;
+  if (isAccessibilityModal) {
+    NSArray *contentElements = contentView.accessibilityElements;
+    accessibilityElements = contentElements.count > 0 ? contentElements : @[ contentView ];
+  } else {
+    accessibilityElements = @[ contentView ];
+  }
 
   self.view.isAccessibilityElement = NO;
   self.view.accessibilityViewIsModal = YES;


### PR DESCRIPTION
## Problem

`setAccessibilityContentElement:` flattened the container's accessibility children into a **frozen** `accessibilityElements` array on `self.view` / `presentedView`. When a footer subtree remounts while the sheet stays presented — e.g. swapping a footer button on a state change (OFFERED → ACCEPTED), or advancing between stops — the snapshot kept pointing at the **destroyed** views. XCTest/VoiceOver (and tools like Maestro) could no longer find the new control.

The transition is a `resize`, not a re-present, so `viewDidAppear` never fires again and the snapshot is never refreshed.

## Fix

Expose the **container itself** (`@[contentView]`) for the non-modal case instead of a flattened child array. `TrueSheetContainerView.accessibilityElements` and `TrueSheetFooterView.accessibilityElements` both recompute by walking the live subview tree on every read, so traversal stays current after any footer/content remount.

The hard-modal branch (dimmed + no footer) keeps the flattened form, since that's the case where XCTest skips nested elements — existing behavior there is untouched.

## Test

Verified against a worker app whose footer swipe button remounts on a state change: before, the post-transition swipe control was missing from the accessibility tree; after, it's discoverable across both the state change and stop→stop transitions.