### PR TITLE
feat: interactive back-swipe (iOS) and back propagation when not dismissible (Android)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### 🎉 New features
+
+- **iOS**: The system back-swipe now interactively drags the sheet closed, tracking the finger and emitting `onPositionChange` through the drag and cancel/commit settle. ([#719](https://github.com/lodev09/react-native-true-sheet/pull/719) by [@lodev09](https://github.com/lodev09))
+
+### 🐛 Bug fixes
+
+- **Android**: A non-dismissible sheet no longer collapses to the first detent on back; back now propagates so navigation can go back to the previous screen. ([#719](https://github.com/lodev09/react-native-true-sheet/pull/719) by [@lodev09](https://github.com/lodev09))
+
 ## 3.11.1
 
 ### 🎉 New features

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -783,8 +783,6 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   fun handleBackPress() {
     if (dismissible) {
       dismiss(animated = true)
-    } else if (currentDetentIndex > 0) {
-      setStateForDetentIndex(0)
     }
   }
 

--- a/example/shared/src/screens/TestScreen.tsx
+++ b/example/shared/src/screens/TestScreen.tsx
@@ -24,7 +24,7 @@ export const TestScreen = ({ onGoBack }: TestScreenProps) => {
         <Button text="Prompt Sheet" onPress={() => promptSheet.current?.present()} />
         <Button text="FlatList Sheet" onPress={() => flatListSheet.current?.present()} />
 
-        <BasicSheet initialDetentIndex={0} dimmed={false} ref={basicSheet} />
+        <BasicSheet dismissible={false} initialDetentIndex={0} dimmed={false} ref={basicSheet} />
         <PromptSheet ref={promptSheet} />
         <FlatListSheet ref={flatListSheet} />
       </View>

--- a/example/shared/src/screens/TestScreen.tsx
+++ b/example/shared/src/screens/TestScreen.tsx
@@ -24,7 +24,7 @@ export const TestScreen = ({ onGoBack }: TestScreenProps) => {
         <Button text="Prompt Sheet" onPress={() => promptSheet.current?.present()} />
         <Button text="FlatList Sheet" onPress={() => flatListSheet.current?.present()} />
 
-        <BasicSheet dimmed={false} ref={basicSheet} />
+        <BasicSheet initialDetentIndex={0} dimmed={false} ref={basicSheet} />
         <PromptSheet ref={promptSheet} />
         <FlatListSheet ref={flatListSheet} />
       </View>

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -705,6 +705,28 @@ using namespace facebook::react;
   }
 }
 
+- (void)presenterInteractiveDismissDidBegin {
+  [_controller beginInteractiveDismiss];
+}
+
+- (void)presenterInteractiveDismissDidUpdate:(CGFloat)progress {
+  [_controller updateInteractiveDismiss:progress];
+}
+
+- (void)presenterInteractiveDismissDidEnd:(BOOL)cancelled duration:(NSTimeInterval)duration {
+  if (cancelled) {
+    [_controller cancelInteractiveDismissWithDuration:duration];
+    return;
+  }
+
+  _dismissedByNavigation = YES;
+  __weak __typeof(self) weakSelf = self;
+  [_controller finishInteractiveDismissWithDuration:duration
+                                         completion:^{
+                                           [weakSelf dismissAnimated:NO completion:nil];
+                                         }];
+}
+
 #pragma mark - Private Helpers
 
 - (void)setupScrollable {

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -92,6 +92,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setupDraggable;
 - (void)setupAnchorViewInView:(UIView *)parentView;
 
+- (void)beginInteractiveDismiss;
+- (void)updateInteractiveDismiss:(CGFloat)progress;
+- (void)cancelInteractiveDismissWithDuration:(NSTimeInterval)duration;
+- (void)finishInteractiveDismissWithDuration:(NSTimeInterval)duration completion:(void (^)(void))completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -43,6 +43,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 - (void)restoreWindowAccessibilityElements;
 - (void)setSheetAccessibilityElementsHidden:(BOOL)hidden;
 - (void)setAccessibilityContentElement:(UIView *)contentView;
+- (void)endInteractiveDismissState;
 
 @end
 
@@ -60,6 +61,10 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   BOOL _isTransitionSnapping;
   BOOL _isTrackingPositionFromLayout;
   BOOL _isWillDismissEmitted;
+
+  BOOL _isInteractiveDismiss;
+  CGFloat _interactiveStartPosition;
+  UIView *_interactiveContainerView;
 
   __weak TrueSheetViewController *_parentSheetController;
 
@@ -648,6 +653,78 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
       [self emitChangePositionDelegateWithPosition:position realtime:realtime debug:@"transition in"];
     }
   }
+}
+
+#pragma mark - Interactive Navigation Dismiss
+
+- (void)beginInteractiveDismiss {
+  if (_isInteractiveDismiss) {
+    return;
+  }
+  _isInteractiveDismiss = YES;
+  _interactiveStartPosition = self.currentPosition;
+  _interactiveContainerView = self.sheet.containerView;
+}
+
+// Translate the presentation container, not the sheet's presentedView (whose transform
+// UISheetPresentationController owns for the floating-sheet inset). Only runs for undimmed
+// sheets — a dimmed sheet's dimming view intercepts the edge-swipe so the pop never starts.
+- (void)updateInteractiveDismiss:(CGFloat)progress {
+  if (!_isInteractiveDismiss) {
+    return;
+  }
+  CGFloat clamped = fmin(1, fmax(0, progress));
+  CGFloat dy = clamped * (self.screenHeight - _interactiveStartPosition);
+  _interactiveContainerView.transform = CGAffineTransformMakeTranslation(0, dy);
+}
+
+- (void)cancelInteractiveDismissWithDuration:(NSTimeInterval)duration {
+  if (!_isInteractiveDismiss) {
+    return;
+  }
+  UIView *container = _interactiveContainerView;
+  [UIView animateWithDuration:fmax(duration, 0.2)
+                        delay:0
+                      options:UIViewAnimationOptionCurveEaseOut | UIViewAnimationOptionBeginFromCurrentState |
+                              UIViewAnimationOptionAllowUserInteraction
+                   animations:^{
+                     container.transform = CGAffineTransformIdentity;
+                   }
+                   completion:^(BOOL finished) {
+                     [self endInteractiveDismissState];
+                   }];
+}
+
+- (void)finishInteractiveDismissWithDuration:(NSTimeInterval)duration completion:(void (^)(void))completion {
+  if (!_isInteractiveDismiss) {
+    if (completion) {
+      completion();
+    }
+    return;
+  }
+  UIView *container = _interactiveContainerView;
+  CGFloat dy = self.screenHeight - _interactiveStartPosition;
+
+  [UIView animateWithDuration:fmax(duration, 0.2)
+                        delay:0
+                      options:UIViewAnimationOptionCurveEaseOut | UIViewAnimationOptionBeginFromCurrentState
+                   animations:^{
+                     // Leave the sheet translated off-screen; the caller tears it down
+                     // non-animated from here so there is no second slide.
+                     container.transform = CGAffineTransformMakeTranslation(0, dy);
+                   }
+                   completion:^(BOOL finished) {
+                     [self endInteractiveDismissState];
+                     if (completion) {
+                       completion();
+                     }
+                   }];
+}
+
+- (void)endInteractiveDismissState {
+  _isInteractiveDismiss = NO;
+  _interactiveContainerView = nil;
+  _interactiveStartPosition = 0;
 }
 
 - (void)emitChangePositionDelegateWithPosition:(CGFloat)position realtime:(BOOL)realtime debug:(NSString *)debug {

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -753,21 +753,21 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   }
 
   [UIView animateWithDuration:fmax(duration, 0.2)
-                        delay:0
-                      options:options
-                   animations:^{
-                     container.transform = transform;
-                   }
-                   completion:^(BOOL finished) {
-                     // A newer gesture superseded this settle and owns teardown now.
-                     if (generation != self->_interactiveGeneration) {
-                       return;
-                     }
-                     [self endInteractiveDismissState];
-                     if (completion) {
-                       completion();
-                     }
-                   }];
+    delay:0
+    options:options
+    animations:^{
+      container.transform = transform;
+    }
+    completion:^(BOOL finished) {
+      // A newer gesture superseded this settle and owns teardown now.
+      if (generation != self->_interactiveGeneration) {
+        return;
+      }
+      [self endInteractiveDismissState];
+      if (completion) {
+        completion();
+      }
+    }];
 }
 
 - (void)endInteractiveDismissState {

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -44,6 +44,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 - (void)setSheetAccessibilityElementsHidden:(BOOL)hidden;
 - (void)setAccessibilityContentElement:(UIView *)contentView;
 - (void)endInteractiveDismissState;
+- (void)emitInteractivePosition;
 
 @end
 
@@ -65,6 +66,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   BOOL _isInteractiveDismiss;
   CGFloat _interactiveStartPosition;
   UIView *_interactiveContainerView;
+  CADisplayLink *_interactivePositionLink;
 
   __weak TrueSheetViewController *_parentSheetController;
 
@@ -115,6 +117,8 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   [self restoreWindowAccessibilityElements];
   [_transitioningTimer invalidate];
   _transitioningTimer = nil;
+  [_interactivePositionLink invalidate];
+  _interactivePositionLink = nil;
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
@@ -449,7 +453,9 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 
-  if (!_isTransitioning) {
+  // Skip during an interactive nav dismiss; emitInteractivePosition owns position then,
+  // and currentPosition (presentedView frame) stays at rest since we move the container.
+  if (!_isTransitioning && !_isInteractiveDismiss) {
     _isTrackingPositionFromLayout = YES;
 
     UIViewController *presented = self.presentedViewController;
@@ -664,6 +670,17 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   _isInteractiveDismiss = YES;
   _interactiveStartPosition = self.currentPosition;
   _interactiveContainerView = self.sheet.containerView;
+
+  // Emit position from the container's presentation layer for the whole gesture, so
+  // both the direct-set drag and the settle animation report a live, smooth position.
+  _interactivePositionLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(emitInteractivePosition)];
+  [_interactivePositionLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+}
+
+- (void)emitInteractivePosition {
+  CALayer *presentation = _interactiveContainerView.layer.presentationLayer;
+  CGFloat offset = presentation ? presentation.affineTransform.ty : 0;
+  [self emitChangePositionDelegateWithPosition:_interactiveStartPosition + offset realtime:YES debug:@"nav swipe"];
 }
 
 // Translate the presentation container, not the sheet's presentedView (whose transform
@@ -725,6 +742,8 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   _isInteractiveDismiss = NO;
   _interactiveContainerView = nil;
   _interactiveStartPosition = 0;
+  [_interactivePositionLink invalidate];
+  _interactivePositionLink = nil;
 }
 
 - (void)emitChangePositionDelegateWithPosition:(CGFloat)position realtime:(BOOL)realtime debug:(NSString *)debug {

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -45,6 +45,10 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 - (void)setAccessibilityContentElement:(UIView *)contentView;
 - (void)endInteractiveDismissState;
 - (void)emitInteractivePosition;
+- (void)animateInteractiveContainerToTransform:(CGAffineTransform)transform
+                                      duration:(NSTimeInterval)duration
+                          allowUserInteraction:(BOOL)allowUserInteraction
+                                    completion:(void (^)(void))completion;
 
 @end
 
@@ -67,6 +71,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   CGFloat _interactiveStartPosition;
   UIView *_interactiveContainerView;
   CADisplayLink *_interactivePositionLink;
+  NSUInteger _interactiveGeneration;
 
   __weak TrueSheetViewController *_parentSheetController;
 
@@ -447,6 +452,14 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
 - (void)viewDidDisappear:(BOOL)animated {
   [super viewDidDisappear:animated];
+
+  // Backstop: if the sheet is torn down mid-gesture (e.g. owning view deallocated),
+  // the observer can't reach us through its weak delegate, so end here to invalidate
+  // _interactivePositionLink — which otherwise retains this controller indefinitely.
+  if (_isInteractiveDismiss) {
+    [self endInteractiveDismissState];
+  }
+
   [self emitDidDismissEvents];
 }
 
@@ -665,8 +678,14 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
 - (void)beginInteractiveDismiss {
   if (_isInteractiveDismiss) {
-    return;
+    // A settle animation from a prior gesture is still running. Stop it and reset so
+    // this gesture tracks from a clean state; its stale completion is ignored via the
+    // generation check in animateInteractiveContainerToTransform.
+    [_interactiveContainerView.layer removeAllAnimations];
+    [self endInteractiveDismissState];
   }
+
+  _interactiveGeneration += 1;
   _isInteractiveDismiss = YES;
   _interactiveStartPosition = self.currentPosition;
   _interactiveContainerView = self.sheet.containerView;
@@ -699,17 +718,10 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   if (!_isInteractiveDismiss) {
     return;
   }
-  UIView *container = _interactiveContainerView;
-  [UIView animateWithDuration:fmax(duration, 0.2)
-                        delay:0
-                      options:UIViewAnimationOptionCurveEaseOut | UIViewAnimationOptionBeginFromCurrentState |
-                              UIViewAnimationOptionAllowUserInteraction
-                   animations:^{
-                     container.transform = CGAffineTransformIdentity;
-                   }
-                   completion:^(BOOL finished) {
-                     [self endInteractiveDismissState];
-                   }];
+  [self animateInteractiveContainerToTransform:CGAffineTransformIdentity
+                                      duration:duration
+                          allowUserInteraction:YES
+                                    completion:nil];
 }
 
 - (void)finishInteractiveDismissWithDuration:(NSTimeInterval)duration completion:(void (^)(void))completion {
@@ -719,18 +731,38 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     }
     return;
   }
-  UIView *container = _interactiveContainerView;
+  // Leave the sheet translated off-screen; the caller tears it down non-animated
+  // from here so there is no second slide.
   CGFloat dy = self.screenHeight - _interactiveStartPosition;
+  [self animateInteractiveContainerToTransform:CGAffineTransformMakeTranslation(0, dy)
+                                      duration:duration
+                          allowUserInteraction:NO
+                                    completion:completion];
+}
+
+- (void)animateInteractiveContainerToTransform:(CGAffineTransform)transform
+                                      duration:(NSTimeInterval)duration
+                          allowUserInteraction:(BOOL)allowUserInteraction
+                                    completion:(void (^)(void))completion {
+  UIView *container = _interactiveContainerView;
+  NSUInteger generation = _interactiveGeneration;
+
+  UIViewAnimationOptions options = UIViewAnimationOptionCurveEaseOut | UIViewAnimationOptionBeginFromCurrentState;
+  if (allowUserInteraction) {
+    options |= UIViewAnimationOptionAllowUserInteraction;
+  }
 
   [UIView animateWithDuration:fmax(duration, 0.2)
                         delay:0
-                      options:UIViewAnimationOptionCurveEaseOut | UIViewAnimationOptionBeginFromCurrentState
+                      options:options
                    animations:^{
-                     // Leave the sheet translated off-screen; the caller tears it down
-                     // non-animated from here so there is no second slide.
-                     container.transform = CGAffineTransformMakeTranslation(0, dy);
+                     container.transform = transform;
                    }
                    completion:^(BOOL finished) {
+                     // A newer gesture superseded this settle and owns teardown now.
+                     if (generation != self->_interactiveGeneration) {
+                       return;
+                     }
                      [self endInteractiveDismissState];
                      if (completion) {
                        completion();

--- a/ios/core/RNScreensEventObserver.h
+++ b/ios/core/RNScreensEventObserver.h
@@ -20,6 +20,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)presenterScreenWillDisappear;
 - (void)presenterScreenWillAppear;
 
+- (void)presenterInteractiveDismissDidBegin;
+- (void)presenterInteractiveDismissDidUpdate:(CGFloat)progress;
+- (void)presenterInteractiveDismissDidEnd:(BOOL)cancelled duration:(NSTimeInterval)duration;
+
 @end
 
 /**

--- a/ios/core/RNScreensEventObserver.mm
+++ b/ios/core/RNScreensEventObserver.mm
@@ -226,12 +226,7 @@ using namespace facebook::react;
   if (_interactiveEnded) {
     return;
   }
-  _interactiveEnded = YES;
-  _isInteractiveTracking = NO;
-  _interactiveCoordinator = nil;
-  [_interactiveDisplayLink invalidate];
-  _interactiveDisplayLink = nil;
-
+  [self stopInteractiveTracking];
   [self.delegate presenterInteractiveDismissDidEnd:cancelled duration:duration];
 }
 

--- a/ios/core/RNScreensEventObserver.mm
+++ b/ios/core/RNScreensEventObserver.mm
@@ -27,6 +27,11 @@ using namespace facebook::react;
   BOOL _dismissedByNavigation;
   BOOL _pendingInteractiveDismiss;
   BOOL _pendingInteractiveAppear;
+
+  CADisplayLink *_interactiveDisplayLink;
+  __weak id<UIViewControllerTransitionCoordinator> _interactiveCoordinator;
+  BOOL _isInteractiveTracking;
+  BOOL _interactiveEnded;
 }
 
 - (instancetype)init {
@@ -70,13 +75,22 @@ using namespace facebook::react;
 
         if (event.type == "topWillDisappear") {
           if (interactive) {
-            strongSelf->_pendingInteractiveDismiss = YES;
+            // Track the swipe in realtime so the sheet slides closed with the screen,
+            // and reverses if the gesture is cancelled. Falls back to dismissing once
+            // the pop commits when realtime tracking can't start.
+            if (![strongSelf beginInteractiveTracking]) {
+              strongSelf->_pendingInteractiveDismiss = YES;
+            }
           } else if ([strongSelf shouldDismissForScreenTag:screenTag]) {
             strongSelf->_dismissedByNavigation = YES;
             [strongSelf.delegate presenterScreenWillDisappear];
           }
         } else if (event.type == "topDisappear") {
-          if (strongSelf->_pendingInteractiveDismiss) {
+          if (strongSelf->_isInteractiveTracking && !strongSelf->_interactiveEnded) {
+            // Safety net: end as committed if the coordinator's interaction-change
+            // notification didn't fire before the screen finished disappearing.
+            [strongSelf endInteractiveTrackingCancelled:NO duration:0.3];
+          } else if (strongSelf->_pendingInteractiveDismiss) {
             strongSelf->_pendingInteractiveDismiss = NO;
             strongSelf->_dismissedByNavigation = YES;
             [strongSelf.delegate presenterScreenWillDisappear];
@@ -100,6 +114,10 @@ using namespace facebook::react;
         } else if (event.type == "topGestureCancel") {
           strongSelf->_pendingInteractiveDismiss = NO;
           strongSelf->_pendingInteractiveAppear = NO;
+          if (strongSelf->_isInteractiveTracking && !strongSelf->_interactiveEnded) {
+            // Safety net for cancel in case the coordinator notification didn't fire.
+            [strongSelf endInteractiveTrackingCancelled:YES duration:0.3];
+          }
         }
       }
       return false;
@@ -110,6 +128,8 @@ using namespace facebook::react;
 }
 
 - (void)stopObserving {
+  [self stopInteractiveTracking];
+
   if (_eventListener) {
     if (auto dispatcher = _eventDispatcher.lock()) {
       dispatcher->removeListener(_eventListener);
@@ -155,6 +175,72 @@ using namespace facebook::react;
 - (BOOL)isInteractiveTransition {
   UINavigationController *navController = _presenterScreenController.navigationController;
   return navController.transitionCoordinator.isInteractive;
+}
+
+#pragma mark - Interactive Dismiss Tracking
+
+- (BOOL)beginInteractiveTracking {
+  if (_isInteractiveTracking) {
+    return YES;
+  }
+
+  UINavigationController *navController = _presenterScreenController.navigationController;
+  id<UIViewControllerTransitionCoordinator> coordinator = navController.transitionCoordinator;
+  if (!coordinator || !coordinator.isInteractive) {
+    return NO;
+  }
+
+  _isInteractiveTracking = YES;
+  _interactiveEnded = NO;
+  _interactiveCoordinator = coordinator;
+
+  [self.delegate presenterInteractiveDismissDidBegin];
+
+  _interactiveDisplayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(handleInteractiveTick)];
+  [_interactiveDisplayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+
+  __weak RNScreensEventObserver *weakSelf = self;
+  [coordinator notifyWhenInteractionChangesUsingBlock:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+    RNScreensEventObserver *strongSelf = weakSelf;
+    if (!strongSelf || strongSelf->_interactiveEnded || context.isInteractive) {
+      return;
+    }
+    [strongSelf endInteractiveTrackingCancelled:context.isCancelled duration:context.transitionDuration];
+  }];
+
+  return YES;
+}
+
+- (void)handleInteractiveTick {
+  if (!_isInteractiveTracking) {
+    return;
+  }
+  id<UIViewControllerTransitionCoordinator> coordinator = _interactiveCoordinator;
+  if (!coordinator) {
+    return;
+  }
+  [self.delegate presenterInteractiveDismissDidUpdate:coordinator.percentComplete];
+}
+
+- (void)endInteractiveTrackingCancelled:(BOOL)cancelled duration:(NSTimeInterval)duration {
+  if (_interactiveEnded) {
+    return;
+  }
+  _interactiveEnded = YES;
+  _isInteractiveTracking = NO;
+  _interactiveCoordinator = nil;
+  [_interactiveDisplayLink invalidate];
+  _interactiveDisplayLink = nil;
+
+  [self.delegate presenterInteractiveDismissDidEnd:cancelled duration:duration];
+}
+
+- (void)stopInteractiveTracking {
+  _interactiveEnded = YES;
+  _isInteractiveTracking = NO;
+  _interactiveCoordinator = nil;
+  [_interactiveDisplayLink invalidate];
+  _interactiveDisplayLink = nil;
 }
 
 - (BOOL)shouldDismissForScreenTag:(NSInteger)screenTag {

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -357,6 +357,11 @@ export class TrueSheet
   private handleBackPress(): boolean {
     if (!this.isPresented || !this.isSheetVisible) return false;
 
+    // When not dismissible, let back propagate (e.g. navigation goes back to the previous screen)
+    if (this.props.dismissible === false) {
+      return this.props.onBackPress?.() ?? false;
+    }
+
     TrueSheetModule?.handleBackPress(this.handle);
     return this.props.onBackPress?.() ?? true;
   }


### PR DESCRIPTION
## Summary

Interactive back/dismiss handling for the sheet.

**iOS** — Make the system back-swipe (interactive pop) drive the sheet:
- Track the interactive pop via the screen's transition coordinator and slide the sheet's presentation container with the drag, springing back on cancel and tearing down on commit.
- Run a display link over the gesture that reads the container's presentation-layer translate, so `onPositionChange` tracks the sheet through both the drag and the cancel/commit settle.
- Guard against a re-swipe during settle: track a gesture generation so an interrupted settle animation's late completion can't tear down state owned by a newer back-swipe.

**Android** — Let back propagate when the sheet is not dismissible:
- Previously a non-dismissible sheet collapsed to the first detent on back. Now it leaves the back event unhandled so navigation can go back to the previous screen. `dismissible` sheets still dismiss on back as before; `onBackPress` can still consume the event.

## Type of Change

- [x] Bug fix
- [x] New feature

## Test Plan

- iOS: present a sheet inside a navigation stack, back-swipe from the edge — sheet follows the finger, springs back on cancel, dismisses on commit; `onPositionChange` fires throughout.
- Android: present a non-dismissible sheet containing a navigation stack, press back / swipe back — navigates to the previous screen instead of collapsing.

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
