### PR TITLE
fix(ios): guard scroll-edge interaction behind iOS 26 SDK check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - **Android**: A non-dismissible sheet no longer collapses to the first detent on back; back now propagates so navigation can go back to the previous screen. ([#719](https://github.com/lodev09/react-native-true-sheet/pull/719) by [@lodev09](https://github.com/lodev09))
+- **iOS**: Fixed build failure on Xcode versions older than 26 (e.g. Xcode 16 / iOS 18.5 SDK) by guarding the iOS 26 scroll-edge interaction code behind a compile-time SDK check. ([#721](https://github.com/lodev09/react-native-true-sheet/pull/721) by [@murattil](https://github.com/murattil))
 
 ## 3.11.1
 

--- a/ios/utils/UIView+ScrollEdgeInteraction.mm
+++ b/ios/utils/UIView+ScrollEdgeInteraction.mm
@@ -10,18 +10,21 @@
 
 #import <objc/runtime.h>
 #import "UIView+ScrollEdgeInteraction.h"
+#import "PlatformUtil.h"
 
 static const void *kEdgeEffectHintKey = &kEdgeEffectHintKey;
 
 @implementation UIView (ScrollEdgeInteraction)
 
 - (void)cleanupEdgeInteraction API_AVAILABLE(ios(26.0)) {
+#if RNTS_IPHONE_OS_VERSION_AVAILABLE(26_0)
   for (id<UIInteraction> interaction in [self.interactions copy]) {
     if ([interaction isKindOfClass:[UIScrollEdgeElementContainerInteraction class]]) {
       [self removeInteraction:interaction];
       break;
     }
   }
+#endif
 
   UILabel *hint = objc_getAssociatedObject(self, kEdgeEffectHintKey);
   [hint removeFromSuperview];
@@ -36,6 +39,7 @@ static const void *kEdgeEffectHintKey = &kEdgeEffectHintKey;
     return;
   }
 
+#if RNTS_IPHONE_OS_VERSION_AVAILABLE(26_0)
   // UIScrollEdgeElementContainerInteraction requires standard UIKit element
   // descendants (UILabel, UIControl, etc.) to trigger the edge effect.
   // RCTViewComponentView subviews are not recognized, so we add a
@@ -50,6 +54,7 @@ static const void *kEdgeEffectHintKey = &kEdgeEffectHintKey;
   interaction.scrollView = scrollView;
   interaction.edge = edge;
   [self addInteraction:interaction];
+#endif
 }
 
 @end


### PR DESCRIPTION
## Summary

- Compiling on Xcode 16 (iOS 18.5 SDK) fails with `use of undeclared identifier 'UIScrollEdgeElementContainerInteraction'` in `ios/utils/UIView+ScrollEdgeInteraction.mm`.
- The class is iOS 26 only. Even though [Xcode 26.2 is strongly recommended](https://github.com/lodev09/react-native-true-sheet/pull/371), the compile-time guard the other iOS 26 files use looks like it was just missed here. This file only has the runtime `API_AVAILABLE(ios(26.0))`, which doesn't stop the compiler from needing the symbol in the active SDK, while [`TrueSheetContentView.mm`](https://github.com/lodev09/react-native-true-sheet/blob/5ce7101001b6d7dd9b164e2dc72ae37b067236c6/ios/TrueSheetContentView.mm#L208) and [`TrueSheetViewController.mm`](https://github.com/lodev09/react-native-true-sheet/blob/5ce7101001b6d7dd9b164e2dc72ae37b067236c6/ios/TrueSheetViewController.mm#L1021) wrap theirs in `#if RNTS_IPHONE_OS_VERSION_AVAILABLE(...)`.
- This PR adds the same `#if RNTS_IPHONE_OS_VERSION_AVAILABLE(26_0)` guard here. It costs nothing on the recommended setup: with the iOS 26 SDK the macro is true and the code is unchanged, and below iOS 26 it was never reached anyway (the methods are `API_AVAILABLE` and the only caller is behind `if (@available(iOS 26.0, *))`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

`clang -fsyntax-only` against the iOS 18.5 simulator SDK:

- Before: fails on this file with the undeclared-identifier error above.
- After: compiles clean.

On the iOS 26 SDK the macro is true, so nothing changes there.

## Screenshots / Videos

N/A (compile-time fix, no UI change).

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android (iOS-only change)
- [ ] I tested on Web (iOS-only change)
- [ ] I updated the documentation (not needed)
- [x] I added a changelog entry (not needed)
