### PR TITLE
fix(ios): compile tvOS stubs to fix Fabric startup crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- **iOS**: Fixed tvOS builds crashing at launch (`RCTThirdPartyComponentsProvider` nil class). The podspec now supports tvOS by compiling inert stub components — sheets remain unsupported on tvOS. ([#729](https://github.com/lodev09/react-native-true-sheet/pull/729) by [@lodev09](https://github.com/lodev09))
+
 ### 🎉 New features
 
 - **iOS**, **Android**: Scrollable sheets now follow the text caret as the user types, scrolling to the caret line instead of the input's full bounds. ([#723](https://github.com/lodev09/react-native-true-sheet/pull/723) by [@bigcupcoffee](https://github.com/bigcupcoffee))

--- a/RNTrueSheet.podspec
+++ b/RNTrueSheet.podspec
@@ -10,10 +10,14 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported }
+  s.platforms    = { :ios => min_ios_version_supported, :tvos => min_ios_version_supported }
   s.source       = { :git => "https://github.com/lodev09/react-native-true-sheet.git", :tag => "#{s.version}" }
 
-  s.source_files = "ios/**/*.{h,m,mm,swift,cpp}", "common/cpp/**/*.{cpp,h}"
+  # tvOS compiles stubs only — sheets are not supported there, but codegen
+  # still registers the components so the classes must exist (#722)
+  s.ios.source_files = "ios/**/*.{h,m,mm,swift,cpp}", "common/cpp/**/*.{cpp,h}"
+  s.ios.exclude_files = "ios/tvos/**/*"
+  s.tvos.source_files = "ios/tvos/**/*.mm", "common/cpp/**/*.{cpp,h}"
   s.private_header_files = "ios/**/*.h"
 
   s.pod_target_xcconfig = {

--- a/ios/tvos/TrueSheetStubs.mm
+++ b/ios/tvos/TrueSheetStubs.mm
@@ -1,0 +1,141 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+// tvOS stubs. Codegen registers TrueSheet components and looks them up via
+// NSClassFromString on all Apple platforms, so the classes must exist on tvOS
+// even though sheets are not supported there.
+
+#import <TargetConditionals.h>
+
+#if TARGET_OS_TV && defined(RCT_NEW_ARCH_ENABLED)
+
+#import <React/RCTBridgeModule.h>
+#import <React/RCTViewComponentView.h>
+
+#import <react/renderer/components/TrueSheetSpec/ComponentDescriptors.h>
+#import <react/renderer/components/TrueSheetSpec/TrueSheetViewComponentDescriptor.h>
+
+#import <TrueSheetSpec/TrueSheetSpec.h>
+
+using namespace facebook::react;
+
+#pragma mark - Component Views
+
+@interface TrueSheetView : RCTViewComponentView
+@end
+
+@implementation TrueSheetView
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetViewComponentDescriptor>();
+}
+
+@end
+
+@interface TrueSheetContainerView : RCTViewComponentView
+@end
+
+@implementation TrueSheetContainerView
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetContainerViewComponentDescriptor>();
+}
+
+@end
+
+@interface TrueSheetContentView : RCTViewComponentView
+@end
+
+@implementation TrueSheetContentView
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetContentViewComponentDescriptor>();
+}
+
+@end
+
+@interface TrueSheetHeaderView : RCTViewComponentView
+@end
+
+@implementation TrueSheetHeaderView
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetHeaderViewComponentDescriptor>();
+}
+
+@end
+
+@interface TrueSheetFooterView : RCTViewComponentView
+@end
+
+@implementation TrueSheetFooterView
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetFooterViewComponentDescriptor>();
+}
+
+@end
+
+#pragma mark - Module
+
+@interface TrueSheetModule : NSObject <RCTBridgeModule, NativeTrueSheetModuleSpec>
+@end
+
+@implementation TrueSheetModule
+
+RCT_EXPORT_MODULE(TrueSheetModule)
+
++ (BOOL)requiresMainQueueSetup {
+  return NO;
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+  (const facebook::react::ObjCTurboModule::InitParams &)params {
+  return std::make_shared<facebook::react::NativeTrueSheetModuleSpecJSI>(params);
+}
+
+- (void)presentByRef:(double)viewTag
+               index:(double)index
+            animated:(BOOL)animated
+             resolve:(RCTPromiseResolveBlock)resolve
+              reject:(RCTPromiseRejectBlock)reject {
+  reject(@"PRESENT_FAILED", @"TrueSheet is not supported on tvOS", nil);
+}
+
+- (void)dismissByRef:(double)viewTag
+            animated:(BOOL)animated
+             resolve:(RCTPromiseResolveBlock)resolve
+              reject:(RCTPromiseRejectBlock)reject {
+  resolve(nil);
+}
+
+- (void)dismissStackByRef:(double)viewTag
+                 animated:(BOOL)animated
+                  resolve:(RCTPromiseResolveBlock)resolve
+                   reject:(RCTPromiseRejectBlock)reject {
+  resolve(nil);
+}
+
+- (void)resizeByRef:(double)viewTag
+              index:(double)index
+            resolve:(RCTPromiseResolveBlock)resolve
+             reject:(RCTPromiseRejectBlock)reject {
+  resolve(nil);
+}
+
+- (void)handleBackPress:(double)viewTag resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+  resolve(nil);
+}
+
+- (void)dismissAll:(BOOL)animated resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+  resolve(nil);
+}
+
+@end
+
+#endif  // TARGET_OS_TV && RCT_NEW_ARCH_ENABLED


### PR DESCRIPTION
## Summary

Fixes #722.

tvOS builds (react-native-tvos) crash at launch with `NSInvalidArgumentException: attempt to insert nil object` in `RCTThirdPartyComponentsProvider thirdPartyFabricComponents`. Codegen runs with `--platform ios` on tvOS and registers TrueSheet components, but the podspec was iOS-only so `NSClassFromString(@"TrueSheetView")` returned nil.

- Add `:tvos` platform to the podspec with per-platform sources: iOS compiles as before; tvOS compiles only `common/cpp` (platform-neutral C++) + a new stub file
- `ios/tvos/TrueSheetStubs.mm` defines inert `RCTViewComponentView` subclasses for all 5 registered components and a stub `TrueSheetModule` (`present` rejects with a clear error; dismiss/resize resolve as no-ops)

Sheets remain unsupported on tvOS — this just makes the library safe to autolink there.

## Type of Change

- [x] Bug fix

## Test Plan

- tvOS: build https://github.com/slvvn/tvos-true-sheet-autolinking-repro against this branch — app should launch without the Fabric registry crash
- iOS: build the example app to confirm the per-platform `source_files` split still picks up all sources

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)