### PR TITLE
fix(web): measure peek content live for initial detent geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- **Web**: The `peek` detent's `TrueSheetPeek` content offset is now measured live during initial presentation — previously the first `willPresent` on autopresent missed it (state lags mount by a frame) and reported only the header/footer height. ([#742](https://github.com/lodev09/react-native-true-sheet/pull/742) by [@lodev09](https://github.com/lodev09))
+
 ## 3.11.8
 
 ### 🐛 Bug fixes

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -10,12 +10,9 @@ import {
   useRef,
   useState,
 } from 'react';
-import { View, useColorScheme, useWindowDimensions } from 'react-native';
 import type { LayoutChangeEvent } from 'react-native';
+import { useColorScheme, useWindowDimensions, View } from 'react-native';
 
-import { Drawer } from './web/vaul';
-import { DEFAULT_PEEK_HEIGHT, TRANSITIONS } from './web/vaul/constants';
-import { TrueSheetPeekContext } from './TrueSheetPeek.web';
 import type {
   DetentChangeEvent,
   DetentInfoEventPayload,
@@ -37,6 +34,7 @@ import type {
   WillFocusEvent,
   WillPresentEvent,
 } from './TrueSheet.types';
+import { measurePeekContentHeight, TrueSheetPeekContext } from './TrueSheetPeek.web';
 import { usePortalContainer, useRegisterSheet, useSheetStack } from './TrueSheetProvider.web';
 import {
   COLOR_SURFACE_CONTAINER_LOW_DARK,
@@ -44,15 +42,17 @@ import {
   DEFAULT_ANCHOR_OFFSET,
   DEFAULT_CORNER_RADIUS,
   DEFAULT_DETACHED_OFFSET,
+  DEFAULT_FORM_SHEET_HEIGHT_RATIO,
+  DEFAULT_FORM_SHEET_WIDTH,
   DEFAULT_GRABBER_COLOR_DARK,
   DEFAULT_GRABBER_COLOR_LIGHT,
   DEFAULT_GRABBER_HEIGHT,
   DEFAULT_GRABBER_TOP_MARGIN,
   DEFAULT_GRABBER_WIDTH,
-  DEFAULT_FORM_SHEET_HEIGHT_RATIO,
-  DEFAULT_FORM_SHEET_WIDTH,
   DEFAULT_MAX_WIDTH,
 } from './web/constants';
+import { Drawer } from './web/vaul';
+import { DEFAULT_PEEK_HEIGHT, TRANSITIONS } from './web/vaul/constants';
 
 const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, ref) => {
   const {
@@ -256,7 +256,8 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   // within the content — measured by the peek against `contentRef`.
   const [peekContentHeight, setPeekContentHeight] = useState(0);
   const contentRef = useRef<View>(null);
-  const peekContext = useMemo(() => ({ contentRef, setPeekContentHeight }), []);
+  const peekElRef = useRef<View>(null);
+  const peekContext = useMemo(() => ({ contentRef, peekRef: peekElRef, setPeekContentHeight }), []);
 
   const peekHeight =
     (header ? headerHeight : 0) + (footer ? footerHeight : 0) + peekContentHeight ||
@@ -383,11 +384,14 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     // measurable here; fall back to the state value when they're absent.
     const headerEl = headerElRef.current as unknown as HTMLElement | null;
     const footerEl = footerElRef.current as unknown as HTMLElement | null;
+    const peekEl = peekElRef.current as unknown as HTMLElement | null;
+    const contentEl = contentRef.current as unknown as HTMLElement | null;
+    const livePeekContentHeight =
+      peekEl && contentEl ? measurePeekContentHeight(peekEl, contentEl) : inputs.peekContentHeight;
     const livePeekHeight =
-      headerEl || footerEl
-        ? (headerEl?.offsetHeight ?? 0) +
-            (footerEl?.offsetHeight ?? 0) +
-            inputs.peekContentHeight || DEFAULT_PEEK_HEIGHT
+      headerEl || footerEl || peekEl
+        ? (headerEl?.offsetHeight ?? 0) + (footerEl?.offsetHeight ?? 0) + livePeekContentHeight ||
+          DEFAULT_PEEK_HEIGHT
         : inputs.peekHeight;
 
     const positions: number[] = [];
@@ -678,10 +682,11 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     // own child didn't move (e.g., child skipped its cascade for a page
     // grandchild) — leaving a visible gap between this sheet and its child.
     const computeTargetY = () => {
-      const parentSnap = parseFloat(parent.style.getPropertyValue('--snap-point-height')) || 0;
+      const parentSnap =
+        Number.parseFloat(parent.style.getPropertyValue('--snap-point-height')) || 0;
       const node = descendants[0]?.nodeRef.current;
       if (!node) return parentSnap;
-      const childSnap = parseFloat(node.style.getPropertyValue('--snap-point-height')) || 0;
+      const childSnap = Number.parseFloat(node.style.getPropertyValue('--snap-point-height')) || 0;
       return Math.max(parentSnap, childSnap);
     };
 
@@ -700,9 +705,10 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       const childDrawer = form.nodeRef.current;
       const childWrapper = childDrawer?.closest<HTMLElement>('[data-vaul-detached-wrapper]');
       if (!parentWrapper || !childDrawer || !childWrapper) return;
-      const snapY = parseFloat(childDrawer.style.getPropertyValue('--snap-point-height')) || 0;
-      const childBottomGap = parseFloat(childWrapper.style.bottom) || 0;
-      const childMaxW = parseFloat(childWrapper.style.maxWidth) || window.innerWidth;
+      const snapY =
+        Number.parseFloat(childDrawer.style.getPropertyValue('--snap-point-height')) || 0;
+      const childBottomGap = Number.parseFloat(childWrapper.style.bottom) || 0;
+      const childMaxW = Number.parseFloat(childWrapper.style.maxWidth) || window.innerWidth;
       const formLeft = (window.innerWidth - childMaxW) / 2;
       const formRight = (window.innerWidth + childMaxW) / 2;
       const formBottom = window.innerHeight - childBottomGap;
@@ -728,7 +734,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       }
       const targetY = computeTargetY();
       const match = parent.style.transform.match(/translate3d\([^,]*,\s*(-?\d*\.?\d+)px/);
-      const currentY = match ? parseFloat(match[1]!) : 0;
+      const currentY = match ? Number.parseFloat(match[1]!) : 0;
       if (Math.abs(currentY - targetY) < 0.5) return;
       parent.style.transition = transition;
       parent.style.transform = `translate3d(0, ${targetY}px, 0)`;

--- a/src/TrueSheetPeek.web.tsx
+++ b/src/TrueSheetPeek.web.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useEffect, useRef, type RefObject } from 'react';
-import { View, type LayoutChangeEvent, type ViewProps } from 'react-native';
+import { createContext, type RefObject, useContext, useEffect, useRef } from 'react';
+import { type LayoutChangeEvent, View, type ViewProps } from 'react-native';
 
 /**
  * Reports the measured peek content height to the owning TrueSheet.
@@ -7,10 +7,24 @@ import { View, type LayoutChangeEvent, type ViewProps } from 'react-native';
  */
 export interface TrueSheetPeekContextValue {
   contentRef: RefObject<View | null>;
+  peekRef: RefObject<View | null>;
   setPeekContentHeight: (height: number) => void;
 }
 
 export const TrueSheetPeekContext = createContext<TrueSheetPeekContextValue | null>(null);
+
+/**
+ * Distance from the top of the content view to the bottom of the peek view,
+ * so the peek view's offset within the content (padding, views above it)
+ * counts toward the peek detent. Both rects live in the drawer's transformed
+ * subtree, so an in-flight translate cancels out of the delta.
+ * @internal
+ */
+export const measurePeekContentHeight = (
+  peekElement: HTMLElement,
+  contentElement: HTMLElement
+): number =>
+  peekElement.getBoundingClientRect().bottom - contentElement.getBoundingClientRect().top;
 
 /**
  * Wrapper component that marks its children as the sheet's peek content.
@@ -20,7 +34,11 @@ export const TrueSheetPeekContext = createContext<TrueSheetPeekContextValue | nu
  */
 export const TrueSheetPeek = ({ onLayout, ...rest }: ViewProps) => {
   const context = useContext(TrueSheetPeekContext);
-  const viewRef = useRef<View>(null);
+  const localRef = useRef<View>(null);
+
+  // Register into the sheet's peek ref so it can measure the peek live
+  // during detent geometry computation (state lags the first willPresent).
+  const viewRef = context?.peekRef ?? localRef;
 
   useEffect(() => () => context?.setPeekContentHeight(0), [context]);
 
@@ -30,12 +48,9 @@ export const TrueSheetPeek = ({ onLayout, ...rest }: ViewProps) => {
       const peekElement = viewRef.current as unknown as HTMLElement | null;
       const contentElement = context.contentRef.current as unknown as HTMLElement | null;
 
-      // Distance from the top of the content view to the bottom of the peek view,
-      // so the peek view's offset within the content (padding, views above it)
-      // counts toward the peek detent.
       const bottom =
         peekElement && contentElement
-          ? peekElement.getBoundingClientRect().bottom - contentElement.getBoundingClientRect().top
+          ? measurePeekContentHeight(peekElement, contentElement)
           : event.nativeEvent.layout.height;
 
       context.setPeekContentHeight(bottom);


### PR DESCRIPTION
## Summary

#740 deferred the first `willPresent` until the drawer is DOM-connected and live-measured the **header/footer** for `'peek'` detent geometry — but the `TrueSheetPeek` content offset still came from React state fed by RN-web `onLayout`, which dispatches a frame after mount. On autopresent (`initialDetentIndex`), a sheet whose peek includes a `TrueSheetPeek` (e.g. footer + peek content, no header) emitted `willPresent` with only the footer height — the peek content read `0`.

This measures the peek content live from the DOM in `computeDetentGeometry`, same as header/footer:

- `TrueSheetPeekContext` gains a `peekRef` the peek registers its element into.
- The rect-delta measurement (`peek bottom − content top`) is extracted into `measurePeekContentHeight()` and shared with the peek's layout handler. Both rects live in the drawer's transformed subtree, so an in-flight translate cancels out of the delta.
- The live branch condition now includes `peekEl`, covering peek-only sheets (no header/footer) that previously fell back to the state-driven `peekHeight`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Reproduced in a consumer app: autopresented sheet with `detents={['peek', 1]}`, a footer, and `TrueSheetPeek` inside scrollable content — `willPresent` emitted `position = height − footerHeight`. With this fix it emits the full peek position (footer + peek content offset). Verified the patched build in-app.
- Example MapScreen (header-only peek) still reports correct geometry.
- `yarn typecheck`, `yarn lint`, `yarn test` (44 tests) pass.

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)