### PR TITLE
fix(web): scrollable content cut-off and drag/scroll conflicts during sheet drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - **Android**: The sheet can now be dragged from views overlaying a scrollable — e.g. a header (including a `TextInput` in it) positioned over a `FlatList` — previously the drag did nothing. ([#734](https://github.com/lodev09/react-native-true-sheet/pull/734) by [@lodev09](https://github.com/lodev09))
 - **Web**: `onWillPresent`, `onDidPresent`, and `onDetentChange` now emit the target detent `position`/`detent` — consistent with iOS/Android. Previously `onWillPresent` emitted `0` on first present or the offscreen position on re-present, `onDetentChange` emitted the old position, and `detent` was `0` for `auto`/`peek` detents. ([#737](https://github.com/lodev09/react-native-true-sheet/pull/737) by [@lodev09](https://github.com/lodev09))
+- **Web**: Scrollable content no longer gets cut off mid-drag — the visible-height layout now tracks the drag live and resizes in sync with snap animations. ([#739](https://github.com/lodev09/react-native-true-sheet/pull/739) by [@lodev09](https://github.com/lodev09))
+- **Web**: Dragging the sheet on a mobile browser no longer scrolls the content along with it — vertical touch pans are reserved for the sheet below the last detent, and latched scroll gestures are halted when the drag engages at the last detent. ([#739](https://github.com/lodev09/react-native-true-sheet/pull/739) by [@lodev09](https://github.com/lodev09))
+- **Web**: The sheet drag now engages immediately during/after Safari's scroll bounce instead of deadening the gesture. ([#739](https://github.com/lodev09/react-native-true-sheet/pull/739) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@
 
 - **Android**: The sheet can now be dragged from views overlaying a scrollable — e.g. a header (including a `TextInput` in it) positioned over a `FlatList` — previously the drag did nothing. ([#734](https://github.com/lodev09/react-native-true-sheet/pull/734) by [@lodev09](https://github.com/lodev09))
 - **Web**: `onWillPresent`, `onDidPresent`, and `onDetentChange` now emit the target detent `position`/`detent` — consistent with iOS/Android. Previously `onWillPresent` emitted `0` on first present or the offscreen position on re-present, `onDetentChange` emitted the old position, and `detent` was `0` for `auto`/`peek` detents. ([#737](https://github.com/lodev09/react-native-true-sheet/pull/737) by [@lodev09](https://github.com/lodev09))
-- **Web**: Scrollable content no longer gets cut off mid-drag — the visible-height layout now tracks the drag live and resizes in sync with snap animations. ([#739](https://github.com/lodev09/react-native-true-sheet/pull/739) by [@lodev09](https://github.com/lodev09))
-- **Web**: Dragging the sheet on a mobile browser no longer scrolls the content along with it — vertical touch pans are reserved for the sheet below the last detent, and latched scroll gestures are halted when the drag engages at the last detent. ([#739](https://github.com/lodev09/react-native-true-sheet/pull/739) by [@lodev09](https://github.com/lodev09))
-- **Web**: The sheet drag now engages immediately during/after Safari's scroll bounce instead of deadening the gesture. ([#739](https://github.com/lodev09/react-native-true-sheet/pull/739) by [@lodev09](https://github.com/lodev09))
+- **Web**: Fixed scrollable content cutting off mid-drag, scrolling along with the sheet drag on mobile, and delayed drag after Safari's scroll bounce. ([#739](https://github.com/lodev09/react-native-true-sheet/pull/739) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.6
 

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -255,6 +255,12 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     (header ? headerHeight : 0) + (footer ? footerHeight : 0) + peekContentHeight ||
     DEFAULT_PEEK_HEIGHT;
 
+  // Below the last detent a vertical touch pan moves the sheet, not the
+  // content — `[data-vaul-scroll-locked]` disables vertical touch panning on
+  // the scroll container and everything inside it (see vaul/style.css).
+  const isScrollLocked =
+    validDetents.length > 0 && activeSnapPoint !== validDetents[validDetents.length - 1];
+
   // Vaul measures the auto-size wrapper's offsetHeight (always, post fork).
   // Track it here so the form sheet can size its card to fit content,
   // clamped between a minimum ratio of the viewport and a maximum derived
@@ -967,7 +973,10 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
                     {isValidElement(header) ? header : createElement(header)}
                   </View>
                 )}
-                <div style={scrollableContainerStyle}>
+                <div
+                  style={scrollableContainerStyle}
+                  data-vaul-scroll-locked={isScrollLocked ? '' : undefined}
+                >
                   <View ref={contentRef} style={style}>
                     {children}
                   </View>

--- a/src/web/vaul/index.tsx
+++ b/src/web/vaul/index.tsx
@@ -443,13 +443,16 @@ export function Root({
       return false;
     }
 
-    // Disallow dragging if drawer was scrolled within `scrollLockTimeout`
+    // Disallow dragging if drawer was scrolled within `scrollLockTimeout`.
+    // Don't re-arm the timestamp here — a prevented drag attempt is not a
+    // scroll, and re-arming would keep the lock alive for as long as the
+    // finger moves, deadening the whole gesture instead of just the first
+    // `scrollLockTimeout` ms after the last real scroll.
     if (
       lastTimeDragPrevented.current &&
       date.getTime() - lastTimeDragPrevented.current.getTime() < scrollLockTimeout &&
       swipeAmount === 0
     ) {
-      lastTimeDragPrevented.current = date;
       return false;
     }
 
@@ -464,7 +467,11 @@ export function Root({
     while (element) {
       // Check if the element is scrollable
       if (element.scrollHeight > element.clientHeight) {
-        if (element.scrollTop !== 0) {
+        // `> 0`, not `!== 0`: Safari reports a negative scrollTop during the
+        // rubber-band bounce at the top — that's "at the top" for drag
+        // purposes, and treating it as scrolled would arm the scroll lock and
+        // delay the sheet drag until the bounce fully settles.
+        if (element.scrollTop > 0) {
           lastTimeDragPrevented.current = new Date();
 
           // The element is scrollable and not scrolled to the top, so don't drag
@@ -527,13 +534,21 @@ export function Root({
         return;
       }
 
-      if (!isAllowedToDrag.current && !shouldDrag(event.target, isDraggingInDirection)) return;
-      drawerRef.current.classList.add(DRAG_CLASS);
-      // If shouldDrag gave true once after pressing down on the drawer, we set isAllowedToDrag to true and it will remain true until we let go, there's no reason to disable dragging mid way, ever, and that's the solution to it
-      isAllowedToDrag.current = true;
-      // Touch pans latched onto a scroller would keep scrolling the content
-      // along with the sheet drag — freeze them for the drag's duration.
-      if (event.pointerType !== 'mouse') freezeScrollables(event.target);
+      if (!isAllowedToDrag.current) {
+        if (!shouldDrag(event.target, isDraggingInDirection)) return;
+        drawerRef.current.classList.add(DRAG_CLASS);
+        // If shouldDrag gave true once after pressing down on the drawer, we set isAllowedToDrag to true and it will remain true until we let go, there's no reason to disable dragging mid way, ever, and that's the solution to it
+        isAllowedToDrag.current = true;
+        // Touch pans latched onto a scroller would keep scrolling the content
+        // along with the sheet drag — freeze them for the drag's duration.
+        if (event.pointerType !== 'mouse') freezeScrollables(event.target);
+        // Drag can engage mid-gesture (content scrolled back to its top under
+        // the same finger, or the scroll lock expiring). Re-anchor and start
+        // moving on the next tick so the sheet tracks the finger from here
+        // instead of jumping by the distance the gesture already consumed.
+        pointerStart.current = isVertical(direction) ? event.pageY : event.pageX;
+        return;
+      }
       set(drawerRef.current, {
         transition: 'none',
       });

--- a/src/web/vaul/index.tsx
+++ b/src/web/vaul/index.tsx
@@ -24,7 +24,7 @@ import type { DrawerDirection } from './types';
 import { useComposedRefs } from './use-composed-refs';
 import { useControllableState } from './use-controllable-state';
 import { usePositionFixed } from './use-position-fixed';
-import { isInput, usePreventScroll } from './use-prevent-scroll';
+import { isInput, isScrollable, usePreventScroll } from './use-prevent-scroll';
 import { useScaleBackground } from './use-scale-background';
 import { useSnapPoints } from './use-snap-points';
 
@@ -337,6 +337,44 @@ export function Root({
     noBodyStyles,
   });
 
+  // While the sheet itself is being dragged, scrollables in the touched chain
+  // are frozen (overflow: hidden). Touch browsers latch the scroll gesture at
+  // touchstart and ignore preventDefault once scrolling has started, so making
+  // the scroller non-scrollable mid-gesture is the only reliable way to keep
+  // the content from panning along with the sheet.
+  const frozenScrollablesRef = React.useRef<
+    { element: HTMLElement; overflowX: string; overflowY: string }[] | null
+  >(null);
+
+  function freezeScrollables(target: EventTarget) {
+    if (frozenScrollablesRef.current) return;
+    const frozen: { element: HTMLElement; overflowX: string; overflowY: string }[] = [];
+    let element = target instanceof HTMLElement ? target : null;
+    while (element && element !== drawerRef.current) {
+      if (isScrollable(element)) {
+        frozen.push({
+          element,
+          overflowX: element.style.overflowX,
+          overflowY: element.style.overflowY,
+        });
+        element.style.overflowX = 'hidden';
+        element.style.overflowY = 'hidden';
+      }
+      element = element.parentElement;
+    }
+    frozenScrollablesRef.current = frozen;
+  }
+
+  function unfreezeScrollables() {
+    const frozen = frozenScrollablesRef.current;
+    if (!frozen) return;
+    frozenScrollablesRef.current = null;
+    for (const { element, overflowX, overflowY } of frozen) {
+      element.style.overflowX = overflowX;
+      element.style.overflowY = overflowY;
+    }
+  }
+
   function getScale() {
     return (window.innerWidth - WINDOW_TOP_OFFSET) / window.innerWidth;
   }
@@ -386,7 +424,16 @@ export function Root({
     }
 
     if (swipeAmount !== null) {
-      if (direction === 'bottom' ? swipeAmount > 0 : swipeAmount < 0) {
+      // Translated past the drag threshold → keep dragging. Below the last
+      // snap point the threshold is 0, so the sheet always wins over content
+      // scrolling. At the last snap point the threshold is its resting
+      // translate — which can still be > 0 when the max detent < 1 — so an
+      // at-rest sheet falls through to the scroll checks and content
+      // scrolling wins, matching native. Mid-drag/mid-animation the sheet is
+      // displaced past rest and still wins.
+      const atLastSnapPoint = snapPoints && activeSnapPointIndex === snapPoints.length - 1;
+      const restOffset = atLastSnapPoint ? (snapPointsOffset?.[activeSnapPointIndex!] ?? 0) : 0;
+      if (direction === 'bottom' ? swipeAmount > restOffset + 1 : swipeAmount < restOffset - 1) {
         return true;
       }
     }
@@ -484,6 +531,9 @@ export function Root({
       drawerRef.current.classList.add(DRAG_CLASS);
       // If shouldDrag gave true once after pressing down on the drawer, we set isAllowedToDrag to true and it will remain true until we let go, there's no reason to disable dragging mid way, ever, and that's the solution to it
       isAllowedToDrag.current = true;
+      // Touch pans latched onto a scroller would keep scrolling the content
+      // along with the sheet drag — freeze them for the drag's duration.
+      if (event.pointerType !== 'mouse') freezeScrollables(event.target);
       set(drawerRef.current, {
         transition: 'none',
       });
@@ -691,6 +741,7 @@ export function Root({
 
     drawerRef.current.classList.remove(DRAG_CLASS);
     isAllowedToDrag.current = false;
+    unfreezeScrollables();
     setIsDragging(false);
     dragEndTime.current = new Date();
   }
@@ -700,6 +751,7 @@ export function Root({
 
     drawerRef.current.classList.remove(DRAG_CLASS);
     isAllowedToDrag.current = false;
+    unfreezeScrollables();
     setIsDragging(false);
     dragEndTime.current = new Date();
     const swipeAmount = getTranslate(drawerRef.current, direction);

--- a/src/web/vaul/style.css
+++ b/src/web/vaul/style.css
@@ -1,7 +1,19 @@
+/* Registered so it can transition in sync with `transform` during snaps.
+   Descendants derive their visible-height layout from it, so `inherits: true`
+   is required. Unsupported browsers ignore this and the value just jumps to
+   the snap target instead of animating. */
+@property --snap-point-height {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 0px;
+}
+
 [data-vaul-drawer] {
   touch-action: none;
   will-change: transform;
-  transition: transform 0.5s cubic-bezier(0.32, 0.72, 0, 1);
+  transition:
+    transform 0.5s cubic-bezier(0.32, 0.72, 0, 1),
+    --snap-point-height 0.5s cubic-bezier(0.32, 0.72, 0, 1);
   animation-duration: 0.5s;
   animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
 }
@@ -82,6 +94,17 @@
 
 [data-vaul-drawer][data-vaul-delayed-snap-points='true'][data-vaul-drawer-direction='right'] {
   transform: translate3d(var(--snap-point-height, 0), 0, 0);
+}
+
+/* Below the last snap point, vertical touch pans should move the sheet — not
+   scroll the content (matches native). touch-action is latched at gesture
+   start and ancestors above a scroller aren't consulted, so every descendant
+   (nested scrollers included) must opt out of vertical panning ahead of time.
+   pan-x keeps horizontal carousels inside the content working. Wheel/trackpad
+   scrolling is unaffected. */
+[data-vaul-scroll-locked],
+[data-vaul-scroll-locked] * {
+  touch-action: pan-x !important;
 }
 
 [data-vaul-overlay][data-vaul-snap-points='false'] {

--- a/src/web/vaul/use-snap-points.ts
+++ b/src/web/vaul/use-snap-points.ts
@@ -198,13 +198,17 @@ export function useSnapPoints({
 
       const animateThisSnap = hasSnappedRef.current || initialAnimated;
       hasSnappedRef.current = true;
+      // `--snap-point-height` transitions alongside `transform` (registered via
+      // @property) so layouts derived from it (e.g. the scrollable fill) resize
+      // in sync with the drawer's slide instead of jumping to the target.
       set(drawerRef.current, {
-        transition: animateThisSnap
-          ? `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(',')})`
+        'transition': animateThisSnap
+          ? `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(',')}), --snap-point-height ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(',')})`
           : 'none',
-        transform: isVertical(direction)
+        'transform': isVertical(direction)
           ? `translate3d(0, ${dimension}px, 0)`
           : `translate3d(${dimension}px, 0, 0)`,
+        '--snap-point-height': `${dimension}px`,
       });
 
       // Snapping implies drag overshoot (if any) should be undone.
@@ -360,19 +364,24 @@ export function useSnapPoints({
     if ((direction === 'bottom' || direction === 'right') && newValue > snapPointsOffset[0]) {
       const excess = newValue - snapPointsOffset[0];
       set(drawerRef.current, {
-        transform: isVertical(direction)
+        'transform': isVertical(direction)
           ? `translate3d(0, ${snapPointsOffset[0]}px, 0)`
           : `translate3d(${snapPointsOffset[0]}px, 0, 0)`,
+        '--snap-point-height': `${snapPointsOffset[0]}px`,
       });
       setDetachedWrapperTransform(excess, false);
       return;
     }
 
     setDetachedWrapperTransform(0, false);
+    // Keep `--snap-point-height` tracking the live drag position so layouts
+    // derived from it (e.g. the scrollable fill) resize with the drawer
+    // instead of staying cut off at the last detent's visible height.
     set(drawerRef.current, {
-      transform: isVertical(direction)
+      'transform': isVertical(direction)
         ? `translate3d(0, ${newValue}px, 0)`
         : `translate3d(${newValue}px, 0, 0)`,
+      '--snap-point-height': `${newValue}px`,
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes three web drag issues around scrollable content:

- **Mid-drag cut-off**: the scrollable fill is sized off `--snap-point-height`, which only updated on detent change — content stayed at the old visible height and got cut off while dragging. The var now tracks the live drag position and transitions in sync with `transform` (registered via `@property`) so the content resizes smoothly through drags and snap animations.
- **Content scrolling along with the drag (mobile)**: below the last detent, vertical touch pans are disabled ahead of time on the scroll container and its descendants (`touch-action` is latched at gesture start and ancestors above a scroller aren't consulted). At the last detent, scrollers in the touched chain are frozen (`overflow: hidden`) once the sheet drag activates, since browsers ignore `preventDefault` after a scroll gesture is latched. `shouldDrag`'s rest threshold is generalized so sheets with a max detent < 1 still scroll content at rest.
- **Delayed drag after scroll bounce (Safari)**: the rubber-band bounce reports negative `scrollTop`, which armed the scroll lock, and the lock re-armed itself on every prevented move — deadening the whole gesture. Bounce now counts as at-top, prevented attempts no longer re-arm, and the drag re-anchors when it engages mid-gesture so the sheet doesn't jump.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Dragged the FlatList/ScrollView sheets between detents on web — content fills the sheet through the whole drag and snap animation
- On mobile browser: dragging the sheet from scrollable content moves only the sheet; content scrolls normally at the last detent
- On Safari: drag engages immediately during/after the scroll bounce
- Verified drags end-to-end in headless Chrome (CDP touch + mouse) and Playwright WebKit
- `yarn jest` (44 tests), `tsc`, `eslint` pass

## Screenshots / Videos

N/A

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)