### PR TITLE
fix(ios): yield sheet accessibility override when overlay presents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Fixed controllers presented over an open sheet (alert, action sheet, image picker) being unreachable by XCTest and assistive technologies by yielding the sheet's window accessibility override while the overlay is presented. ([#703](https://github.com/lodev09/react-native-true-sheet/pull/703) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fixed footer accessibility elements going stale when a footer or content subtree remounts while the sheet stays presented (e.g. swapping a footer button on a state change), which hid the new controls from XCTest and assistive technologies. ([#702](https://github.com/lodev09/react-native-true-sheet/pull/702) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fixed nested footer accessibility elements and window accessibility restoration when footer controls are present. ([#700](https://github.com/lodev09/react-native-true-sheet/pull/700) by [@erickreutz](https://github.com/erickreutz))
 - **iOS**: Fixed sheet footer controls being hidden from XCTest and assistive technologies by exposing mounted sheet content and footer accessibility elements. ([#699](https://github.com/lodev09/react-native-true-sheet/pull/699) by [@erickreutz](https://github.com/erickreutz))

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -366,10 +366,11 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
                      animated:(BOOL)flag
                    completion:(void (^)(void))completion {
   // A non-sheet controller (e.g. an action sheet, alert, or image picker) is about
-  // to present over us. Yield our window accessibility override so XCTest and
-  // assistive technologies can reach it; nested sheets claim their own override.
+  // to present over us. Clear our window accessibility override so UIKit's default
+  // traversal surfaces it for XCTest and assistive technologies; we reclaim the
+  // override when it dismisses. Nested sheets claim their own override.
   if (![viewControllerToPresent isKindOfClass:[TrueSheetViewController class]]) {
-    [self restoreWindowAccessibilityElements];
+    self.view.window.accessibilityElements = nil;
   }
 
   [super presentViewController:viewControllerToPresent animated:flag completion:completion];

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -360,6 +360,36 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   [self restoreWindowAccessibilityElements];
 }
 
+#pragma mark - Presentation
+
+- (void)presentViewController:(UIViewController *)viewControllerToPresent
+                     animated:(BOOL)flag
+                   completion:(void (^)(void))completion {
+  // A non-sheet controller (e.g. an action sheet, alert, or image picker) is about
+  // to present over us. Yield our window accessibility override so XCTest and
+  // assistive technologies can reach it; nested sheets claim their own override.
+  if (![viewControllerToPresent isKindOfClass:[TrueSheetViewController class]]) {
+    [self restoreWindowAccessibilityElements];
+  }
+
+  [super presentViewController:viewControllerToPresent animated:flag completion:completion];
+}
+
+- (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^)(void))completion {
+  [super dismissViewControllerAnimated:flag
+                            completion:^{
+                              if (completion) {
+                                completion();
+                              }
+
+                              // Reclaim the window accessibility override once nothing
+                              // else is presented over us.
+                              if (self.isPresented && self.presentedViewController == nil) {
+                                [self setupAccessibilityContainer];
+                              }
+                            }];
+}
+
 - (void)emitWillDismissEvents {
   if (self.isBeingDismissed && !_isWillDismissEmitted) {
     _isWillDismissEmitted = YES;


### PR DESCRIPTION
## Summary

When a sheet is open it installs a window-level accessibility override so XCTest/VoiceOver traverse only the sheet's content. Any non-sheet controller presented over the sheet (alert, action sheet, image picker) was unreachable because the window's `accessibilityElements` still pointed at the sheet.

- `presentViewController:` — before presenting a non-sheet controller, release the override so the overlay is reachable. Nested `TrueSheetViewController`s are skipped (they install their own override).
- `dismissViewControllerAnimated:` — after the overlay dismisses, reclaim the override if the sheet is still presented with nothing on top.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Present an alert/action sheet over an open sheet and confirm XCTest and VoiceOver can reach it; confirm the sheet reclaims accessibility traversal after the overlay dismisses.

## Screenshots / Videos

<!-- N/A -->

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)