### PR TITLE
feat: add footerOptions.keyboardOffset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🎉 New features
 
-- Added `footerOptions.keyboardOffset` to reduce how far the footer rises when the keyboard opens, so its safe-area padding tucks behind the keyboard instead of leaving a gap. ([#716](https://github.com/lodev09/react-native-true-sheet/pull/716) by [@bigcupcoffee](https://github.com/bigcupcoffee))
+- Added `footerOptions.keyboardOffset` to adjust how far the footer rises when the keyboard opens. Pass `-insets.bottom` to tuck its safe-area padding behind the keyboard instead of leaving a gap. ([#716](https://github.com/lodev09/react-native-true-sheet/pull/716) by [@bigcupcoffee](https://github.com/bigcupcoffee))
 
 ## 3.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🎉 New features
+
+- Added `footerOptions.keyboardOffset` to reduce how far the footer rises when the keyboard opens, so its safe-area padding tucks behind the keyboard instead of leaving a gap. ([#716](https://github.com/lodev09/react-native-true-sheet/pull/716) by [@bigcupcoffee](https://github.com/bigcupcoffee))
+
 ## 3.11.0
 
 ### 🎉 New features

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -7,6 +7,7 @@ import android.view.accessibility.AccessibilityEvent
 import androidx.annotation.UiThread
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
@@ -281,6 +282,10 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
   fun setScrollableOptions(options: ScrollableOptions?) {
     viewController.scrollableOptions = options
     setupScrollable()
+  }
+
+  fun setFooterKeyboardOffset(offset: Float) {
+    viewController.footerKeyboardOffset = offset.dpToPx().toInt()
   }
 
   private fun setupScrollable() {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -286,6 +286,7 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
 
   fun setFooterKeyboardOffset(offset: Float) {
     viewController.footerKeyboardOffset = offset.dpToPx().toInt()
+    viewController.positionFooter()
   }
 
   private fun setupScrollable() {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -979,6 +979,8 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   // MARK: - Footer Positioning
   // =============================================================================
 
+  var footerKeyboardOffset: Int = 0
+
   fun positionFooter(slideOffset: Float? = null) {
     if (!isPresented) return
     val footerView = containerView?.footerView ?: return
@@ -988,7 +990,8 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     val sheetHeight = sheet.height
     val sheetTop = sheet.top
 
-    var footerY = (sheetHeight - sheetTop - footerHeight - currentKeyboardInset).toFloat()
+    val keyboardShift = maxOf(0, currentKeyboardInset - footerKeyboardOffset)
+    var footerY = (sheetHeight - sheetTop - footerHeight - keyboardShift).toFloat()
 
     // Adjust during dismiss animation when slideOffset is negative
     if (slideOffset != null && slideOffset < 0) {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -990,7 +990,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     val sheetHeight = sheet.height
     val sheetTop = sheet.top
 
-    val keyboardShift = maxOf(0, currentKeyboardInset + footerKeyboardOffset)
+    val keyboardShift = if (currentKeyboardInset > 0) maxOf(0, currentKeyboardInset + footerKeyboardOffset) else 0
     var footerY = (sheetHeight - sheetTop - footerHeight - keyboardShift).toFloat()
 
     // Adjust during dismiss animation when slideOffset is negative

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -990,7 +990,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     val sheetHeight = sheet.height
     val sheetTop = sheet.top
 
-    val keyboardShift = maxOf(0, currentKeyboardInset - footerKeyboardOffset)
+    val keyboardShift = maxOf(0, currentKeyboardInset + footerKeyboardOffset)
     var footerY = (sheetHeight - sheetTop - footerHeight - keyboardShift).toFloat()
 
     // Adjust during dismiss animation when slideOffset is negative

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -230,6 +230,13 @@ class TrueSheetViewManager :
     view.setScrollableOptions(scrollableOptions)
   }
 
+  @ReactProp(name = "footerOptions")
+  override fun setFooterOptions(view: TrueSheetView, options: ReadableMap?) {
+    val keyboardOffset =
+      if (options != null && options.hasKey("keyboardOffset")) options.getDouble("keyboardOffset").toFloat() else 0f
+    view.setFooterKeyboardOffset(keyboardOffset)
+  }
+
   companion object {
     const val REACT_CLASS = "TrueSheetView"
     const val TAG_NAME = "TrueSheet"

--- a/docs/docs/guides/footer.mdx
+++ b/docs/docs/guides/footer.mdx
@@ -86,7 +86,7 @@ const MyFooter = () => {
 
 This ensures the footer background extends into the safe area while keeping the content above the home indicator.
 
-When the keyboard opens, that bottom padding leaves a gap above the keyboard. Pass the same inset to [`footerOptions.keyboardOffset`](../reference/configuration#footeroptions) to tuck it behind the keyboard — see [Keyboard Handling](./keyboard#footer-behavior).
+When the keyboard opens, that bottom padding leaves a gap above the keyboard. Pass `-insets.bottom` to [`footerOptions.keyboardOffset`](../reference/configuration#footeroptions) to tuck it behind the keyboard — see [Keyboard Handling](./keyboard#footer-behavior).
 
 :::note
 On iPad, the sheet is displayed as a floating modal, so bottom padding is not needed.

--- a/docs/docs/guides/footer.mdx
+++ b/docs/docs/guides/footer.mdx
@@ -86,6 +86,8 @@ const MyFooter = () => {
 
 This ensures the footer background extends into the safe area while keeping the content above the home indicator.
 
+When the keyboard opens, that bottom padding leaves a gap above the keyboard. Pass the same inset to [`footerOptions.keyboardOffset`](../reference/configuration#footeroptions) to tuck it behind the keyboard — see [Keyboard Handling](./keyboard#footer-behavior).
+
 :::note
 On iPad, the sheet is displayed as a floating modal, so bottom padding is not needed.
 :::

--- a/docs/docs/guides/keyboard.mdx
+++ b/docs/docs/guides/keyboard.mdx
@@ -56,6 +56,18 @@ This is especially useful for forms with multiple inputs — as the user taps be
 
 When using a [`footer`](../reference/configuration#footer) component, it automatically repositions above the keyboard, staying visible while the user types.
 
+If your footer renders its own bottom inset (e.g. safe-area padding for the home indicator), that padding leaves a gap above the keyboard. Use `keyboardOffset` in [`footerOptions`](../reference/configuration#footeroptions) to tuck it behind the keyboard:
+
+```tsx
+const insets = useSafeAreaInsets()
+
+<TrueSheet footer={<Footer />} footerOptions={{ keyboardOffset: insets.bottom }}>
+  {/* ... */}
+</TrueSheet>
+```
+
+The footer slides up by the keyboard height minus `keyboardOffset`, so its content sits flush above the keyboard while the inset hides behind it.
+
 ## Autofocus Limitation
 
 Avoid using `autoFocus` on `TextInput` components inside the sheet. The keyboard may appear before the sheet has finished presenting, causing layout issues.

--- a/docs/docs/guides/keyboard.mdx
+++ b/docs/docs/guides/keyboard.mdx
@@ -56,17 +56,17 @@ This is especially useful for forms with multiple inputs — as the user taps be
 
 When using a [`footer`](../reference/configuration#footer) component, it automatically repositions above the keyboard, staying visible while the user types.
 
-If your footer renders its own bottom inset (e.g. safe-area padding for the home indicator), that padding leaves a gap above the keyboard. Use `keyboardOffset` in [`footerOptions`](../reference/configuration#footeroptions) to tuck it behind the keyboard:
+If your footer renders its own bottom inset (e.g. safe-area padding for the home indicator), that padding leaves a gap above the keyboard. Use `keyboardOffset` in [`footerOptions`](../reference/configuration#footeroptions) to adjust the rise — pass `-insets.bottom` to tuck the inset behind the keyboard:
 
 ```tsx
 const insets = useSafeAreaInsets()
 
-<TrueSheet footer={<Footer />} footerOptions={{ keyboardOffset: insets.bottom }}>
+<TrueSheet footer={<Footer />} footerOptions={{ keyboardOffset: -insets.bottom }}>
   {/* ... */}
 </TrueSheet>
 ```
 
-The footer slides up by the keyboard height minus `keyboardOffset`, so its content sits flush above the keyboard while the inset hides behind it.
+The footer slides up by the keyboard height plus `keyboardOffset`. A negative value reduces the rise so the inset sits behind the keyboard; a positive value raises the footer higher.
 
 ## Autofocus Limitation
 

--- a/docs/docs/reference/01-configuration.mdx
+++ b/docs/docs/reference/01-configuration.mdx
@@ -288,6 +288,14 @@ Style for the footer container.
 | - | - | - | - | - |
 | `StyleProp<ViewStyle>` | | ✅ | ✅ | ✅ |
 
+## `footerOptions`
+
+Options for customizing footer behavior.
+
+| Type | Default | 🍎 | 🤖 | 🌐 |
+| - | - | - | - | - |
+| [`FooterOptions`](types#footeroptions) | | ✅ | ✅ | |
+
 ## `scrollable`
 
 On iOS, automatically pins ScrollView or FlatList to fit within the sheet's available space. When enabled, the ScrollView's top edge will be pinned below any top sibling views, and its left, right, and bottom edges will be pinned to the container. See [this guide](../guides/scrolling) for example.

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -100,6 +100,25 @@ Options for customizing scrollable behavior. Only applies when `scrollable` is `
 | `topScrollEdgeEffect` | [`ScrollEdgeEffect`](#scrolledgeeffect) | The scroll edge effect applied to the top edge of the scroll view and header. iOS 26+ only. | `'hidden'` |
 | `bottomScrollEdgeEffect` | [`ScrollEdgeEffect`](#scrolledgeeffect) | The scroll edge effect applied to the bottom edge of the scroll view and footer. iOS 26+ only. | `'hidden'` |
 
+## `FooterOptions`
+
+Options for customizing footer behavior.
+
+```tsx
+<TrueSheet
+  footer={<Footer />}
+  footerOptions={{
+    keyboardOffset: insets.bottom,
+  }}
+>
+  {/* ... */}
+</TrueSheet>
+```
+
+| Property | Type | Description | Default |
+| - | - | - | - |
+| `keyboardOffset` | `number` | Reduces how far the footer rises when the keyboard opens, so its safe-area padding tucks behind the keyboard instead of leaving a gap. | `0` |
+
 ## `ScrollEdgeEffect`
 
 Controls the blur/gradient edge effect on the scroll view edges and header/footer overlay views. iOS 26+ only.

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -108,7 +108,7 @@ Options for customizing footer behavior.
 <TrueSheet
   footer={<Footer />}
   footerOptions={{
-    keyboardOffset: insets.bottom,
+    keyboardOffset: -insets.bottom,
   }}
 >
   {/* ... */}
@@ -117,7 +117,7 @@ Options for customizing footer behavior.
 
 | Property | Type | Description | Default |
 | - | - | - | - |
-| `keyboardOffset` | `number` | Reduces how far the footer rises when the keyboard opens, so its safe-area padding tucks behind the keyboard instead of leaving a gap. | `0` |
+| `keyboardOffset` | `number` | Adjusts how far the footer rises when the keyboard opens. Positive values raise it higher; pass `-insets.bottom` to tuck its safe-area padding behind the keyboard instead of leaving a gap. | `0` |
 
 ## `ScrollEdgeEffect`
 

--- a/example/shared/src/components/sheets/PromptSheet.tsx
+++ b/example/shared/src/components/sheets/PromptSheet.tsx
@@ -80,7 +80,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
       <ScrollView
         nestedScrollEnabled
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={[styles.content, { paddingBottom: FOOTER_HEIGHT + GAP * 2 }]}
+        contentContainerStyle={[styles.content, { paddingBottom: FOOTER_HEIGHT + GAP + SPACING }]}
         scrollIndicatorInsets={{ bottom: FOOTER_HEIGHT + GAP }}
       >
         <Input

--- a/example/shared/src/components/sheets/PromptSheet.tsx
+++ b/example/shared/src/components/sheets/PromptSheet.tsx
@@ -74,7 +74,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
           <Button style={styles.button} text="Submit" onPress={handleSubmitPress} />
         </View>
       }
-      footerOptions={{ keyboardOffset: bottom }}
+      footerOptions={{ keyboardOffset: -bottom }}
       {...props}
     >
       <ScrollView

--- a/example/shared/src/components/sheets/PromptSheet.tsx
+++ b/example/shared/src/components/sheets/PromptSheet.tsx
@@ -47,7 +47,11 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
       name="prompt-sheet"
       detents={[0.75, 1]}
       scrollable
-      scrollableOptions={{ keyboardScrollOffset: FOOTER_HEIGHT + SPACING }}
+      scrollableOptions={{
+        keyboardScrollOffset: FOOTER_HEIGHT + SPACING,
+        topScrollEdgeEffect: 'soft',
+        bottomScrollEdgeEffect: 'soft',
+      }}
       backgroundBlur="dark"
       backgroundColor={DARK}
       onDidDismiss={handleDismiss}

--- a/example/shared/src/components/sheets/PromptSheet.tsx
+++ b/example/shared/src/components/sheets/PromptSheet.tsx
@@ -1,17 +1,18 @@
 import { forwardRef, useRef, type Ref, useImperativeHandle } from 'react';
-import { ScrollView, StyleSheet, TextInput } from 'react-native';
+import { ScrollView, StyleSheet, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
 
-import { DARK, FOOTER_HEIGHT, GAP, SPACING } from '../../utils';
+import { DARK, BUTTON_HEIGHT as FOOTER_HEIGHT, GAP, SPACING } from '../../utils';
 import { Input } from '../Input';
 import { Button } from '../Button';
 import { Header } from '../Header';
-import { Spacer } from '../Spacer';
-import { Footer } from '../Footer';
 
 interface PromptSheetProps extends TrueSheetProps {}
 
 export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueSheet>) => {
+  const { bottom } = useSafeAreaInsets();
+
   const sheetRef = useRef<TrueSheet>(null);
   const input1Ref = useRef<TextInput>(null);
   const input2Ref = useRef<TextInput>(null);
@@ -67,14 +68,20 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
         console.log('Back button pressed!');
       }}
       header={<Header />}
-      footer={<Footer />}
+      footer={
+        <View style={[styles.footer, { paddingBottom: bottom + GAP }]}>
+          <Button style={styles.button} text="Dismiss" onPress={handleDismissPress} />
+          <Button style={styles.button} text="Submit" onPress={handleSubmitPress} />
+        </View>
+      }
+      footerOptions={{ keyboardOffset: bottom }}
       {...props}
     >
       <ScrollView
         nestedScrollEnabled
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={styles.content}
-        scrollIndicatorInsets={{ bottom: FOOTER_HEIGHT }}
+        contentContainerStyle={[styles.content, { paddingBottom: FOOTER_HEIGHT + GAP * 2 }]}
+        scrollIndicatorInsets={{ bottom: FOOTER_HEIGHT + GAP }}
       >
         <Input
           ref={input1Ref}
@@ -150,9 +157,6 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
           onSubmitEditing={() => textAreaRef.current?.focus()}
         />
         <Input ref={textAreaRef} placeholder="Message..." multiline />
-        <Spacer />
-        <Button text="Submit" onPress={handleSubmitPress} />
-        <Button text="Dismiss" onPress={handleDismissPress} />
       </ScrollView>
     </TrueSheet>
   );
@@ -161,8 +165,15 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
 const styles = StyleSheet.create({
   content: {
     padding: SPACING,
-    paddingBottom: FOOTER_HEIGHT + SPACING,
     gap: GAP,
+  },
+  footer: {
+    flexDirection: 'row',
+    paddingHorizontal: SPACING,
+    gap: GAP,
+  },
+  button: {
+    flex: 1,
   },
 });
 

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -72,6 +72,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)layoutFooter;
 
+/**
+ * Re-applies the footer's keyboard slide to reflect a live `keyboardOffset` change.
+ */
+- (void)updateFooterKeyboardOffset;
+
 - (BOOL)hasAccessibilityFooterElements;
 
 /**

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -128,6 +128,10 @@ using namespace facebook::react;
   }
 }
 
+- (void)updateFooterKeyboardOffset {
+  [_footerView applyKeyboardOffset];
+}
+
 - (void)setScrollableEnabled:(BOOL)scrollableEnabled {
   _scrollableEnabled = scrollableEnabled;
   _scrollableSet = YES;

--- a/ios/TrueSheetFooterView.h
+++ b/ios/TrueSheetFooterView.h
@@ -29,6 +29,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setupConstraintsWithHeight:(CGFloat)height;
 
+/**
+ * Re-applies the footer's keyboard slide using the current keyboard height.
+ * No-op when the keyboard is hidden. Used to reflect live `keyboardOffset` changes.
+ */
+- (void)applyKeyboardOffset;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/TrueSheetFooterView.mm
+++ b/ios/TrueSheetFooterView.mm
@@ -151,13 +151,15 @@ using namespace facebook::react;
     return;
   }
 
-  _currentKeyboardOffset = height;
+  CGFloat keyboardOffset = self.keyboardObserver.viewController.footerKeyboardOffset;
+  CGFloat slide = MAX(0, height - keyboardOffset);
+  _currentKeyboardOffset = slide;
 
   [UIView animateWithDuration:duration
                         delay:0
                       options:curve | UIViewAnimationOptionBeginFromCurrentState
                    animations:^{
-                     self->_bottomConstraint.constant = -height;
+                     self->_bottomConstraint.constant = -slide;
                      [self.superview layoutIfNeeded];
                    }
                    completion:nil];

--- a/ios/TrueSheetFooterView.mm
+++ b/ios/TrueSheetFooterView.mm
@@ -152,7 +152,7 @@ using namespace facebook::react;
   }
 
   CGFloat keyboardOffset = self.keyboardObserver.viewController.footerKeyboardOffset;
-  CGFloat slide = MAX(0, height - keyboardOffset);
+  CGFloat slide = MAX(0, height + keyboardOffset);
   _currentKeyboardOffset = slide;
 
   [UIView animateWithDuration:duration

--- a/ios/TrueSheetFooterView.mm
+++ b/ios/TrueSheetFooterView.mm
@@ -182,6 +182,19 @@ using namespace facebook::react;
                    completion:nil];
 }
 
+- (void)applyKeyboardOffset {
+  CGFloat height = self.keyboardObserver.currentHeight;
+  if (!_bottomConstraint || height <= 0) {
+    return;
+  }
+
+  CGFloat keyboardOffset = self.keyboardObserver.viewController.footerKeyboardOffset;
+  CGFloat slide = MAX(0, height + keyboardOffset);
+  _currentKeyboardOffset = slide;
+  _bottomConstraint.constant = -slide;
+  [self.superview layoutIfNeeded];
+}
+
 @end
 
 Class<RCTComponentViewProtocol> TrueSheetFooterViewCls(void) {

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -263,6 +263,7 @@ using namespace facebook::react;
   }
 
   _controller.scrollingExpandsSheet = scrollingExpandsSheet;
+  _controller.footerKeyboardOffset = newProps.footerOptions.keyboardOffset;
 
   _insetAdjustment = newProps.insetAdjustment;
   _controller.insetAdjustment = _insetAdjustment;

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -263,7 +263,12 @@ using namespace facebook::react;
   }
 
   _controller.scrollingExpandsSheet = scrollingExpandsSheet;
-  _controller.footerKeyboardOffset = newProps.footerOptions.keyboardOffset;
+
+  CGFloat footerKeyboardOffset = newProps.footerOptions.keyboardOffset;
+  if (_controller.footerKeyboardOffset != footerKeyboardOffset) {
+    _controller.footerKeyboardOffset = footerKeyboardOffset;
+    [_containerView updateFooterKeyboardOffset];
+  }
 
   _insetAdjustment = newProps.insetAdjustment;
   _controller.insetAdjustment = _insetAdjustment;

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -71,6 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) facebook::react::TrueSheetViewAnchor anchor;
 @property (nonatomic, assign) facebook::react::TrueSheetViewInsetAdjustment insetAdjustment;
 @property (nonatomic, assign) BOOL scrollingExpandsSheet;
+@property (nonatomic, assign) CGFloat footerKeyboardOffset;
 @property (nonatomic, assign) BOOL dismissible;
 @property (nonatomic, assign) BOOL isPresented;
 @property (nonatomic, assign) NSInteger activeDetentIndex;

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -454,6 +454,7 @@ export class TrueSheet
       anchorOffset,
       scrollable = false,
       scrollableOptions,
+      footerOptions,
       presentation = 'page',
       children,
       style,
@@ -509,6 +510,7 @@ export class TrueSheet
         anchorOffset={anchorOffset}
         scrollable={scrollable}
         scrollableOptions={scrollableOptions}
+        footerOptions={footerOptions}
         presentation={presentation}
         insetAdjustment={insetAdjustment}
         onMount={this.onMount}

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -133,6 +133,19 @@ export interface ScrollableOptions {
 }
 
 /**
+ * Options for footer behavior
+ */
+export interface FooterOptions {
+  /**
+   * Reduces how far the footer rises when the keyboard opens.
+   * Use it to tuck the footer's safe-area padding behind the keyboard.
+   *
+   * @default 0
+   */
+  keyboardOffset?: number;
+}
+
+/**
  * Options for customizing the blur effect.
  * Only applies when `backgroundBlur` is set.
  *
@@ -450,6 +463,11 @@ export interface TrueSheetProps extends ViewProps {
    * Options for scrollable behavior.
    */
   scrollableOptions?: ScrollableOptions;
+
+  /**
+   * Options for footer behavior.
+   */
+  footerOptions?: FooterOptions;
 
   /**
    * Renders the sheet as a detached floating card, not attached to the bottom edge.

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -137,8 +137,9 @@ export interface ScrollableOptions {
  */
 export interface FooterOptions {
   /**
-   * Reduces how far the footer rises when the keyboard opens.
-   * Use it to tuck the footer's safe-area padding behind the keyboard.
+   * Adjusts how far the footer rises when the keyboard opens.
+   * Positive values raise it higher; negative values reduce the rise.
+   * Pass `-insets.bottom` to tuck the footer's safe-area padding behind the keyboard.
    *
    * @default 0
    */

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -30,6 +30,10 @@ type ScrollableOptionsType = Readonly<{
   bottomScrollEdgeEffect?: WithDefault<ScrollEdgeEffect, 'hidden'>;
 }>;
 
+type FooterOptionsType = Readonly<{
+  keyboardOffset?: WithDefault<Double, 0>;
+}>;
+
 export interface DetentInfoEventPayload {
   index: Int32;
   position: Double;
@@ -101,6 +105,7 @@ export interface NativeProps extends ViewProps {
   initialDetentAnimated?: WithDefault<boolean, true>;
   scrollable?: WithDefault<boolean, false>;
   scrollableOptions?: ScrollableOptionsType;
+  footerOptions?: FooterOptionsType;
   presentation?: WithDefault<'page' | 'form', 'page'>;
 
   // Event handlers


### PR DESCRIPTION
## Summary

Add `footerOptions.keyboardOffset` so we can offset the safe area bottom padding we usually apply when keyboard is open.

Scrollable sheets without a footer when raised do not have any extra bottom space you can scroll to

If prop is updated while keyboard is open Android will update the position in real-time, while iOS won't (no layout update or keyboard event happens). I didn't add any extra logic to handle it on iOS, let me know if (and ideally how) you'd want that too

## Type of Change

- [x] New feature

## Test Plan

Simulators

## Screenshots / Videos

Both iOS/Android videos first shows before using it, then after (simple footer with `paddingBottom: bottomInset + GAP`)

| iOS | Android |
| -- | -- |
| ![ios.mov](https://github.com/user-attachments/assets/1b69ee47-dacb-41e9-9a4e-db58eec4ec1d) | ![android.mp4](https://github.com/user-attachments/assets/f7a1c346-35af-40df-a564-ba784d834e9e) |

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)
