### PR TITLE
fix(web): don't float form sheet on mobile portrait when not detached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- **Web**: A `presentation="form"` sheet no longer floats on mobile portrait when `detached` is not set; it stays edge-attached, mirroring iOS form-sheet behavior on compact devices. ([#724](https://github.com/lodev09/react-native-true-sheet/pull/724) by [@lodev09](https://github.com/lodev09))
+
 ## 3.11.2
 
 ### 🎉 New features

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -117,9 +117,11 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   const isLandscapeOrTablet = windowWidth >= 600 || windowWidth > windowHeight;
   const isFormSheet = isLandscapeOrTablet && presentation === 'form';
 
-  // presentation='form' implies a floating/detached sheet on web — mirrors iOS
-  // form-sheet semantics where the sheet is never edge-attached.
-  const effectiveDetached = presentation === 'form' || detached;
+  // A form sheet floats (detached) only on tablet/landscape — mirrors iOS where
+  // a form sheet is a centered card on iPad but an edge-attached bottom sheet on
+  // a compact iPhone. On mobile portrait it stays edge-attached unless `detached`
+  // is explicitly set.
+  const effectiveDetached = isFormSheet || detached;
 
   const colorScheme = useColorScheme();
   const backgroundColor =


### PR DESCRIPTION
## Summary

On web, a `presentation="form"` sheet floated (detached) on all viewports because `effectiveDetached` checked `presentation === 'form'` directly. On mobile portrait this produced a floating card, unlike iOS where a form sheet is edge-attached on a compact iPhone.

Gates the form-implies-detached behavior on `isFormSheet` (`isLandscapeOrTablet && presentation === 'form'`). On mobile portrait a form sheet now stays edge-attached unless `detached` is explicitly set; on tablet/landscape it still floats as before.

## Type of Change

- [x] Bug fix

## Test Plan

Open a `presentation="form"` sheet (without `detached`) on a mobile-width viewport — it stays edge-attached instead of floating. On tablet/landscape it still floats as a centered card.

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)