### PR TITLE
feat: add TrueSheetPeek component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🎉 New features
 
-- New `TrueSheetPeek` component that marks part of the content as the sheet's peek content — its natively-measured height is included in the `peek` detent height along with the `header` and `footer` heights. ([#730](https://github.com/lodev09/react-native-true-sheet/pull/730) by [@lodev09](https://github.com/lodev09))
+- New `TrueSheetPeek` component that marks part of the content as the sheet's peek content — the `peek` detent height covers the content through its bottom edge (measured natively), along with the `header` and `footer` heights. ([#730](https://github.com/lodev09/react-native-true-sheet/pull/730) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🎉 New features
+
+- New `TrueSheetPeek` component that marks part of the content as the sheet's peek content — its natively-measured height is included in the `peek` detent height along with the `header` and `footer` heights. ([#730](https://github.com/lodev09/react-native-true-sheet/pull/730) by [@lodev09](https://github.com/lodev09))
+
 ## 3.11.4
 
 ### 🐛 Bug fixes

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
@@ -39,7 +39,26 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
   var contentHeight: Int = 0
   var headerHeight: Int = 0
   var footerHeight: Int = 0
-  var peekContentHeight: Int = 0
+
+  /**
+   * Distance from the top of the content view to the bottom of the peek view.
+   * Includes the peek view's offset within the content (padding, views above it)
+   * so the peek detent reveals everything down to the peek content's bottom edge.
+   */
+  val peekContentHeight: Int
+    get() {
+      val peek = peekView ?: return 0
+      val content = contentView ?: return peek.height
+
+      var bottom = peek.height
+      var view: View = peek
+      while (view !== content) {
+        bottom += view.top
+        view = view.parent as? View ?: return peek.height
+      }
+
+      return bottom
+    }
 
   var insetAdjustment: TrueSheetInsetAdjustment = TrueSheetInsetAdjustment.AUTOMATIC
   var scrollViewBottomInset: Int = 0
