### PR TITLE
docs: add tracer bullets skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 💡 Others
+
+- **Docs**: Added the Tracer Bullets AI skill so agents can build small end-to-end slices before expanding uncertain feature work. ([#725](https://github.com/lodev09/react-native-true-sheet/pull/725) by [@jakequade-pc](https://github.com/jakequade-pc))
+
 ## 3.11.3
 
 ### 🐛 Bug fixes

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Skills are reusable AI capabilities that give your AI coding agent knowledge abo
 npx skills add lodev09/react-native-true-sheet
 ```
 
-This will install the **TrueSheet Usage** skill into your project.
+This will install the **TrueSheet Usage** and **Tracer Bullets** skills into your project.
 
 ## That map is awesome!
 

--- a/docs/docs/usage.mdx
+++ b/docs/docs/usage.mdx
@@ -56,4 +56,4 @@ Skills are reusable AI capabilities that give your AI coding agent knowledge abo
 npx skills add lodev09/react-native-true-sheet
 ```
 
-This will install the **TrueSheet Usage** skill into your project.
+This will install the **TrueSheet Usage** and **Tracer Bullets** skills into your project.

--- a/skills/tracer-bullets/SKILL.md
+++ b/skills/tracer-bullets/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: tracer-bullets
+description: >-
+  Use when starting or expanding a feature, risky refactor, cross-layer change, or uncertain implementation.
+  Guides the agent to build a tiny end-to-end slice first, validate the architecture quickly, seek feedback,
+  then expand from a working path instead of designing the whole system upfront.
+---
+
+# Tracer Bullets
+
+Build the smallest useful slice that travels through the real system before expanding the feature.
+
+## Workflow
+
+1. Define the desired outcome in one sentence.
+2. Pick the thinnest end-to-end path that proves the core shape works.
+3. Implement only that path through the real layers, using production code paths where possible.
+4. Validate it with the fastest meaningful check: a focused test, local run, simulator flow, or observable UI/API behavior.
+5. Report what the slice proves, what remains deliberately incomplete, and what feedback would change the direction.
+6. Expand from the working slice in small increments, validating each meaningful step.
+
+## Slice Rules
+
+- Prefer real integration points over mocks unless the mock is the only way to get fast feedback.
+- Keep placeholders obvious and local; do not let scaffolding look like finished behavior.
+- Preserve a runnable path at every step.
+- When architecture is uncertain, make the tracer bullet answer the riskiest question first.
+- Stop to seek feedback when the first slice changes the product behavior, data shape, public API, or developer workflow.
+
+## Report Format
+
+Use this short shape when handing off the first slice:
+
+```markdown
+Tracer bullet:
+
+- Proves:
+- Left out:
+- Validation:
+- Next expansion:
+```


### PR DESCRIPTION
## Summary

Adds a Tracer Bullets skill so agents can start risky or uncertain implementation work with a tiny end-to-end slice before expanding. The skill install docs now mention both packaged skills, and the changelog tracks the docs addition.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Test Plan

- `git diff --check origin/main...HEAD`
- `yarn node -e '...frontmatter YAML/name/description/H1 check...'` validated both skill frontmatter files
- `npx --yes skills add . --list --full-depth` found `tracer-bullets` and `truesheet-usage`
- temp install smoke: `npx skills add "$repo" --skill '*' --agent codex --copy -y --full-depth` copied both skills into a temp `.agents/skills`
- `python3 quick_validate.py skills/tracer-bullets` with temp `PYTHONPATH=/tmp/codex-pyyaml`
- `yarn typecheck`
- `yarn docs typecheck`
- `yarn test --runInBand` (2 suites, 43 tests)
- `yarn eslint "**/*.{ts,tsx}"` (passes with existing `no-void` warning in `example/shared/src/components/SwipeButton.tsx`)
- `yarn prettier --check skills/tracer-bullets/SKILL.md`

Simplify pass: `ce-simplify-code` applied folded YAML frontmatter for the new skill description; no reuse or efficiency findings.

Review pass: `ce-code-review mode:agent base:origin/main` on the final diff reported no actionable findings. Caveat: one final reviewer artifact was missing after long skills CLI probing; earlier full review passed cleanly before the changelog-only follow-up.

Not run: simulator/device manual flows; docs/skill-only change with no runtime behavior.

Known existing issue: `yarn prettier --check README.md docs/docs/usage.mdx skills/tracer-bullets/SKILL.md` fails because README.md and docs/docs/usage.mdx already fail on `origin/main`; the new skill file passes Prettier.

## Screenshots / Videos

N/A

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)
