### PR TITLE
feat: add peek detent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🎉 New features
+
+- New `peek` detent that collapses the sheet to the combined `header` and `footer` height, falling back to a fixed `150` when neither is provided. ([#728](https://github.com/lodev09/react-native-true-sheet/pull/728) by [@lodev09](https://github.com/lodev09))
+
 ## 3.11.3
 
 ### 🐛 Bug fixes

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -615,7 +615,8 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
   }
 
   override fun containerViewFooterDidChangeSize(width: Int, height: Int) {
-    // Footer changes don't affect detents, only reposition it
+    // Footer height affects peek detents
+    updateSheetIfNeeded()
     viewController.positionFooter()
   }
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -275,12 +275,16 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   // Cached values used during dismiss when container is unmounted
   private var cachedContentHeight: Int = 0
   private var cachedHeaderHeight: Int = 0
+  private var cachedFooterHeight: Int = 0
 
   override val contentHeight: Int
     get() = containerView?.contentHeight ?: cachedContentHeight
 
   override val headerHeight: Int
     get() = containerView?.headerHeight ?: cachedHeaderHeight
+
+  override val footerHeight: Int
+    get() = containerView?.footerHeight ?: cachedFooterHeight
 
   // Insets
   // Target keyboard height used for detent calculations
@@ -836,6 +840,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     containerView?.let {
       cachedContentHeight = it.contentHeight
       cachedHeaderHeight = it.headerHeight
+      cachedFooterHeight = it.footerHeight
     }
 
     interactionState = InteractionState.Reconfiguring

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
@@ -1,5 +1,6 @@
 package com.lodev09.truesheet.core
 
+import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.util.RNLog
@@ -14,6 +15,7 @@ interface TrueSheetDetentCalculatorDelegate {
   val detents: MutableList<Double>
   val contentHeight: Int
   val headerHeight: Int
+  val footerHeight: Int
   val contentBottomInset: Int
   val maxContentHeight: Int?
   val keyboardInset: Int
@@ -31,17 +33,30 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
   private val detents: List<Double> get() = delegate?.detents ?: emptyList()
   private val contentHeight: Int get() = delegate?.contentHeight ?: 0
   private val headerHeight: Int get() = delegate?.headerHeight ?: 0
+  private val footerHeight: Int get() = delegate?.footerHeight ?: 0
   private val contentBottomInset: Int get() = delegate?.contentBottomInset ?: 0
   private val maxContentHeight: Int? get() = delegate?.maxContentHeight
   private val keyboardInset: Int get() = delegate?.keyboardInset ?: 0
 
   /**
+   * Height for peek (-2.0) detents: header + footer height.
+   * Falls back to 150dp when neither is present.
+   */
+  private val peekDetentHeight: Int
+    get() {
+      val height = headerHeight + footerHeight
+      return if (height > 0) height else DEFAULT_PEEK_HEIGHT.dpToPx().toInt()
+    }
+
+  /**
    * Calculate the height in pixels for a given detent value.
-   * @param detent The detent value: -1.0 for content-fit, or 0.0-1.0 for screen fraction
+   * @param detent The detent value: -1.0 for content-fit, -2.0 for peek, or 0.0-1.0 for screen fraction
    */
   fun getDetentHeight(detent: Double, includeKeyboard: Boolean = true): Int {
     val baseHeight = if (detent == -1.0) {
       contentHeight + headerHeight + contentBottomInset
+    } else if (detent == -2.0) {
+      peekDetentHeight + contentBottomInset
     } else {
       if (detent <= 0.0 || detent > 1.0) {
         throw IllegalArgumentException("TrueSheet: detent fraction ($detent) must be between 0 and 1")
@@ -83,6 +98,8 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
     val value = detents[index]
     return if (value == -1.0) {
       (contentHeight + headerHeight).toFloat() / screenHeight.toFloat()
+    } else if (value == -2.0) {
+      peekDetentHeight.toFloat() / screenHeight.toFloat()
     } else {
       value.toFloat()
     }
@@ -210,5 +227,9 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
     val fromDetent = getDetentValueForIndex(fromIndex)
     val toDetent = getDetentValueForIndex(toIndex)
     return fromDetent + progress * (toDetent - fromDetent)
+  }
+
+  companion object {
+    private const val DEFAULT_PEEK_HEIGHT = 150f
   }
 }

--- a/docs/docs/guides/header.mdx
+++ b/docs/docs/guides/header.mdx
@@ -65,6 +65,28 @@ const App = () => {
 When using `header` with `FlatList` or `ScrollView`, the content area height is automatically adjusted to account for the header height. This ensures proper scrolling behavior on both iOS and Android.
 :::
 
+## Collapsing to the Header
+
+Use the [`"peek"`](../reference/types#sheetdetent) detent to collapse the sheet down to just the header (plus [`footer`](footer), if provided). Great for map-style sheets with a compact summary that expands into full content.
+
+```tsx {4-4}
+const App = () => {
+  return (
+    <TrueSheet
+      detents={['peek', 0.9]}
+      initialDetentIndex={0}
+      header={<BookingSummary />}
+      footer={<SheetActions />}
+      scrollable
+    >
+      <BookingDetails />
+    </TrueSheet>
+  )
+}
+```
+
+The peek height automatically follows the measured header and footer sizes — no `onLayout` juggling needed. When neither `header` nor `footer` is provided, it falls back to a fixed height of `150`.
+
 ## Platform Support
 
 The `header` prop is supported on both **iOS** and **Android**.

--- a/docs/docs/guides/resizing.mdx
+++ b/docs/docs/guides/resizing.mdx
@@ -6,7 +6,7 @@ keywords: [bottom sheet resizing, bottom sheet detents, bottom sheet auto resizi
 
 import resizing from './assets/resizing.gif'
 
-`TrueSheet` has a main prop called [`detents`](../reference/configuration#detents) which allows you to define the detents that the sheet can support. This is an array of [`SheetDetent`](../reference/types#sheetdetent) that supports values like `"auto"` or fractional numbers (0-1).
+`TrueSheet` has a main prop called [`detents`](../reference/configuration#detents) which allows you to define the detents that the sheet can support. This is an array of [`SheetDetent`](../reference/types#sheetdetent) that supports values like `"auto"`, `"peek"`, or fractional numbers (0-1).
 
 In some cases, you may want to resize the sheet programmatically for a better experience.
 

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -15,6 +15,7 @@ keywords: [bottom sheet types, bottom sheet typescript, bottom sheet definitions
 | Value | Description | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |
 | `"auto"` | Auto resize based on content height. | **_16+_** | ✅ | ✅ |
+| `"peek"` | Collapsed height based on the combined [`header`](configuration#header) and [`footer`](configuration#footer) heights. Falls back to a fixed height of `150` when neither is provided. | **_16+_** | ✅ | ✅ |
 | `number` | Fractional height (0-1) representing percentage of screen height. | ✅ | ✅ | ✅ |
 
 :::warning

--- a/example/shared/src/screens/MapScreen.tsx
+++ b/example/shared/src/screens/MapScreen.tsx
@@ -100,7 +100,6 @@ const MapScreenInner = ({
   }, [width, height]);
 
   const sheetRef = useRef<TrueSheet>(null);
-  const minHeight = HEADER_HEIGHT + Platform.select({ ios: 0, default: SPACING });
 
   const basicSheet = useRef<TrueSheet>(null);
   const promptSheet = useRef<TrueSheet>(null);
@@ -172,7 +171,7 @@ const MapScreenInner = ({
       />
       <ReanimatedTrueSheet
         name="main"
-        detents={[minHeight / height, 'auto', 1]}
+        detents={['peek', 'auto', 1]}
         ref={sheetRef}
         initialDetentIndex={0}
         anchor={anchorLeft ? 'left' : 'center'}

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -68,6 +68,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (CGFloat)headerHeight;
 
 /**
+ * Returns the current footer height
+ */
+- (CGFloat)footerHeight;
+
+/**
  * Updates footer layout constraints if needed
  */
 - (void)layoutFooter;

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -119,6 +119,10 @@ using namespace facebook::react;
   return _headerView ? _headerView.frame.size.height : 0;
 }
 
+- (CGFloat)footerHeight {
+  return _footerView ? _footerView.frame.size.height : 0;
+}
+
 - (void)layoutFooter {
   if (_footerView) {
     CGFloat height = _footerView.frame.size.height;

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -215,6 +215,7 @@ using namespace facebook::react;
     }
     _footerView = (TrueSheetFooterView *)childComponentView;
     _footerView.delegate = self;
+    [self footerViewDidChangeSize:_footerView.frame.size];
   }
 }
 
@@ -233,6 +234,7 @@ using namespace facebook::react;
   if ([childComponentView isKindOfClass:[TrueSheetFooterView class]]) {
     _footerView.delegate = nil;
     _footerView = nil;
+    [self footerViewDidChangeSize:CGSizeZero];
   }
 
   [super unmountChildComponentView:childComponentView index:index];

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -393,6 +393,11 @@ using namespace facebook::react;
     _controller.headerHeight = @(headerHeight);
   }
 
+  CGFloat footerHeight = [_containerView footerHeight];
+  if (footerHeight > 0) {
+    _controller.footerHeight = @(footerHeight);
+  }
+
   if (_eventEmitter) {
     [TrueSheetLifecycleEvents emitMount:_eventEmitter];
   } else {
@@ -580,6 +585,8 @@ using namespace facebook::react;
 }
 
 - (void)containerViewFooterDidChangeSize:(CGSize)newSize {
+  _controller.footerHeight = @(newSize.height);
+  [self setupSheetDetentsForSizeChange];
   [_controller setupAccessibilityContainer];
 }
 

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -57,6 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSNumber *maxContentWidth;
 @property (nonatomic, strong, nullable) NSNumber *contentHeight;
 @property (nonatomic, strong, nullable) NSNumber *headerHeight;
+@property (nonatomic, strong, nullable) NSNumber *footerHeight;
 @property (nonatomic, strong, nullable) UIColor *backgroundColor;
 @property (nonatomic, strong, nullable) NSNumber *cornerRadius;
 @property (nonatomic, assign) BOOL grabber;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -91,6 +91,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     _detents = @[ @0.5, @1 ];
     _contentHeight = @(0);
     _headerHeight = @(0);
+    _footerHeight = @(0);
     _grabber = YES;
     _draggable = YES;
     _scrollingExpandsSheet = YES;
@@ -893,6 +894,14 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   if (value == -1) {
     if (@available(iOS 16.0, *)) {
       return [self customDetentWithIdentifier:@"custom-auto" height:autoHeight atIndex:index];
+    } else {
+      return [UISheetPresentationControllerDetent mediumDetent];
+    }
+  }
+
+  if (value == -2) {
+    if (@available(iOS 16.0, *)) {
+      return [self customDetentWithIdentifier:@"custom-peek" height:[_detentCalculator peekHeight] atIndex:index];
     } else {
       return [UISheetPresentationControllerDetent mediumDetent];
     }

--- a/ios/core/TrueSheetDetentCalculator.h
+++ b/ios/core/TrueSheetDetentCalculator.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSArray<NSNumber *> *detents;
 @property (nonatomic, strong, readonly, nullable) NSNumber *contentHeight;
 @property (nonatomic, strong, readonly, nullable) NSNumber *headerHeight;
+@property (nonatomic, strong, readonly, nullable) NSNumber *footerHeight;
 
 @end
 
@@ -36,8 +37,16 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns the detent value (0-1 fraction) for a given index.
  For auto (-1) detents, calculates based on content + header height.
+ For peek (-2) detents, calculates based on header + footer height.
  */
 - (CGFloat)detentValueForIndex:(NSInteger)index;
+
+/**
+ Returns the height for peek (-2) detents: header + footer height.
+ Falls back to 150 when neither is present — matches the iOS 26
+ floating small-detent threshold.
+ */
+- (CGFloat)peekHeight;
 
 /**
  Learns the offset between resolver height and actual presented height for a detent.

--- a/ios/core/TrueSheetDetentCalculator.mm
+++ b/ios/core/TrueSheetDetentCalculator.mm
@@ -22,9 +22,17 @@
       CGFloat autoHeight = [self.delegate.contentHeight floatValue] + [self.delegate.headerHeight floatValue];
       return autoHeight / self.delegate.screenHeight;
     }
+    if (value == -2) {
+      return [self peekHeight] / self.delegate.screenHeight;
+    }
     return value;
   }
   return 0;
+}
+
+- (CGFloat)peekHeight {
+  CGFloat height = [self.delegate.headerHeight floatValue] + [self.delegate.footerHeight floatValue];
+  return height > 0 ? height : 150;
 }
 
 - (void)learnOffsetForDetentIndex:(NSInteger)index {

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -136,7 +136,7 @@ export class TrueSheet
     // Warn for invalid detent fractions
     if (detents) {
       detents.forEach((detent, index) => {
-        if (detent !== 'auto' && typeof detent === 'number') {
+        if (typeof detent === 'number' && detent !== -1 && detent !== -2) {
           if (detent <= 0 || detent > 1) {
             console.warn(
               `TrueSheet: detent at index ${index} (${detent}) should be between 0 and 1. It will be clamped.`
@@ -474,6 +474,7 @@ export class TrueSheet
     // Trim to max 3 detents and clamp fractions
     const resolvedDetents = detents.slice(0, 3).map((detent) => {
       if (detent === 'auto' || detent === -1) return -1;
+      if (detent === 'peek' || detent === -2) return -2;
 
       // Default to 0.1 if zero or below
       if (detent <= 0) return 0.1;

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -225,6 +225,15 @@ export type SheetDetent =
   | 'auto'
 
   /**
+   * Collapsed height based on the combined `header` and `footer` heights.
+   * Falls back to a fixed height of `150` when neither is provided.
+   *
+   * @platform android
+   * @platform ios 16+
+   */
+  | 'peek'
+
+  /**
    * Relative height as a fraction (0-1) of the available height.
    * For example, 0.5 represents 50% of the available height.
    *

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -11,9 +11,10 @@ import {
   useState,
 } from 'react';
 import { View, useColorScheme, useWindowDimensions } from 'react-native';
+import type { LayoutChangeEvent } from 'react-native';
 
 import { Drawer } from './web/vaul';
-import { TRANSITIONS } from './web/vaul/constants';
+import { DEFAULT_PEEK_HEIGHT, TRANSITIONS } from './web/vaul/constants';
 import type {
   DetentChangeEvent,
   DetentInfoEventPayload,
@@ -99,7 +100,10 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   } = props;
 
   const validDetents = useMemo(
-    () => detents.filter((d): d is SheetDetent => typeof d === 'number' || d === 'auto'),
+    () =>
+      detents.filter(
+        (d): d is SheetDetent => typeof d === 'number' || d === 'auto' || d === 'peek'
+      ),
     [detents]
   );
 
@@ -149,7 +153,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     setActiveSnapPoint(
       snapPoint == null
         ? null
-        : typeof snapPoint === 'number' || snapPoint === 'auto'
+        : typeof snapPoint === 'number' || snapPoint === 'auto' || snapPoint === 'peek'
           ? (snapPoint as SheetDetent)
           : null
     );
@@ -227,6 +231,22 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
 
   const drawerContentRef = useRef<HTMLDivElement | null>(null);
 
+  // Measured header/footer heights drive the 'peek' snap point — mirrors
+  // native, where the controller tracks headerHeight/footerHeight.
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const [footerHeight, setFooterHeight] = useState(0);
+
+  const handleHeaderLayout = useCallback((e: LayoutChangeEvent) => {
+    setHeaderHeight(e.nativeEvent.layout.height);
+  }, []);
+
+  const handleFooterLayout = useCallback((e: LayoutChangeEvent) => {
+    setFooterHeight(e.nativeEvent.layout.height);
+  }, []);
+
+  const peekHeight =
+    (header ? headerHeight : 0) + (footer ? footerHeight : 0) || DEFAULT_PEEK_HEIGHT;
+
   // Present/dismiss events. The sheet settles via a CSS `transform` transition
   // on either the drawer (snap-points on autopresent) or the wrapper (whole-
   // card slide on reopen/dismiss). `Animation.finished` from the Web Animations
@@ -295,6 +315,10 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
           const h = Math.min(d * effectiveH, ceiling);
           positions.push(effectiveH - h);
           values.push(effectiveH > 0 ? h / effectiveH : 0);
+        } else if (d === 'peek') {
+          const h = Math.min(peekHeight, ceiling);
+          positions.push(effectiveH - h);
+          values.push(effectiveH > 0 ? h / effectiveH : 0);
         } else {
           positions.push(effectiveH - autoHeight);
           values.push(effectiveH > 0 ? autoHeight / effectiveH : 0);
@@ -346,7 +370,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
 
       return { index: count - 1, detent: values[count - 1]! };
     },
-    [effectiveDetached, detachedOffset, maxContentHeight]
+    [effectiveDetached, detachedOffset, maxContentHeight, peekHeight]
   );
 
   const handlePositionChange = useCallback(
@@ -859,6 +883,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       detachedOffset={effectiveDetachedOffset}
       detachedRadius={effectiveCornerRadius}
       maxContentHeight={effectiveMaxContentHeight}
+      peekHeight={peekHeight}
       initialAnimated={initialDetentAnimated}
       detachedWrapperStyle={wrapperStyle}
       onContentHeightChange={setMeasuredContentHeight}
@@ -875,7 +900,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
           detachedSiblings={
             footer ? (
               <div style={footerFloatStyle}>
-                <View style={footerStyle}>
+                <View style={footerStyle} onLayout={handleFooterLayout}>
                   {isValidElement(footer) ? footer : createElement(footer)}
                 </View>
               </div>
@@ -892,7 +917,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
             // definite height for the scroll container's flex:1 to fill.
             <div style={scrollableLayoutStyle}>
               {header && (
-                <View style={headerStyle}>
+                <View style={headerStyle} onLayout={handleHeaderLayout}>
                   {isValidElement(header) ? header : createElement(header)}
                 </View>
               )}
@@ -903,7 +928,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
           ) : (
             <>
               {header && (
-                <View style={headerStyle}>
+                <View style={headerStyle} onLayout={handleHeaderLayout}>
                   {isValidElement(header) ? header : createElement(header)}
                 </View>
               )}

--- a/src/web/vaul/constants.ts
+++ b/src/web/vaul/constants.ts
@@ -5,6 +5,8 @@ export const TRANSITIONS = {
 
 export const VELOCITY_THRESHOLD = 0.4;
 
+export const DEFAULT_PEEK_HEIGHT = 150;
+
 export const CLOSE_THRESHOLD = 0.25;
 
 export const SCROLL_LOCK_TIMEOUT = 100;

--- a/src/web/vaul/index.tsx
+++ b/src/web/vaul/index.tsx
@@ -182,6 +182,11 @@ export type DialogProps = {
    */
   maxContentHeight?: number;
   /**
+   * Resolved height (in px) for the 'peek' snap point — the caller measures
+   * its header/footer and passes the combined height.
+   */
+  peekHeight?: number;
+  /**
    * When `false` the first snap on mount is applied without a transition so
    * the sheet appears at its target detent instantly. Defaults to `true`.
    */
@@ -231,6 +236,7 @@ export function Root({
   detachedRadius = 0,
   detachedWrapperStyle,
   maxContentHeight,
+  peekHeight,
   initialAnimated = true,
   onContentHeightChange,
 }: DialogProps) {
@@ -307,6 +313,7 @@ export function Root({
     contentHeight,
     detachedOffset: detached ? detachedOffset : 0,
     maxContentHeight,
+    peekHeight,
     initialAnimated,
   });
 

--- a/src/web/vaul/use-snap-points.ts
+++ b/src/web/vaul/use-snap-points.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck — vendored upstream, incompatible with noUncheckedIndexedAccess
 import React from 'react';
 import { set, isVertical } from './helpers';
-import { TRANSITIONS, VELOCITY_THRESHOLD } from './constants';
+import { DEFAULT_PEEK_HEIGHT, TRANSITIONS, VELOCITY_THRESHOLD } from './constants';
 import { useControllableState } from './use-controllable-state';
 import type { DrawerDirection } from './types';
 
@@ -20,6 +20,7 @@ export function useSnapPoints({
   contentHeight,
   detachedOffset = 0,
   maxContentHeight,
+  peekHeight,
   initialAnimated = true,
 }: {
   activeSnapPointProp?: number | string | null;
@@ -36,6 +37,7 @@ export function useSnapPoints({
   contentHeight?: number;
   detachedOffset?: number;
   maxContentHeight?: number;
+  peekHeight?: number;
   initialAnimated?: boolean;
 }) {
   const [activeSnapPoint, setActiveSnapPoint] = useControllableState<string | number | null>({
@@ -102,11 +104,14 @@ export function useSnapPoints({
       snapPoints?.map((snapPoint) => {
         // 'auto' resolves to measured content height. Falls back to half the
         // container so the initial snap is close to final before ResizeObserver
-        // reports a real measurement.
+        // reports a real measurement. 'peek' resolves to the caller-measured
+        // header + footer height.
         const resolved =
           snapPoint === 'auto'
             ? `${contentHeight && contentHeight > 0 ? contentHeight : effectiveHeight / 2}px`
-            : snapPoint;
+            : snapPoint === 'peek'
+              ? `${peekHeight && peekHeight > 0 ? peekHeight : DEFAULT_PEEK_HEIGHT}px`
+              : snapPoint;
         const isPx = typeof resolved === 'string';
         let snapPointAsNumber = 0;
 
@@ -151,7 +156,15 @@ export function useSnapPoints({
         return width;
       }) ?? []
     );
-  }, [snapPoints, windowDimensions, container, contentHeight, detachedOffset, maxContentHeight]);
+  }, [
+    snapPoints,
+    windowDimensions,
+    container,
+    contentHeight,
+    detachedOffset,
+    maxContentHeight,
+    peekHeight,
+  ]);
 
   const activeSnapPointOffset = React.useMemo(
     () => (activeSnapPointIndex !== null ? snapPointsOffset?.[activeSnapPointIndex] : null),


### PR DESCRIPTION
## Summary

Adds a `'peek'` detent that collapses the sheet to the combined `header` + `footer` height, falling back to a fixed `150` when neither is provided. Resolves the pattern requested in #727 — a compact summary detent without JS measurement or hard-coded heights.

- Maps to a `-2` sentinel in the existing `detents` array (no codegen change), alongside `auto`'s `-1`.
- iOS/Android now track footer height in detent calculations; peek recalculates when header/footer resize.
- iOS: footer height now syncs on mount/unmount (was stale when footer was added/removed dynamically).
- Web resolves `'peek'` via measured header/footer DOM heights.
- Insets follow the same rules as `auto` (`insetAdjustment` respected on both platforms).

Closes #727

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Test Plan

- `yarn tidy` (typecheck, eslint, objclint, ktlint) and jest suite pass
- Example app: MapScreen main sheet + BasicSheet use `detents={['peek', ...]}`; verified collapsed presentation, header/footer resize tracking, and dynamic footer add/remove on iOS

## Screenshots / Videos

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)