@@ -178,7 +197,6 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
   }
 
   override fun peekViewDidChangeSize(width: Int, height: Int) {
-    peekContentHeight = height
     delegate?.containerViewPeekDidChangeSize(width, height)
   }
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.events.EventDispatcher
+import com.facebook.react.util.RNLog
 import com.facebook.react.views.view.ReactViewGroup
 
 interface TrueSheetContainerViewDelegate {
@@ -156,7 +157,12 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
   }
 
   fun attachPeekView(view: TrueSheetPeekView) {
-    if (peekView === view || peekView != null) return
+    if (peekView === view) return
+
+    if (peekView != null) {
+      RNLog.w(context as ThemedReactContext, "TrueSheet: Sheet can only have one peek component.")
+      return
+    }
 
     peekView = view
     view.delegate = this

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
@@ -2,6 +2,7 @@ package com.lodev09.truesheet
 
 import android.annotation.SuppressLint
 import android.view.View
+import android.view.ViewGroup
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.view.ReactViewGroup
@@ -13,6 +14,7 @@ interface TrueSheetContainerViewDelegate {
   fun containerViewScrollViewDidChange()
   fun containerViewHeaderDidChangeSize(width: Int, height: Int)
   fun containerViewFooterDidChangeSize(width: Int, height: Int)
+  fun containerViewPeekDidChangeSize(width: Int, height: Int)
 }
 
 /**
@@ -24,17 +26,20 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
   ReactViewGroup(reactContext),
   TrueSheetContentViewDelegate,
   TrueSheetHeaderViewDelegate,
-  TrueSheetFooterViewDelegate {
+  TrueSheetFooterViewDelegate,
+  TrueSheetPeekViewDelegate {
 
   var delegate: TrueSheetContainerViewDelegate? = null
 
   var contentView: TrueSheetContentView? = null
   var headerView: TrueSheetHeaderView? = null
   var footerView: TrueSheetFooterView? = null
+  var peekView: TrueSheetPeekView? = null
 
   var contentHeight: Int = 0
   var headerHeight: Int = 0
   var footerHeight: Int = 0
+  var peekContentHeight: Int = 0
 
   var insetAdjustment: TrueSheetInsetAdjustment = TrueSheetInsetAdjustment.AUTOMATIC
   var scrollViewBottomInset: Int = 0
@@ -75,6 +80,10 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
         child.delegate = this
         child.scrollableOptions = scrollableOptions
         contentView = child
+
+        // Children mount bottom-up, so the content subtree is complete here.
+        // Late-mounted peek views attach themselves instead (see TrueSheetPeekView).
+        findPeekView(child)?.let { attachPeekView(it) }
       }
 
       is TrueSheetHeaderView -> {
@@ -113,6 +122,36 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
     super.removeViewAt(index)
   }
 
+  // ==================== Peek View ====================
+
+  private fun findPeekView(view: View): TrueSheetPeekView? {
+    if (view is TrueSheetPeekView) return view
+
+    if (view is ViewGroup) {
+      for (i in 0 until view.childCount) {
+        findPeekView(view.getChildAt(i))?.let { return it }
+      }
+    }
+
+    return null
+  }
+
+  fun attachPeekView(view: TrueSheetPeekView) {
+    if (peekView === view || peekView != null) return
+
+    peekView = view
+    view.delegate = this
+    peekViewDidChangeSize(view.width, view.height)
+  }
+
+  fun detachPeekView(view: TrueSheetPeekView) {
+    if (peekView !== view) return
+
+    view.delegate = null
+    peekView = null
+    peekViewDidChangeSize(0, 0)
+  }
+
   // ==================== Delegate Implementations ====================
 
   override fun contentViewDidChangeSize(width: Int, height: Int) {
@@ -136,6 +175,11 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
   override fun footerViewDidChangeSize(width: Int, height: Int) {
     footerHeight = height
     delegate?.containerViewFooterDidChangeSize(width, height)
+  }
+
+  override fun peekViewDidChangeSize(width: Int, height: Int) {
+    peekContentHeight = height
+    delegate?.containerViewPeekDidChangeSize(width, height)
   }
 
   companion object {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetPackage.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetPackage.kt
@@ -39,6 +39,7 @@ class TrueSheetPackage : BaseReactPackage() {
       TrueSheetContainerViewManager(),
       TrueSheetContentViewManager(),
       TrueSheetHeaderViewManager(),
-      TrueSheetFooterViewManager()
+      TrueSheetFooterViewManager(),
+      TrueSheetPeekViewManager()
     )
 }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetPeekView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetPeekView.kt
@@ -14,7 +14,7 @@ interface TrueSheetPeekViewDelegate {
 
 /**
  * Peek view that marks part of the content as the sheet's peek content.
- * Its measured height is included in the peek detent height.
+ * The peek detent covers the content through this view's bottom edge.
  */
 @SuppressLint("ViewConstructor")
 class TrueSheetPeekView(context: ThemedReactContext) : ReactViewGroup(context) {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetPeekView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetPeekView.kt
@@ -1,0 +1,69 @@
+package com.lodev09.truesheet
+
+import android.annotation.SuppressLint
+import android.view.ViewParent
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.views.view.ReactViewGroup
+
+/**
+ * Delegate interface for peek view size changes
+ */
+interface TrueSheetPeekViewDelegate {
+  fun peekViewDidChangeSize(width: Int, height: Int)
+}
+
+/**
+ * Peek view that marks part of the content as the sheet's peek content.
+ * Its measured height is included in the peek detent height.
+ */
+@SuppressLint("ViewConstructor")
+class TrueSheetPeekView(context: ThemedReactContext) : ReactViewGroup(context) {
+  var delegate: TrueSheetPeekViewDelegate? = null
+
+  private var lastWidth = 0
+  private var lastHeight = 0
+
+  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+    super.onSizeChanged(w, h, oldw, oldh)
+
+    attachToContainerView()
+
+    if (w != lastWidth || h != lastHeight) {
+      lastWidth = w
+      lastHeight = h
+      delegate?.peekViewDidChangeSize(w, h)
+    }
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    attachToContainerView()
+  }
+
+  /**
+   * Peek can be nested anywhere within the content, so it attaches itself to the
+   * nearest container instead of being mounted by it. The container also searches
+   * for it when the content is added to cover the initial (bottom-up) mount order.
+   */
+  private fun attachToContainerView() {
+    if (delegate != null) return
+
+    var parent: ViewParent? = parent
+    while (parent != null && parent !is TrueSheetContainerView) {
+      parent = parent.parent
+    }
+
+    (parent as? TrueSheetContainerView)?.attachPeekView(this)
+  }
+
+  /**
+   * Called by the ViewManager when the view is dropped (Fabric unmount)
+   */
+  fun detachFromContainerView() {
+    (delegate as? TrueSheetContainerView)?.detachPeekView(this)
+  }
+
+  companion object {
+    const val TAG_NAME = "TrueSheet"
+  }
+}

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetPeekView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetPeekView.kt
@@ -20,18 +20,15 @@ interface TrueSheetPeekViewDelegate {
 class TrueSheetPeekView(context: ThemedReactContext) : ReactViewGroup(context) {
   var delegate: TrueSheetPeekViewDelegate? = null
 
-  private var lastWidth = 0
-  private var lastHeight = 0
-
-  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
-    super.onSizeChanged(w, h, oldw, oldh)
+  override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+    super.onLayout(changed, left, top, right, bottom)
 
     attachToContainerView()
 
-    if (w != lastWidth || h != lastHeight) {
-      lastWidth = w
-      lastHeight = h
-      delegate?.peekViewDidChangeSize(w, h)
+    // Position changes matter too — the peek's offset within the content
+    // affects the peek detent.
+    if (changed) {
+      delegate?.peekViewDidChangeSize(width, height)
     }
   }
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetPeekViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetPeekViewManager.kt
@@ -1,5 +1,6 @@
 package com.lodev09.truesheet
 
+import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
@@ -9,6 +10,7 @@ import com.facebook.react.uimanager.annotations.ReactProp
  * ViewManager for TrueSheetPeekView
  * Marks part of the content as the sheet's peek content
  */
+@ReactModule(name = TrueSheetPeekViewManager.REACT_CLASS)
 class TrueSheetPeekViewManager : ViewGroupManager<TrueSheetPeekView>() {
 
   override fun getName(): String = REACT_CLASS

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetPeekViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetPeekViewManager.kt
@@ -1,0 +1,31 @@
+package com.lodev09.truesheet
+
+import com.facebook.react.uimanager.PointerEvents
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewGroupManager
+import com.facebook.react.uimanager.annotations.ReactProp
+
+/**
+ * ViewManager for TrueSheetPeekView
+ * Marks part of the content as the sheet's peek content
+ */
+class TrueSheetPeekViewManager : ViewGroupManager<TrueSheetPeekView>() {
+
+  override fun getName(): String = REACT_CLASS
+
+  override fun createViewInstance(reactContext: ThemedReactContext): TrueSheetPeekView = TrueSheetPeekView(reactContext)
+
+  override fun onDropViewInstance(view: TrueSheetPeekView) {
+    super.onDropViewInstance(view)
+    view.detachFromContainerView()
+  }
+
+  @ReactProp(name = "pointerEvents")
+  fun setPointerEvents(view: TrueSheetPeekView, pointerEventsStr: String?) {
+    view.pointerEvents = PointerEvents.parsePointerEvents(pointerEventsStr)
+  }
+
+  companion object {
+    const val REACT_CLASS = "TrueSheetPeekView"
+  }
+}

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -620,6 +620,11 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     viewController.positionFooter()
   }
 
+  override fun containerViewPeekDidChangeSize(width: Int, height: Int) {
+    // Peek content height affects peek detents
+    updateSheetIfNeeded()
+  }
+
   // ==================== RNScreensEventObserverDelegate ====================
 
   override fun presenterScreenWillDisappear() {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -276,6 +276,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   private var cachedContentHeight: Int = 0
   private var cachedHeaderHeight: Int = 0
   private var cachedFooterHeight: Int = 0
+  private var cachedPeekContentHeight: Int = 0
 
   override val contentHeight: Int
     get() = containerView?.contentHeight ?: cachedContentHeight
@@ -285,6 +286,9 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   override val footerHeight: Int
     get() = containerView?.footerHeight ?: cachedFooterHeight
+
+  override val peekContentHeight: Int
+    get() = containerView?.peekContentHeight ?: cachedPeekContentHeight
 
   // Insets
   // Target keyboard height used for detent calculations
@@ -841,6 +845,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
       cachedContentHeight = it.contentHeight
       cachedHeaderHeight = it.headerHeight
       cachedFooterHeight = it.footerHeight
+      cachedPeekContentHeight = it.peekContentHeight
     }
 
     interactionState = InteractionState.Reconfiguring

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
@@ -16,6 +16,7 @@ interface TrueSheetDetentCalculatorDelegate {
   val contentHeight: Int
   val headerHeight: Int
   val footerHeight: Int
+  val peekContentHeight: Int
   val contentBottomInset: Int
   val maxContentHeight: Int?
   val keyboardInset: Int
@@ -34,17 +35,18 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
   private val contentHeight: Int get() = delegate?.contentHeight ?: 0
   private val headerHeight: Int get() = delegate?.headerHeight ?: 0
   private val footerHeight: Int get() = delegate?.footerHeight ?: 0
+  private val peekContentHeight: Int get() = delegate?.peekContentHeight ?: 0
   private val contentBottomInset: Int get() = delegate?.contentBottomInset ?: 0
   private val maxContentHeight: Int? get() = delegate?.maxContentHeight
   private val keyboardInset: Int get() = delegate?.keyboardInset ?: 0
 
   /**
-   * Height for peek (-2.0) detents: header + footer height.
-   * Falls back to 150dp when neither is present.
+   * Height for peek (-2.0) detents: header + footer + peek content height.
+   * Falls back to 150dp when none is present.
    */
   private val peekDetentHeight: Int
     get() {
-      val height = headerHeight + footerHeight
+      val height = headerHeight + footerHeight + peekContentHeight
       return if (height > 0) height else DEFAULT_PEEK_HEIGHT.dpToPx().toInt()
     }
 

--- a/docs/docs/guides/footer.mdx
+++ b/docs/docs/guides/footer.mdx
@@ -91,3 +91,23 @@ When the keyboard opens, that bottom padding leaves a gap above the keyboard. Pa
 :::note
 On iPad, the sheet is displayed as a floating modal, so bottom padding is not needed.
 :::
+
+## Collapsing to the Footer
+
+The footer height counts toward the [`"peek"`](../reference/types#sheetdetent) detent — collapse the sheet down to just the [`header`](header), footer, and any peeking content.
+
+```tsx {4-4}
+const App = () => {
+  return (
+    <TrueSheet
+      detents={['peek', 0.9]}
+      initialDetentIndex={0}
+      footer={<SheetActions />}
+    >
+      <BookingDetails />
+    </TrueSheet>
+  )
+}
+```
+
+Since the footer floats, it stays visible at every detent. See [Peeking Content](peeking) for the full guide.

--- a/docs/docs/guides/header.mdx
+++ b/docs/docs/guides/header.mdx
@@ -106,6 +106,10 @@ const App = () => {
 }
 ```
 
+:::warning
+Place `TrueSheetPeek` at the **top** of your content. Only its measured *height* is used for the peek detent — the sheet always reveals content from the top, so content rendered above it would occupy the collapsed area instead and the peek content would end up below the fold.
+:::
+
 ## Platform Support
 
 The `header` prop is supported on both **iOS** and **Android**.

--- a/docs/docs/guides/header.mdx
+++ b/docs/docs/guides/header.mdx
@@ -87,6 +87,25 @@ const App = () => {
 
 The peek height automatically follows the measured header and footer sizes — no `onLayout` juggling needed. When neither `header` nor `footer` is provided, it falls back to a fixed height of `150`.
 
+### Peeking Content
+
+To include part of the content in the peek height, wrap it with the `TrueSheetPeek` component. Its measured height is added to the header and footer heights.
+
+```tsx {8-10}
+import { TrueSheet, TrueSheetPeek } from '@lodev09/react-native-true-sheet'
+
+const App = () => {
+  return (
+    <TrueSheet detents={['peek', 0.9]} initialDetentIndex={0}>
+      <TrueSheetPeek>
+        <BookingSummary />
+      </TrueSheetPeek>
+      <BookingDetails />
+    </TrueSheet>
+  )
+}
+```
+
 ## Platform Support
 
 The `header` prop is supported on both **iOS** and **Android**.

--- a/docs/docs/guides/header.mdx
+++ b/docs/docs/guides/header.mdx
@@ -89,7 +89,7 @@ The peek height automatically follows the measured header and footer sizes — n
 
 ### Peeking Content
 
-To include part of the content in the peek height, wrap it with the `TrueSheetPeek` component. Its measured height is added to the header and footer heights.
+To include part of the content in the peek height, wrap it with the `TrueSheetPeek` component. The peek detent then reveals everything from the top of the sheet through the bottom of the peek content — content padding and anything rendered above it count toward the height, while content below it stays hidden until the sheet is expanded.
 
 ```tsx {8-10}
 import { TrueSheet, TrueSheetPeek } from '@lodev09/react-native-true-sheet'
@@ -106,8 +106,8 @@ const App = () => {
 }
 ```
 
-:::warning
-Place `TrueSheetPeek` at the **top** of your content. Only its measured *height* is used for the peek detent — the sheet always reveals content from the top, so content rendered above it would occupy the collapsed area instead and the peek content would end up below the fold.
+:::info
+`TrueSheetPeek` can be placed anywhere within the content — the collapsed sheet simply reveals everything above it, including itself.
 :::
 
 ## Platform Support

--- a/docs/docs/guides/header.mdx
+++ b/docs/docs/guides/header.mdx
@@ -85,30 +85,7 @@ const App = () => {
 }
 ```
 
-The peek height automatically follows the measured header and footer sizes — no `onLayout` juggling needed. When neither `header` nor `footer` is provided, it falls back to a fixed height of `150`.
-
-### Peeking Content
-
-To include part of the content in the peek height, wrap it with the `TrueSheetPeek` component. The peek detent then reveals everything from the top of the sheet through the bottom of the peek content — content padding and anything rendered above it count toward the height, while content below it stays hidden until the sheet is expanded.
-
-```tsx {8-10}
-import { TrueSheet, TrueSheetPeek } from '@lodev09/react-native-true-sheet'
-
-const App = () => {
-  return (
-    <TrueSheet detents={['peek', 0.9]} initialDetentIndex={0}>
-      <TrueSheetPeek>
-        <BookingSummary />
-      </TrueSheetPeek>
-      <BookingDetails />
-    </TrueSheet>
-  )
-}
-```
-
-:::info
-`TrueSheetPeek` can be placed anywhere within the content — the collapsed sheet simply reveals everything above it, including itself.
-:::
+The peek height automatically follows the measured header and footer sizes — no `onLayout` juggling needed. You can also include part of the content via the `TrueSheetPeek` component — see [Peeking Content](peeking) for the full guide.
 
 ## Platform Support
 

--- a/docs/docs/guides/peeking.mdx
+++ b/docs/docs/guides/peeking.mdx
@@ -1,0 +1,107 @@
+---
+title: Peeking Content
+description: Collapse the sheet to a compact peek that expands into full content.
+keywords: [bottom sheet peek, bottom sheet collapsed, bottom sheet snap points, map bottom sheet]
+---
+
+Building a map-style sheet with a compact summary that expands into full content? The [`"peek"`](../reference/types#sheetdetent) detent collapses the sheet down to just the essentials — no manual height juggling needed.
+
+## The `"peek"` Detent
+
+Add `"peek"` to your [`detents`](../reference/configuration#detents) to get a collapsed size based on the measured [`header`](header) and [`footer`](footer) heights.
+
+```tsx {4-4}
+const App = () => {
+  return (
+    <TrueSheet
+      detents={['peek', 0.9]}
+      initialDetentIndex={0}
+      header={<BookingSummary />}
+      footer={<SheetActions />}
+      scrollable
+    >
+      <BookingDetails />
+    </TrueSheet>
+  )
+}
+```
+
+The peek height automatically follows the measured header and footer sizes. When neither `header` nor `footer` is provided, it falls back to a fixed height of `150`.
+
+## Peeking Part of the Content
+
+To include part of the content in the peek height, wrap it with the `TrueSheetPeek` component.
+
+```tsx {8-10}
+import { TrueSheet, TrueSheetPeek } from '@lodev09/react-native-true-sheet'
+
+const App = () => {
+  return (
+    <TrueSheet detents={['peek', 0.9]} initialDetentIndex={0}>
+      <TrueSheetPeek>
+        <BookingSummary />
+      </TrueSheetPeek>
+      <BookingDetails />
+    </TrueSheet>
+  )
+}
+```
+
+When collapsed, the sheet reveals everything from the top of the sheet through the **bottom edge** of `TrueSheetPeek` — content padding and anything rendered above it count toward the height, while content below it stays hidden until the sheet is expanded.
+
+```
+┌──────────────────────┐
+│ header               │ ─┐
+│ ┌──────────────────┐ │  │
+│ │  TrueSheetPeek   │ │  ├─ visible when collapsed
+│ └──────────────────┘ │  │
+│ footer               │ ─┘
+├──────────────────────┤
+│ rest of the content  │ ── hidden until expanded
+└──────────────────────┘
+```
+
+:::info
+`TrueSheetPeek` can be placed anywhere within the content — the collapsed sheet simply reveals everything above it, including itself. A sheet can only have **one** peek component.
+:::
+
+:::tip
+Since everything above it counts, an **empty** `TrueSheetPeek` works as a fold marker — drop it between your existing views to mark where the collapsed sheet ends, no wrapping needed.
+
+```tsx {3}
+<TrueSheet detents={['peek', 0.9]} initialDetentIndex={0}>
+  <BookingSummary />
+  <TrueSheetPeek />
+  <BookingDetails />
+</TrueSheet>
+```
+:::
+
+## Styling
+
+`TrueSheetPeek` is a regular `View` — style it like any other.
+
+```tsx
+<TrueSheetPeek style={styles.summary}>
+  <Text style={styles.title}>True Sheet</Text>
+  <Text style={styles.subtitle}>The true native bottom sheet experience.</Text>
+</TrueSheetPeek>
+```
+
+Note that only the content through its bottom edge counts — a `marginBottom` on the peek itself is *not* included. If you want breathing room below the peek content while collapsed, use `paddingBottom` instead.
+
+## Safe Area
+
+By default ([`insetAdjustment="automatic"`](../reference/configuration#insetadjustment)), the bottom safe area inset is added to the peek height so the peek content clears the system navigation bar. Set `insetAdjustment="never"` if you're handling insets yourself.
+
+## Resizing
+
+`"peek"` works like any other detent — resize to it programmatically or listen for changes. See [Resizing Programmatically](resizing).
+
+```tsx
+sheet.current?.resize(0) // collapse back to peek
+```
+
+## Platform Support
+
+The `"peek"` detent and `TrueSheetPeek` are supported on **iOS 16+**, **Android**, and **Web**.

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -15,7 +15,7 @@ keywords: [bottom sheet types, bottom sheet typescript, bottom sheet definitions
 | Value | Description | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |
 | `"auto"` | Auto resize based on content height. | **_16+_** | ✅ | ✅ |
-| `"peek"` | Collapsed height based on the combined [`header`](configuration#header) and [`footer`](configuration#footer) heights. Falls back to a fixed height of `150` when neither is provided. | **_16+_** | ✅ | ✅ |
+| `"peek"` | Collapsed height based on the combined [`header`](configuration#header) and [`footer`](configuration#footer) heights, plus the measured height of a `TrueSheetPeek` component rendered within the content. Falls back to a fixed height of `150` when none is provided. | **_16+_** | ✅ | ✅ |
 | `number` | Fractional height (0-1) representing percentage of screen height. | ✅ | ✅ | ✅ |
 
 :::warning

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -15,7 +15,7 @@ keywords: [bottom sheet types, bottom sheet typescript, bottom sheet definitions
 | Value | Description | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |
 | `"auto"` | Auto resize based on content height. | **_16+_** | ✅ | ✅ |
-| `"peek"` | Collapsed height based on the combined [`header`](configuration#header) and [`footer`](configuration#footer) heights, plus the content up to the bottom of a `TrueSheetPeek` component rendered within it. Falls back to a fixed height of `150` when none is provided. | **_16+_** | ✅ | ✅ |
+| `"peek"` | Collapsed height based on the combined [`header`](configuration#header) and [`footer`](configuration#footer) heights, plus the content up to the bottom of a [`TrueSheetPeek`](../guides/peeking) component rendered within it. Falls back to a fixed height of `150` when none is provided. | **_16+_** | ✅ | ✅ |
 | `number` | Fractional height (0-1) representing percentage of screen height. | ✅ | ✅ | ✅ |
 
 :::warning

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -15,7 +15,7 @@ keywords: [bottom sheet types, bottom sheet typescript, bottom sheet definitions
 | Value | Description | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |
 | `"auto"` | Auto resize based on content height. | **_16+_** | ✅ | ✅ |
-| `"peek"` | Collapsed height based on the combined [`header`](configuration#header) and [`footer`](configuration#footer) heights, plus the measured height of a `TrueSheetPeek` component rendered within the content. Falls back to a fixed height of `150` when none is provided. | **_16+_** | ✅ | ✅ |
+| `"peek"` | Collapsed height based on the combined [`header`](configuration#header) and [`footer`](configuration#footer) heights, plus the content up to the bottom of a `TrueSheetPeek` component rendered within it. Falls back to a fixed height of `150` when none is provided. | **_16+_** | ✅ | ✅ |
 | `number` | Fractional height (0-1) representing percentage of screen height. | ✅ | ✅ | ✅ |
 
 :::warning

--- a/example/bare/ios/Podfile.lock
+++ b/example/bare/ios/Podfile.lock
@@ -2049,7 +2049,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNTrueSheet (3.11.3):
+  - RNTrueSheet (3.11.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2481,7 +2481,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 2ff61eac036eaf89f6818bf4ed9c39771a17d134
   RNReanimated: f735b1747a7a93bda7ca102c6d37a3cf54b6d5e8
   RNScreens: 991cc417cd396602a6cf59a42139e5a9d91462a9
-  RNTrueSheet: 353c65cecd44828c2e8be1bed59f9766003e8d1c
+  RNTrueSheet: 4dcd3292bcfe21502d48e0fd26b4fb3f68da0ad9
   RNWorklets: 4931990f73bc8f347586918b2e13f11dfadf3b75
   Yoga: 77dfa8673de2874e1855002ae59c68b8be9b007b
 

--- a/example/shared/src/components/sheets/BasicSheet.tsx
+++ b/example/shared/src/components/sheets/BasicSheet.tsx
@@ -1,6 +1,11 @@
 import { forwardRef, useRef, useState, type Ref, useImperativeHandle } from 'react';
 import { StyleSheet } from 'react-native';
-import { TrueSheet, useTrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
+import {
+  TrueSheet,
+  TrueSheetPeek,
+  useTrueSheet,
+  type TrueSheetProps,
+} from '@lodev09/react-native-true-sheet';
 
 import { BLUE, DARK, DARK_BLUE, FOOTER_HEIGHT, GAP, SPACING, times } from '../../utils';
 import { DemoContent } from '../DemoContent';
@@ -57,7 +62,7 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
 
   return (
     <TrueSheet
-      detents={['auto', 0.8, 1]}
+      detents={['peek', 'auto', 1]}
       name="basic"
       ref={sheetRef}
       detached
@@ -109,6 +114,7 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
       backgroundColor={detentIndex > 0 ? BLUE : undefined}
       header={<Header />}
       footer={<Footer />}
+      insetAdjustment="never"
       {...rest}
     >
       {times(contentCount, (i) => (
@@ -121,6 +127,7 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
         <Button text="80%" onPress={() => resize(1)} />
         <Button text="Auto" onPress={() => resize(0)} />
       </ButtonGroup>
+      <TrueSheetPeek />
       <Spacer />
       <Input />
       <ButtonGroup>

--- a/example/shared/src/screens/MapScreen.tsx
+++ b/example/shared/src/screens/MapScreen.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 import {
   TrueSheet,
+  TrueSheetPeek,
   type DetentChangeEvent,
   type DidPresentEvent,
   type DragBeginEvent,
@@ -230,10 +231,10 @@ const MapScreenInner = ({
         onDidDismiss={() => log('didDismiss')}
         header={<Header />}
       >
-        <View style={styles.heading}>
+        <TrueSheetPeek style={styles.heading}>
           <Text style={styles.title}>True Sheet</Text>
           <Text style={styles.subtitle}>The true native bottom sheet experience.</Text>
-        </View>
+        </TrueSheetPeek>
         <Button
           text="TrueSheet View"
           hint="Long press to stress test"

--- a/example/shared/src/screens/MapScreen.tsx
+++ b/example/shared/src/screens/MapScreen.tsx
@@ -231,10 +231,6 @@ const MapScreenInner = ({
         onDidDismiss={() => log('didDismiss')}
         header={<Header />}
       >
-        <TrueSheetPeek style={styles.heading}>
-          <Text style={styles.title}>True Sheet</Text>
-          <Text style={styles.subtitle}>The true native bottom sheet experience.</Text>
-        </TrueSheetPeek>
         <Button
           text="TrueSheet View"
           hint="Long press to stress test"
@@ -249,6 +245,10 @@ const MapScreenInner = ({
             <Button text="Center" onPress={() => setAnchorLeft(false)} />
           </ButtonGroup>
         )}
+        <TrueSheetPeek style={styles.heading}>
+          <Text style={styles.title}>True Sheet</Text>
+          <Text style={styles.subtitle}>The true native bottom sheet experience.</Text>
+        </TrueSheetPeek>
         <ButtonGroup>
           <Button text="Test Screen" onPress={onNavigateToTest} />
           <Button text="Test Stack" onPress={onNavigateToTestStack} />

--- a/example/shared/src/screens/MapScreen.tsx
+++ b/example/shared/src/screens/MapScreen.tsx
@@ -12,7 +12,6 @@ import {
 } from 'react-native';
 import {
   TrueSheet,
-  TrueSheetPeek,
   type DetentChangeEvent,
   type DidPresentEvent,
   type DragBeginEvent,
@@ -231,6 +230,10 @@ const MapScreenInner = ({
         onDidDismiss={() => log('didDismiss')}
         header={<Header />}
       >
+        <View style={styles.heading}>
+          <Text style={styles.title}>True Sheet</Text>
+          <Text style={styles.subtitle}>The true native bottom sheet experience.</Text>
+        </View>
         <Button
           text="TrueSheet View"
           hint="Long press to stress test"
@@ -245,10 +248,6 @@ const MapScreenInner = ({
             <Button text="Center" onPress={() => setAnchorLeft(false)} />
           </ButtonGroup>
         )}
-        <TrueSheetPeek style={styles.heading}>
-          <Text style={styles.title}>True Sheet</Text>
-          <Text style={styles.subtitle}>The true native bottom sheet experience.</Text>
-        </TrueSheetPeek>
         <ButtonGroup>
           <Button text="Test Screen" onPress={onNavigateToTest} />
           <Button text="Test Stack" onPress={onNavigateToTestStack} />

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -23,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@class TrueSheetPeekView;
+
 @protocol TrueSheetContainerViewDelegate <NSObject>
 
 - (void)containerViewContentDidChangeSize:(CGSize)newSize;
@@ -32,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)containerViewHeaderDidChangeSize:(CGSize)newSize;
 - (void)containerViewFooterDidChangeSize:(CGSize)newSize;
+- (void)containerViewPeekDidChangeSize:(CGSize)newSize;
 
 @end
 
@@ -71,6 +74,16 @@ NS_ASSUME_NONNULL_BEGIN
  * Returns the current footer height
  */
 - (CGFloat)footerHeight;
+
+/**
+ * Returns the current height of the peek view within the content
+ */
+- (CGFloat)peekContentHeight;
+
+/**
+ * Registers a peek view found within the content subtree
+ */
+- (void)attachPeekView:(TrueSheetPeekView *)peekView;
 
 /**
  * Updates footer layout constraints if needed

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -13,6 +13,7 @@
 #import "TrueSheetContentView.h"
 #import "TrueSheetFooterView.h"
 #import "TrueSheetHeaderView.h"
+#import "TrueSheetPeekView.h"
 #import "TrueSheetViewController.h"
 #import "core/TrueSheetKeyboardObserver.h"
 #import "utils/UIView+ScrollEdgeInteraction.h"
@@ -45,13 +46,15 @@ using namespace facebook::react;
 
 @interface TrueSheetContainerView () <TrueSheetContentViewDelegate,
   TrueSheetHeaderViewDelegate,
-  TrueSheetFooterViewDelegate>
+  TrueSheetFooterViewDelegate,
+  TrueSheetPeekViewDelegate>
 @end
 
 @implementation TrueSheetContainerView {
   TrueSheetContentView *_contentView;
   TrueSheetHeaderView *_headerView;
   TrueSheetFooterView *_footerView;
+  TrueSheetPeekView *__weak _peekView;
   TrueSheetKeyboardObserver *_keyboardObserver;
   BOOL _scrollableSet;
 }
@@ -121,6 +124,10 @@ using namespace facebook::react;
 
 - (CGFloat)footerHeight {
   return _footerView ? _footerView.frame.size.height : 0;
+}
+
+- (CGFloat)peekContentHeight {
+  return _peekView ? _peekView.frame.size.height : 0;
 }
 
 - (void)layoutFooter {
@@ -196,6 +203,13 @@ using namespace facebook::react;
     }
     _contentView = (TrueSheetContentView *)childComponentView;
     _contentView.delegate = self;
+
+    // Children mount bottom-up, so the content subtree is complete here.
+    // Late-mounted peek views attach themselves instead (see TrueSheetPeekView).
+    TrueSheetPeekView *peekView = [self findPeekViewIn:_contentView];
+    if (peekView) {
+      [self attachPeekView:peekView];
+    }
   }
 
   if ([childComponentView isKindOfClass:[TrueSheetHeaderView class]]) {
@@ -276,6 +290,52 @@ using namespace facebook::react;
   if (@available(iOS 26.0, *)) {
     [self setupEdgeInteractions];
   }
+}
+
+#pragma mark - TrueSheetPeekViewDelegate
+
+- (nullable TrueSheetPeekView *)findPeekViewIn:(UIView *)view {
+  if ([view isKindOfClass:[TrueSheetPeekView class]]) {
+    return (TrueSheetPeekView *)view;
+  }
+
+  for (UIView *subview in view.subviews) {
+    TrueSheetPeekView *found = [self findPeekViewIn:subview];
+    if (found) {
+      return found;
+    }
+  }
+
+  return nil;
+}
+
+- (void)attachPeekView:(TrueSheetPeekView *)peekView {
+  if (_peekView == peekView) {
+    return;
+  }
+
+  if (_peekView != nil) {
+    RCTLogWarn(@"TrueSheet: Sheet can only have one peek component.");
+    return;
+  }
+
+  _peekView = peekView;
+  peekView.delegate = self;
+  [self peekViewDidChangeSize:peekView.frame.size];
+}
+
+- (void)peekViewDidChangeSize:(CGSize)newSize {
+  [self.delegate containerViewPeekDidChangeSize:newSize];
+}
+
+- (void)peekViewWillDetach:(TrueSheetPeekView *)peekView {
+  if (_peekView != peekView) {
+    return;
+  }
+
+  _peekView.delegate = nil;
+  _peekView = nil;
+  [self peekViewDidChangeSize:CGSizeZero];
 }
 
 #pragma mark - Keyboard Observer

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -126,8 +126,19 @@ using namespace facebook::react;
   return _footerView ? _footerView.frame.size.height : 0;
 }
 
+// Distance from the top of the content view to the bottom of the peek view.
+// Includes the peek view's offset within the content (padding, views above it)
+// so the peek detent reveals everything down to the peek content's bottom edge.
 - (CGFloat)peekContentHeight {
-  return _peekView ? _peekView.frame.size.height : 0;
+  if (!_peekView) {
+    return 0;
+  }
+
+  if (!_contentView || ![_peekView isDescendantOfView:_contentView]) {
+    return _peekView.frame.size.height;
+  }
+
+  return CGRectGetMaxY([_peekView convertRect:_peekView.bounds toView:_contentView]);
 }
 
 - (void)layoutFooter {

--- a/ios/TrueSheetPeekView.h
+++ b/ios/TrueSheetPeekView.h
@@ -1,0 +1,32 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import <React/RCTViewComponentView.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class TrueSheetPeekView;
+
+@protocol TrueSheetPeekViewDelegate <NSObject>
+@optional
+- (void)peekViewDidChangeSize:(CGSize)size;
+- (void)peekViewWillDetach:(TrueSheetPeekView *)peekView;
+@end
+
+@interface TrueSheetPeekView : RCTViewComponentView
+
+@property (nonatomic, weak, nullable) id<TrueSheetPeekViewDelegate> delegate;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/ios/TrueSheetPeekView.mm
+++ b/ios/TrueSheetPeekView.mm
@@ -1,0 +1,96 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import "TrueSheetPeekView.h"
+#import <react/renderer/components/TrueSheetSpec/ComponentDescriptors.h>
+#import <react/renderer/components/TrueSheetSpec/EventEmitters.h>
+#import <react/renderer/components/TrueSheetSpec/Props.h>
+#import <react/renderer/components/TrueSheetSpec/RCTComponentViewHelpers.h>
+#import "TrueSheetContainerView.h"
+
+using namespace facebook::react;
+
+@implementation TrueSheetPeekView {
+  CGSize _lastSize;
+}
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetPeekViewComponentDescriptor>();
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const TrueSheetPeekViewProps>();
+    _props = defaultProps;
+
+    _lastSize = CGSizeZero;
+  }
+  return self;
+}
+
+/**
+ * Peek can be nested anywhere within the content, so it attaches itself to the
+ * nearest container instead of being mounted by it. The container also searches
+ * for it when the content mounts to cover the initial (bottom-up) mount order.
+ */
+- (void)attachToContainerView {
+  if (self.delegate) {
+    return;
+  }
+
+  UIView *view = self.superview;
+  while (view && ![view isKindOfClass:[TrueSheetContainerView class]]) {
+    view = view.superview;
+  }
+
+  if (view) {
+    [(TrueSheetContainerView *)view attachPeekView:self];
+  }
+}
+
+- (void)didMoveToSuperview {
+  [super didMoveToSuperview];
+  if (self.superview) {
+    [self attachToContainerView];
+  }
+}
+
+- (void)didMoveToWindow {
+  [super didMoveToWindow];
+  if (self.window) {
+    [self attachToContainerView];
+  }
+}
+
+- (void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics {
+  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+
+  CGSize newSize = CGSizeMake(layoutMetrics.frame.size.width, layoutMetrics.frame.size.height);
+
+  if (!CGSizeEqualToSize(newSize, _lastSize)) {
+    _lastSize = newSize;
+    [self.delegate peekViewDidChangeSize:newSize];
+  }
+}
+
+- (void)prepareForRecycle {
+  [super prepareForRecycle];
+  _lastSize = CGSizeZero;
+  [self.delegate peekViewWillDetach:self];
+}
+
+@end
+
+Class<RCTComponentViewProtocol> TrueSheetPeekViewCls(void) {
+  return TrueSheetPeekView.class;
+}
+
+#endif

--- a/ios/TrueSheetPeekView.mm
+++ b/ios/TrueSheetPeekView.mm
@@ -18,7 +18,7 @@
 using namespace facebook::react;
 
 @implementation TrueSheetPeekView {
-  CGSize _lastSize;
+  CGRect _lastFrame;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider {
@@ -30,7 +30,7 @@ using namespace facebook::react;
     static const auto defaultProps = std::make_shared<const TrueSheetPeekViewProps>();
     _props = defaultProps;
 
-    _lastSize = CGSizeZero;
+    _lastFrame = CGRectZero;
   }
   return self;
 }
@@ -73,17 +73,23 @@ using namespace facebook::react;
            oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics {
   [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
 
-  CGSize newSize = CGSizeMake(layoutMetrics.frame.size.width, layoutMetrics.frame.size.height);
+  // Compare the whole frame — the peek's offset within the content affects
+  // the peek detent, so position changes matter too.
+  CGRect newFrame = CGRectMake(
+    layoutMetrics.frame.origin.x,
+    layoutMetrics.frame.origin.y,
+    layoutMetrics.frame.size.width,
+    layoutMetrics.frame.size.height);
 
-  if (!CGSizeEqualToSize(newSize, _lastSize)) {
-    _lastSize = newSize;
-    [self.delegate peekViewDidChangeSize:newSize];
+  if (!CGRectEqualToRect(newFrame, _lastFrame)) {
+    _lastFrame = newFrame;
+    [self.delegate peekViewDidChangeSize:newFrame.size];
   }
 }
 
 - (void)prepareForRecycle {
   [super prepareForRecycle];
-  _lastSize = CGSizeZero;
+  _lastFrame = CGRectZero;
   [self.delegate peekViewWillDetach:self];
 }
 

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -398,6 +398,11 @@ using namespace facebook::react;
     _controller.footerHeight = @(footerHeight);
   }
 
+  CGFloat peekContentHeight = [_containerView peekContentHeight];
+  if (peekContentHeight > 0) {
+    _controller.peekContentHeight = @(peekContentHeight);
+  }
+
   if (_eventEmitter) {
     [TrueSheetLifecycleEvents emitMount:_eventEmitter];
   } else {
@@ -588,6 +593,11 @@ using namespace facebook::react;
   _controller.footerHeight = @(newSize.height);
   [self setupSheetDetentsForSizeChange];
   [_controller setupAccessibilityContainer];
+}
+
+- (void)containerViewPeekDidChangeSize:(CGSize)newSize {
+  _controller.peekContentHeight = @(newSize.height);
+  [self setupSheetDetentsForSizeChange];
 }
 
 // When the ScrollView changes (e.g. conditional remount), re-pin the new ScrollView.

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -596,7 +596,9 @@ using namespace facebook::react;
 }
 
 - (void)containerViewPeekDidChangeSize:(CGSize)newSize {
-  _controller.peekContentHeight = @(newSize.height);
+  // The size event is only a trigger; read the computed value which also
+  // accounts for the peek view's offset within the content.
+  _controller.peekContentHeight = @([_containerView peekContentHeight]);
   [self setupSheetDetentsForSizeChange];
 }
 

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -575,6 +575,9 @@ using namespace facebook::react;
     if (!self->_containerView)
       return;
 
+    // Refresh here (not just on peek size events) since the peek's offset
+    // within the content can change without its own size changing.
+    self->_controller.peekContentHeight = @([self->_containerView peekContentHeight]);
     [self->_controller setupSheetDetentsForSizeChange];
   });
 }
@@ -596,9 +599,6 @@ using namespace facebook::react;
 }
 
 - (void)containerViewPeekDidChangeSize:(CGSize)newSize {
-  // The size event is only a trigger; read the computed value which also
-  // accounts for the peek view's offset within the content.
-  _controller.peekContentHeight = @([_containerView peekContentHeight]);
   [self setupSheetDetentsForSizeChange];
 }
 

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -58,6 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSNumber *contentHeight;
 @property (nonatomic, strong, nullable) NSNumber *headerHeight;
 @property (nonatomic, strong, nullable) NSNumber *footerHeight;
+@property (nonatomic, strong, nullable) NSNumber *peekContentHeight;
 @property (nonatomic, strong, nullable) UIColor *backgroundColor;
 @property (nonatomic, strong, nullable) NSNumber *cornerRadius;
 @property (nonatomic, assign) BOOL grabber;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -92,6 +92,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     _contentHeight = @(0);
     _headerHeight = @(0);
     _footerHeight = @(0);
+    _peekContentHeight = @(0);
     _grabber = YES;
     _draggable = YES;
     _scrollingExpandsSheet = YES;

--- a/ios/core/TrueSheetDetentCalculator.h
+++ b/ios/core/TrueSheetDetentCalculator.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly, nullable) NSNumber *contentHeight;
 @property (nonatomic, strong, readonly, nullable) NSNumber *headerHeight;
 @property (nonatomic, strong, readonly, nullable) NSNumber *footerHeight;
+@property (nonatomic, strong, readonly, nullable) NSNumber *peekContentHeight;
 
 @end
 
@@ -42,8 +43,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (CGFloat)detentValueForIndex:(NSInteger)index;
 
 /**
- Returns the height for peek (-2) detents: header + footer height.
- Falls back to 150 when neither is present — matches the iOS 26
+ Returns the height for peek (-2) detents: header + footer + peek content height.
+ Falls back to 150 when none is present — matches the iOS 26
  floating small-detent threshold.
  */
 - (CGFloat)peekHeight;

--- a/ios/core/TrueSheetDetentCalculator.mm
+++ b/ios/core/TrueSheetDetentCalculator.mm
@@ -31,7 +31,8 @@
 }
 
 - (CGFloat)peekHeight {
-  CGFloat height = [self.delegate.headerHeight floatValue] + [self.delegate.footerHeight floatValue];
+  CGFloat height = [self.delegate.headerHeight floatValue] + [self.delegate.footerHeight floatValue] +
+                   [self.delegate.peekContentHeight floatValue];
   return height > 0 ? height : 150;
 }
 

--- a/ios/tvos/TrueSheetStubs.mm
+++ b/ios/tvos/TrueSheetStubs.mm
@@ -81,6 +81,17 @@ using namespace facebook::react;
 
 @end
 
+@interface TrueSheetPeekView : RCTViewComponentView
+@end
+
+@implementation TrueSheetPeekView
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetPeekViewComponentDescriptor>();
+}
+
+@end
+
 #pragma mark - Module
 
 @interface TrueSheetModule : NSObject <RCTBridgeModule, NativeTrueSheetModuleSpec>

--- a/package.json
+++ b/package.json
@@ -265,6 +265,9 @@
         },
         "TrueSheetFooterView": {
           "className": "TrueSheetFooterView"
+        },
+        "TrueSheetPeekView": {
+          "className": "TrueSheetPeekView"
         }
       }
     }

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -226,8 +226,8 @@ export type SheetDetent =
 
   /**
    * Collapsed height based on the combined `header` and `footer` heights.
-   * Render a `TrueSheetPeek` component within the content to include its
-   * measured height as well.
+   * Render a `TrueSheetPeek` component within the content to also include
+   * the content up to its bottom edge.
    * Falls back to a fixed height of `150` when none is provided.
    *
    * @platform android

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -226,7 +226,9 @@ export type SheetDetent =
 
   /**
    * Collapsed height based on the combined `header` and `footer` heights.
-   * Falls back to a fixed height of `150` when neither is provided.
+   * Render a `TrueSheetPeek` component within the content to include its
+   * measured height as well.
+   * Falls back to a fixed height of `150` when none is provided.
    *
    * @platform android
    * @platform ios 16+

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -15,6 +15,7 @@ import type { LayoutChangeEvent } from 'react-native';
 
 import { Drawer } from './web/vaul';
 import { DEFAULT_PEEK_HEIGHT, TRANSITIONS } from './web/vaul/constants';
+import { TrueSheetPeekContext } from './TrueSheetPeek.web';
 import type {
   DetentChangeEvent,
   DetentInfoEventPayload,
@@ -244,8 +245,12 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     setFooterHeight(e.nativeEvent.layout.height);
   }, []);
 
+  // Measured height of a `TrueSheetPeek` rendered within the content
+  const [peekContentHeight, setPeekContentHeight] = useState(0);
+
   const peekHeight =
-    (header ? headerHeight : 0) + (footer ? footerHeight : 0) || DEFAULT_PEEK_HEIGHT;
+    (header ? headerHeight : 0) + (footer ? footerHeight : 0) + peekContentHeight ||
+    DEFAULT_PEEK_HEIGHT;
 
   // Present/dismiss events. The sheet settles via a CSS `transform` transition
   // on either the drawer (snap-points on autopresent) or the wrapper (whole-
@@ -868,76 +873,78 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   );
 
   return (
-    <Drawer.Root
-      open={isOpen}
-      onOpenChange={handleOpenChange}
-      onPositionChange={handlePositionChange}
-      onDrag={handleDrag}
-      onRelease={handleRelease}
-      dismissible={dismissible}
-      draggable={draggable}
-      repositionInputs={false}
-      modal={dimmed}
-      nested={isNested}
-      detached={effectiveDetached}
-      detachedOffset={effectiveDetachedOffset}
-      detachedRadius={effectiveCornerRadius}
-      maxContentHeight={effectiveMaxContentHeight}
-      peekHeight={peekHeight}
-      initialAnimated={initialDetentAnimated}
-      detachedWrapperStyle={wrapperStyle}
-      onContentHeightChange={setMeasuredContentHeight}
-      activeSnapPoint={activeSnapPoint}
-      setActiveSnapPoint={handleSetActiveSnapPoint}
-      {...snapPointsProps}
-    >
-      <Drawer.Portal container={portalContainer ?? undefined}>
-        <Drawer.Overlay style={overlayStyle} />
-        <Drawer.Content
-          ref={drawerContentRef}
-          style={mergedContentStyle}
-          onPointerDownOutside={handlePointerDownOutside}
-          detachedSiblings={
-            footer ? (
-              <div style={footerFloatStyle}>
-                <View style={footerStyle} onLayout={handleFooterLayout}>
-                  {isValidElement(footer) ? footer : createElement(footer)}
-                </View>
+    <TrueSheetPeekContext.Provider value={setPeekContentHeight}>
+      <Drawer.Root
+        open={isOpen}
+        onOpenChange={handleOpenChange}
+        onPositionChange={handlePositionChange}
+        onDrag={handleDrag}
+        onRelease={handleRelease}
+        dismissible={dismissible}
+        draggable={draggable}
+        repositionInputs={false}
+        modal={dimmed}
+        nested={isNested}
+        detached={effectiveDetached}
+        detachedOffset={effectiveDetachedOffset}
+        detachedRadius={effectiveCornerRadius}
+        maxContentHeight={effectiveMaxContentHeight}
+        peekHeight={peekHeight}
+        initialAnimated={initialDetentAnimated}
+        detachedWrapperStyle={wrapperStyle}
+        onContentHeightChange={setMeasuredContentHeight}
+        activeSnapPoint={activeSnapPoint}
+        setActiveSnapPoint={handleSetActiveSnapPoint}
+        {...snapPointsProps}
+      >
+        <Drawer.Portal container={portalContainer ?? undefined}>
+          <Drawer.Overlay style={overlayStyle} />
+          <Drawer.Content
+            ref={drawerContentRef}
+            style={mergedContentStyle}
+            onPointerDownOutside={handlePointerDownOutside}
+            detachedSiblings={
+              footer ? (
+                <div style={footerFloatStyle}>
+                  <View style={footerStyle} onLayout={handleFooterLayout}>
+                    {isValidElement(footer) ? footer : createElement(footer)}
+                  </View>
+                </div>
+              ) : undefined
+            }
+          >
+            <Drawer.Title style={visuallyHiddenStyle}>Sheet</Drawer.Title>
+            {grabber && <Drawer.Handle style={handleStyle} />}
+            {scrollable ? (
+              // vaul wraps children in `[data-vaul-auto-size-wrapper]` (display:
+              // flow-root) which doesn't honor descendant flex layout. Use an
+              // absolute fill sized to the visible portion (via vaul's
+              // `--snap-point-height` var) so the inner flex column has a
+              // definite height for the scroll container's flex:1 to fill.
+              <div style={scrollableLayoutStyle}>
+                {header && (
+                  <View style={headerStyle} onLayout={handleHeaderLayout}>
+                    {isValidElement(header) ? header : createElement(header)}
+                  </View>
+                )}
+                <div style={scrollableContainerStyle}>
+                  <View style={style}>{children}</View>
+                </div>
               </div>
-            ) : undefined
-          }
-        >
-          <Drawer.Title style={visuallyHiddenStyle}>Sheet</Drawer.Title>
-          {grabber && <Drawer.Handle style={handleStyle} />}
-          {scrollable ? (
-            // vaul wraps children in `[data-vaul-auto-size-wrapper]` (display:
-            // flow-root) which doesn't honor descendant flex layout. Use an
-            // absolute fill sized to the visible portion (via vaul's
-            // `--snap-point-height` var) so the inner flex column has a
-            // definite height for the scroll container's flex:1 to fill.
-            <div style={scrollableLayoutStyle}>
-              {header && (
-                <View style={headerStyle} onLayout={handleHeaderLayout}>
-                  {isValidElement(header) ? header : createElement(header)}
-                </View>
-              )}
-              <div style={scrollableContainerStyle}>
+            ) : (
+              <>
+                {header && (
+                  <View style={headerStyle} onLayout={handleHeaderLayout}>
+                    {isValidElement(header) ? header : createElement(header)}
+                  </View>
+                )}
                 <View style={style}>{children}</View>
-              </div>
-            </div>
-          ) : (
-            <>
-              {header && (
-                <View style={headerStyle} onLayout={handleHeaderLayout}>
-                  {isValidElement(header) ? header : createElement(header)}
-                </View>
-              )}
-              <View style={style}>{children}</View>
-            </>
-          )}
-        </Drawer.Content>
-      </Drawer.Portal>
-    </Drawer.Root>
+              </>
+            )}
+          </Drawer.Content>
+        </Drawer.Portal>
+      </Drawer.Root>
+    </TrueSheetPeekContext.Provider>
   );
 });
 

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -245,8 +245,11 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     setFooterHeight(e.nativeEvent.layout.height);
   }, []);
 
-  // Measured height of a `TrueSheetPeek` rendered within the content
+  // Distance from the content top to the bottom of a `TrueSheetPeek` rendered
+  // within the content — measured by the peek against `contentRef`.
   const [peekContentHeight, setPeekContentHeight] = useState(0);
+  const contentRef = useRef<View>(null);
+  const peekContext = useMemo(() => ({ contentRef, setPeekContentHeight }), []);
 
   const peekHeight =
     (header ? headerHeight : 0) + (footer ? footerHeight : 0) + peekContentHeight ||
@@ -873,7 +876,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   );
 
   return (
-    <TrueSheetPeekContext.Provider value={setPeekContentHeight}>
+    <TrueSheetPeekContext.Provider value={peekContext}>
       <Drawer.Root
         open={isOpen}
         onOpenChange={handleOpenChange}
@@ -928,7 +931,9 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
                   </View>
                 )}
                 <div style={scrollableContainerStyle}>
-                  <View style={style}>{children}</View>
+                  <View ref={contentRef} style={style}>
+                    {children}
+                  </View>
                 </div>
               </div>
             ) : (
@@ -938,7 +943,9 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
                     {isValidElement(header) ? header : createElement(header)}
                   </View>
                 )}
-                <View style={style}>{children}</View>
+                <View ref={contentRef} style={style}>
+                  {children}
+                </View>
               </>
             )}
           </Drawer.Content>

--- a/src/TrueSheetPeek.tsx
+++ b/src/TrueSheetPeek.tsx
@@ -1,0 +1,10 @@
+import type { ViewProps } from 'react-native';
+
+import TrueSheetPeekViewNativeComponent from './fabric/TrueSheetPeekViewNativeComponent';
+
+/**
+ * Wrapper component that marks its children as the sheet's peek content.
+ * When rendered within a `TrueSheet`, its measured height is included in the
+ * `"peek"` detent height (along with the `header` and `footer` heights).
+ */
+export const TrueSheetPeek = (props: ViewProps) => <TrueSheetPeekViewNativeComponent {...props} />;

--- a/src/TrueSheetPeek.tsx
+++ b/src/TrueSheetPeek.tsx
@@ -4,10 +4,8 @@ import TrueSheetPeekViewNativeComponent from './fabric/TrueSheetPeekViewNativeCo
 
 /**
  * Wrapper component that marks its children as the sheet's peek content.
- * When rendered within a `TrueSheet`, its measured height is included in the
- * `"peek"` detent height (along with the `header` and `footer` heights).
- *
- * Place it at the top of the content - only its height is used, and the
- * sheet reveals content from the top when collapsed.
+ * When rendered within a `TrueSheet`, the `"peek"` detent reveals everything
+ * from the top of the sheet through the bottom of this component — content
+ * below it stays hidden until the sheet is expanded.
  */
 export const TrueSheetPeek = (props: ViewProps) => <TrueSheetPeekViewNativeComponent {...props} />;

--- a/src/TrueSheetPeek.tsx
+++ b/src/TrueSheetPeek.tsx
@@ -6,5 +6,8 @@ import TrueSheetPeekViewNativeComponent from './fabric/TrueSheetPeekViewNativeCo
  * Wrapper component that marks its children as the sheet's peek content.
  * When rendered within a `TrueSheet`, its measured height is included in the
  * `"peek"` detent height (along with the `header` and `footer` heights).
+ *
+ * Place it at the top of the content - only its height is used, and the
+ * sheet reveals content from the top when collapsed.
  */
 export const TrueSheetPeek = (props: ViewProps) => <TrueSheetPeekViewNativeComponent {...props} />;

--- a/src/TrueSheetPeek.web.tsx
+++ b/src/TrueSheetPeek.web.tsx
@@ -11,6 +11,9 @@ export const TrueSheetPeekContext = createContext<((height: number) => void) | n
  * Wrapper component that marks its children as the sheet's peek content.
  * When rendered within a `TrueSheet`, its measured height is included in the
  * `"peek"` detent height (along with the `header` and `footer` heights).
+ *
+ * Place it at the top of the content - only its height is used, and the
+ * sheet reveals content from the top when collapsed.
  */
 export const TrueSheetPeek = ({ onLayout, ...rest }: ViewProps) => {
   const setPeekContentHeight = useContext(TrueSheetPeekContext);

--- a/src/TrueSheetPeek.web.tsx
+++ b/src/TrueSheetPeek.web.tsx
@@ -1,29 +1,48 @@
-import { createContext, useContext, useEffect } from 'react';
+import { createContext, useContext, useEffect, useRef, type RefObject } from 'react';
 import { View, type LayoutChangeEvent, type ViewProps } from 'react-native';
 
 /**
  * Reports the measured peek content height to the owning TrueSheet.
  * @internal
  */
-export const TrueSheetPeekContext = createContext<((height: number) => void) | null>(null);
+export interface TrueSheetPeekContextValue {
+  contentRef: RefObject<View | null>;
+  setPeekContentHeight: (height: number) => void;
+}
+
+export const TrueSheetPeekContext = createContext<TrueSheetPeekContextValue | null>(null);
 
 /**
  * Wrapper component that marks its children as the sheet's peek content.
- * When rendered within a `TrueSheet`, its measured height is included in the
- * `"peek"` detent height (along with the `header` and `footer` heights).
- *
- * Place it at the top of the content - only its height is used, and the
- * sheet reveals content from the top when collapsed.
+ * When rendered within a `TrueSheet`, the `"peek"` detent reveals everything
+ * from the top of the sheet through the bottom of this component — content
+ * below it stays hidden until the sheet is expanded.
  */
 export const TrueSheetPeek = ({ onLayout, ...rest }: ViewProps) => {
-  const setPeekContentHeight = useContext(TrueSheetPeekContext);
+  const context = useContext(TrueSheetPeekContext);
+  const viewRef = useRef<View>(null);
 
-  useEffect(() => () => setPeekContentHeight?.(0), [setPeekContentHeight]);
+  useEffect(() => () => context?.setPeekContentHeight(0), [context]);
 
   const handleLayout = (event: LayoutChangeEvent) => {
-    setPeekContentHeight?.(event.nativeEvent.layout.height);
+    if (context) {
+      // On web, View refs resolve to the underlying DOM elements.
+      const peekElement = viewRef.current as unknown as HTMLElement | null;
+      const contentElement = context.contentRef.current as unknown as HTMLElement | null;
+
+      // Distance from the top of the content view to the bottom of the peek view,
+      // so the peek view's offset within the content (padding, views above it)
+      // counts toward the peek detent.
+      const bottom =
+        peekElement && contentElement
+          ? peekElement.getBoundingClientRect().bottom - contentElement.getBoundingClientRect().top
+          : event.nativeEvent.layout.height;
+
+      context.setPeekContentHeight(bottom);
+    }
+
     onLayout?.(event);
   };
 
-  return <View {...rest} onLayout={handleLayout} />;
+  return <View {...rest} ref={viewRef} onLayout={handleLayout} />;
 };

--- a/src/TrueSheetPeek.web.tsx
+++ b/src/TrueSheetPeek.web.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, useEffect } from 'react';
+import { View, type LayoutChangeEvent, type ViewProps } from 'react-native';
+
+/**
+ * Reports the measured peek content height to the owning TrueSheet.
+ * @internal
+ */
+export const TrueSheetPeekContext = createContext<((height: number) => void) | null>(null);
+
+/**
+ * Wrapper component that marks its children as the sheet's peek content.
+ * When rendered within a `TrueSheet`, its measured height is included in the
+ * `"peek"` detent height (along with the `header` and `footer` heights).
+ */
+export const TrueSheetPeek = ({ onLayout, ...rest }: ViewProps) => {
+  const setPeekContentHeight = useContext(TrueSheetPeekContext);
+
+  useEffect(() => () => setPeekContentHeight?.(0), [setPeekContentHeight]);
+
+  const handleLayout = (event: LayoutChangeEvent) => {
+    setPeekContentHeight?.(event.nativeEvent.layout.height);
+    onLayout?.(event);
+  };
+
+  return <View {...rest} onLayout={handleLayout} />;
+};

--- a/src/__tests__/TrueSheet.test.tsx
+++ b/src/__tests__/TrueSheet.test.tsx
@@ -1,6 +1,6 @@
 import { Text } from 'react-native';
 import { render, act } from '@testing-library/react-native';
-import { TrueSheet } from '../index';
+import { TrueSheet, TrueSheetPeek } from '../index';
 import type {
   DidDismissEvent,
   WillFocusEvent,
@@ -52,6 +52,19 @@ describe('TrueSheet', () => {
     );
     expect(getByText('Content')).toBeDefined();
     expect(getByText('Footer Content')).toBeDefined();
+  });
+
+  it('should render TrueSheetPeek within content', () => {
+    const { getByText } = render(
+      <TrueSheet name="test" detents={['peek', 1]} initialDetentIndex={0}>
+        <TrueSheetPeek>
+          <Text>Peek Content</Text>
+        </TrueSheetPeek>
+        <Text>Content</Text>
+      </TrueSheet>
+    );
+    expect(getByText('Peek Content')).toBeDefined();
+    expect(getByText('Content')).toBeDefined();
   });
 
   it('should render with detents prop', () => {

--- a/src/fabric/TrueSheetPeekViewNativeComponent.ts
+++ b/src/fabric/TrueSheetPeekViewNativeComponent.ts
@@ -1,0 +1,8 @@
+import type { ViewProps } from 'react-native';
+import { codegenNativeComponent } from 'react-native';
+
+export interface NativeProps extends ViewProps {
+  // Peek-specific props can be added here if needed
+}
+
+export default codegenNativeComponent<NativeProps>('TrueSheetPeekView', {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './TrueSheet';
 export * from './TrueSheet.types';
+export { TrueSheetPeek } from './TrueSheetPeek';
 export { TrueSheetProvider, useTrueSheet } from './TrueSheetProvider';

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,5 +1,5 @@
 import React, { createElement, isValidElement, type ReactNode } from 'react';
-import { View } from 'react-native';
+import { View, type ViewProps } from 'react-native';
 
 import type { TrueSheetProps, TrueSheetStaticMethods } from '../TrueSheet.types';
 
@@ -57,6 +57,13 @@ export class TrueSheet extends React.Component<TrueSheetProps, TrueSheetState> {
     const { children, style } = this.props;
     return React.createElement(View, { style }, this.renderHeader(), children, this.renderFooter());
   }
+}
+
+/**
+ * Mock TrueSheetPeek component for testing.
+ */
+export function TrueSheetPeek({ children, ...rest }: ViewProps) {
+  return React.createElement(View, rest, children);
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a new `TrueSheetPeek` wrapper component that marks part of the content as the sheet's peek content. The `peek` detent height covers the content from the top of the sheet through the peek's **bottom edge** (measured natively, along with the `header` and `footer` heights), so the collapsed size follows the actual content — no `onLayout` juggling.

```tsx
<TrueSheet detents={['peek', 0.9]} initialDetentIndex={0}>
  <TrueSheetPeek>
    <BookingSummary />
  </TrueSheetPeek>
  <BookingDetails />
</TrueSheet>
```

- New `TrueSheetPeekView` Fabric component (iOS/Android) that measures via native layout and reports to the sheet's detent calculator — no JS round trip
- Registers with the nearest container: subtree search when content mounts (Fabric mounts bottom-up), self-attach walk-up for late mounts, detach on unmount
- Measures to the peek's **bottom edge** within the content — not just its height — so content padding and views above it count. `TrueSheetPeek` can therefore be placed anywhere, and an empty `<TrueSheetPeek />` works as a fold marker
- Reconfigure triggers cover position changes too (Android `onLayout` `changed` flag, iOS frame compare), and iOS re-reads the measured value on every debounced reconfigure
- Web mirrors it via DOM rect measurement + context feeding the vaul snap point
- New [Peeking Content](https://sheet.lodev09.com/guides/peeking) docs guide; header/footer guides and the type reference link to it
- `MapScreen` example places the peek mid-content to exercise offset measurement

## Type of Change

- [x] New feature

## Test Plan

- `yarn typecheck`, `yarn lint`, `yarn test` (44 passed)
- Example app `MapScreen` on iOS/Android: presents at the peek detent sized through the peek content's bottom edge; on Android both `insetAdjustment="automatic"` and `"never"` now measure correctly with content padding; resizes live when peek content changes

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)