### PR TITLE
docs: note Expo precompiled modules drop the react-native-screens patch on EAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - Bump `react-native-monorepo-config` to fix build on windows. ([#672](https://github.com/lodev09/react-native-true-sheet/pull/672) by [@harveylx](https://github.com/harveylx))
 - Upgrade examples to Expo SDK 56 / React Native 0.85.3, TypeScript 6, and `react-native-builder-bob` 0.41. ([#694](https://github.com/lodev09/react-native-true-sheet/pull/694) by [@lodev09](https://github.com/lodev09))
+- **Docs**: Documented that Expo SDK 56+ ships `react-native-screens` precompiled on EAS, silently dropping the navigation patch; added a Troubleshooting fix (`EXPO_USE_PRECOMPILED_MODULES=0`). ([#715](https://github.com/lodev09/react-native-true-sheet/pull/715) by [@lodev09](https://github.com/lodev09))
 
 ## 3.10.1
 

--- a/docs/docs/guides/navigation.mdx
+++ b/docs/docs/guides/navigation.mdx
@@ -276,7 +276,9 @@ navigation.navigate('SomeScreen')
 ```
 
 :::note
-Requires a [patch to react-native-screens](https://github.com/lodev09/react-native-true-sheet/blob/main/.yarn/patches/react-native-screens-npm-4.18.0-fa7de65975.patch). See [PR #3415](https://github.com/software-mansion/react-native-screens/pull/3415).
+Requires a [patch to react-native-screens](https://github.com/lodev09/react-native-true-sheet/blob/main/.yarn/patches/react-native-screens-npm-4.25.2.patch). See [PR #3415](https://github.com/software-mansion/react-native-screens/pull/3415).
+
+On **Expo SDK 56+**, this patch is silently dropped on EAS builds because `react-native-screens` ships precompiled. See [Patched react-native-screens Not Applied on EAS](../troubleshooting#patched-react-native-screens-not-applied-on-eas-precompiled-modules) to force it to build from source.
 :::
 
 ### Web Limitation

--- a/docs/docs/migration.mdx
+++ b/docs/docs/migration.mdx
@@ -383,7 +383,7 @@ See the [Configuration reference](reference/configuration#bluroptions) for more 
 Version 3 works seamlessly with React Navigation! You can navigate to other screens from within a sheet and the sheet will remain visible in the background when presenting modals on top.
 
 :::note
-This requires changes to `react-native-screens`. There is a [pending PR](https://github.com/software-mansion/react-native-screens/pull/3415) that adds support for this. In the meantime, you can apply the patch from the [example app](https://github.com/lodev09/react-native-true-sheet/blob/main/.yarn/patches/react-native-screens-npm-4.18.0-fa7de65975.patch).
+This requires changes to `react-native-screens`. There is a [pending PR](https://github.com/software-mansion/react-native-screens/pull/3415) that adds support for this. In the meantime, you can apply the patch from the [example app](https://github.com/lodev09/react-native-true-sheet/blob/main/.yarn/patches/react-native-screens-npm-4.25.2.patch).
 :::
 
 ```tsx

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -140,3 +140,43 @@ When using [EAS Build](https://docs.expo.dev/build/introduction/), configure you
   }
 }
 ```
+
+### Patched `react-native-screens` Not Applied on EAS (Precompiled Modules)
+
+If you apply the [`react-native-screens` patch](guides/navigation) so the sheet stays visible when presenting screens on top, you may find that on **Expo SDK 56+ EAS builds** the sheet dismisses — or a full-screen modal fails to present over the sheet — even though it works in a local build.
+
+This is because Expo SDK 56 ships `react-native-screens` (and other common libraries like `react-native-reanimated`, `react-native-svg`) as **precompiled XCFrameworks** on EAS. The prebuilt framework is built from the library's own source, so any patch you apply to `react-native-screens` (via `patch-package`, `pnpm patch`, or Yarn `patches`) is **never compiled in** — it's silently ignored on EAS, while local builds still work because they fall back to compiling from source.
+
+**Fix:**
+
+Disable precompiled modules so `react-native-screens` builds from your patched source. Add the env var to each build profile in `eas.json`:
+
+```json
+{
+  "build": {
+    "development": { "env": { "EXPO_USE_PRECOMPILED_MODULES": "0" } },
+    "preview": { "env": { "EXPO_USE_PRECOMPILED_MODULES": "0" } },
+    "production": { "env": { "EXPO_USE_PRECOMPILED_MODULES": "0" } }
+  }
+}
+```
+
+This only disables **module** precompilation — React Native core stays prebuilt, so build times are largely unaffected.
+
+:::info
+To keep precompiled modules for everything else and only build `react-native-screens` from source, opt it out per-package in `package.json` instead:
+
+```json
+{
+  "expo": {
+    "autolinking": {
+      "ios": { "buildFromSource": ["react-native-screens"] }
+    }
+  }
+}
+```
+:::
+
+:::warning
+Avoid `ios.buildReactNativeFromSource: true` for this — it also rebuilds React Native core from source, which is much slower.
+:::


### PR DESCRIPTION
## Summary

Documents that on **Expo SDK 56+**, EAS ships `react-native-screens` as a precompiled XCFramework, which silently drops the `react-native-screens` patch required for the React Navigation "sheet stays visible when presenting screens on top" feature. The result is the sheet dismissing (or a full-screen modal failing to present) on EAS builds while working locally.

- Adds a Troubleshooting section explaining the cause and the fix (`EXPO_USE_PRECOMPILED_MODULES=0`, with a per-package `buildFromSource` alternative).
- Links to it from the React Navigation guide's patch note.
- Fixes stale patch links (`4.18.0` → `4.25.2`) in the navigation guide and migration docs.

## Type of Change

- [x] Documentation update

## Test Plan

Docs-only. Verified the troubleshooting anchor matches the Docusaurus slug and the relative link resolves from `guides/`.
