### PR TITLE
feat: support auto detent with scrollables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,4 +87,6 @@ Add entry to `Unreleased` section in `CHANGELOG.md` for user-facing changes:
 
 Format: `- **Platform**: Description. ([#123](https://github.com/lodev09/react-native-true-sheet/pull/123) by [@username](https://github.com/username))`
 
+One entry per PR — summarize the PR's user-facing change in a single entry under its primary section.
+
 Sort entries by platform: **iOS** first, then **Android**, then **Web**, then cross-platform or unscoped entries last.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@
 
 ### 💥 Breaking changes
 
-- Requires React Native 0.82+. ([#735](https://github.com/lodev09/react-native-true-sheet/pull/735) by [@lodev09](https://github.com/lodev09))
-- Synchronous per-detent container layout — the container is sized to the sheet's visible height per detent and tracks it in realtime while dragging, on all platforms. Previously it was sized to the screen height / largest detent; layouts relying on that may shift. ([#735](https://github.com/lodev09/react-native-true-sheet/pull/735) by [@lodev09](https://github.com/lodev09))
-- Removed the `scrollable` prop — scrollables are auto-detected. `ScrollView`/`FlatList` work plugged in directly, like a regular view; insets, keyboard handling, and nested scrolling are wired automatically. ([#735](https://github.com/lodev09/react-native-true-sheet/pull/735) by [@lodev09](https://github.com/lodev09))
+- Synchronous per-detent container layout — the container is sized to the sheet's visible height per detent and tracks it in realtime while dragging, on all platforms (previously sized to the screen height / largest detent). The `scrollable` prop is removed — scrollables are auto-detected and work plugged in directly. Requires React Native 0.82+. ([#735](https://github.com/lodev09/react-native-true-sheet/pull/735) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 - The `auto` detent now works with plugged scrollables — the sheet sizes to the scrollable's content height and resizes as content grows or shrinks. ([#743](https://github.com/lodev09/react-native-true-sheet/pull/743) by [@lodev09](https://github.com/lodev09))
 
-### 🐛 Bug fixes
-
-- **iOS**: Content size changes no longer rebuild the sheet's detents — auto/peek detents resolve lazily and are invalidated in place, fixing visible glitches on the sheet behind during rapid present/dismiss and presentations snapping without animation. ([#743](https://github.com/lodev09/react-native-true-sheet/pull/743) by [@lodev09](https://github.com/lodev09))
-
 ### 💥 Breaking changes
 
 - Requires React Native 0.82+. ([#735](https://github.com/lodev09/react-native-true-sheet/pull/735) by [@lodev09](https://github.com/lodev09))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### 🎉 New features
+
+- The `auto` detent now works with plugged scrollables — the sheet sizes to the scrollable's content height and resizes as content grows or shrinks. ([#743](https://github.com/lodev09/react-native-true-sheet/pull/743) by [@lodev09](https://github.com/lodev09))
+
+### 🐛 Bug fixes
+
+- **iOS**: Content size changes no longer rebuild the sheet's detents — auto/peek detents resolve lazily and are invalidated in place, fixing visible glitches on the sheet behind during rapid present/dismiss and presentations snapping without animation. ([#743](https://github.com/lodev09/react-native-true-sheet/pull/743) by [@lodev09](https://github.com/lodev09))
+
 ### 💥 Breaking changes
 
 - Requires React Native 0.82+. ([#735](https://github.com/lodev09/react-native-true-sheet/pull/735) by [@lodev09](https://github.com/lodev09))

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -9,7 +9,9 @@ import android.widget.EditText
 import android.widget.ScrollView
 import androidx.core.widget.NestedScrollView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.uimanager.PixelUtil.dpToPx
+import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.lodev09.truesheet.core.TrueSheetKeyboardObserver
@@ -36,13 +38,42 @@ interface TrueSheetContentViewDelegate {
 @SuppressLint("ViewConstructor")
 class TrueSheetContentView(private val reactContext: ThemedReactContext) : ReactViewGroup(reactContext) {
   var delegate: TrueSheetContentViewDelegate? = null
+  var stateWrapper: StateWrapper? = null
 
   private var lastWidth = 0
   private var lastHeight = 0
 
   private var pinnedScrollView: ViewGroup? = null
+  private var observedScrollChild: View? = null
   private var originalScrollViewPaddingBottom: Int = 0
   private var bottomInset: Int = 0
+  private var scrollableBounded = false
+  private var isReportPending = false
+
+  // Content growth is invisible to layout once the viewport is bounded, so track
+  // the scroll content size directly to keep the auto detent height in sync.
+  private val scrollChildLayoutListener =
+    View.OnLayoutChangeListener { _, _, top, _, bottom, _, oldTop, _, oldBottom ->
+      if (bottom - top != oldBottom - oldTop) {
+        reportSizeIfChanged()
+      }
+    }
+
+  /**
+   * Content height with the pinned ScrollView's viewport replaced by its content
+   * size — the height the content wants regardless of container bounds.
+   * Falls back to the view height when no ScrollView is pinned.
+   */
+  val naturalHeight: Int
+    get() {
+      var naturalHeight = height
+      pinnedScrollView?.let { scrollView ->
+        scrollView.getChildAt(0)?.let { child ->
+          naturalHeight += child.height - scrollView.height
+        }
+      }
+      return maxOf(0, naturalHeight)
+    }
 
   private var keyboardScrollOffset: Float = 0f
   private var keyboardObserver: TrueSheetKeyboardObserver? = null
@@ -74,11 +105,49 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
 
   override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
     super.onSizeChanged(w, h, oldw, oldh)
+    reportSizeIfChanged()
+  }
 
-    if (w != lastWidth || h != lastHeight) {
-      lastWidth = w
-      lastHeight = h
-      delegate?.contentViewDidChangeSize(w, h)
+  private fun reportSizeIfChanged() {
+    // naturalHeight mixes sizes from different views; mid-layout they're
+    // momentarily inconsistent (parent resizes before its children), which
+    // feeds back into the auto detent and oscillates. Coalesce to the next
+    // frame so sizes are settled before measuring.
+    if (pinnedScrollView != null) {
+      if (isReportPending) return
+      isReportPending = true
+
+      post {
+        isReportPending = false
+        reportSizeNow()
+      }
+      return
+    }
+
+    reportSizeNow()
+  }
+
+  private fun reportSizeNow() {
+    val newHeight = naturalHeight
+    if (width != lastWidth || newHeight != lastHeight) {
+      lastWidth = width
+      lastHeight = newHeight
+      delegate?.contentViewDidChangeSize(width, newHeight)
+    }
+  }
+
+  /**
+   * Tells the shadow node to fill the container (flexGrow/flexShrink) so the
+   * pinned ScrollView's viewport is bounded to the visible space.
+   */
+  private fun setScrollableBounded(bounded: Boolean) {
+    if (scrollableBounded == bounded) return
+    scrollableBounded = bounded
+
+    stateWrapper?.let {
+      val newState = WritableNativeMap()
+      newState.putBoolean("scrollableBounded", bounded)
+      it.updateState(newState)
     }
   }
 
@@ -108,6 +177,13 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
           delegate?.contentViewDidScroll()
         }
       }
+
+      scrollView.getChildAt(0)?.let { child ->
+        observedScrollChild = child
+        child.addOnLayoutChangeListener(scrollChildLayoutListener)
+      }
+      setScrollableBounded(true)
+      reportSizeIfChanged()
     }
 
     this.bottomInset = bottomInset
@@ -137,9 +213,13 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     pinnedScrollView?.isNestedScrollingEnabled = false
     (pinnedScrollView?.parent as? SwipeRefreshLayout)?.isNestedScrollingEnabled = true
     setScrollViewPaddingBottom(originalScrollViewPaddingBottom)
+    observedScrollChild?.removeOnLayoutChangeListener(scrollChildLayoutListener)
+    observedScrollChild = null
+    setScrollableBounded(false)
     pinnedScrollView = null
     originalScrollViewPaddingBottom = 0
     bottomInset = 0
+    reportSizeIfChanged()
   }
 
   fun findScrollView(): ViewGroup? {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentViewManager.kt
@@ -2,6 +2,8 @@ package com.lodev09.truesheet
 
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.PointerEvents
+import com.facebook.react.uimanager.ReactStylesDiffMap
+import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
@@ -16,6 +18,11 @@ class TrueSheetContentViewManager : ViewGroupManager<TrueSheetContentView>() {
   override fun getName(): String = REACT_CLASS
 
   override fun createViewInstance(reactContext: ThemedReactContext): TrueSheetContentView = TrueSheetContentView(reactContext)
+
+  override fun updateState(view: TrueSheetContentView, props: ReactStylesDiffMap?, stateWrapper: StateWrapper?): Any? {
+    view.stateWrapper = stateWrapper
+    return null
+  }
 
   @ReactProp(name = "pointerEvents")
   fun setPointerEvents(view: TrueSheetContentView, pointerEventsStr: String?) {

--- a/android/src/main/jni/TrueSheetSpec.h
+++ b/android/src/main/jni/TrueSheetSpec.h
@@ -3,6 +3,7 @@
 #include <ReactCommon/JavaTurboModule.h>
 #include <ReactCommon/TurboModule.h>
 #include <jsi/jsi.h>
+#include <react/renderer/components/TrueSheetSpec/TrueSheetContentViewComponentDescriptor.h>
 #include <react/renderer/components/TrueSheetSpec/TrueSheetViewComponentDescriptor.h>
 
 namespace facebook {

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewComponentDescriptor.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.h>
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+namespace facebook::react {
+
+/*
+ * Descriptor for <TrueSheetContentView> component.
+ */
+class TrueSheetContentViewComponentDescriptor final
+    : public ConcreteComponentDescriptor<TrueSheetContentViewShadowNode> {
+  using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
+
+  void adopt(ShadowNode &shadowNode) const override {
+    auto &concreteShadowNode =
+        static_cast<TrueSheetContentViewShadowNode &>(shadowNode);
+    concreteShadowNode.adjustLayoutWithState();
+
+    ConcreteComponentDescriptor::adopt(shadowNode);
+  }
+};
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.cpp
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.cpp
@@ -1,0 +1,42 @@
+#include "TrueSheetContentViewShadowNode.h"
+
+#include <react/renderer/components/view/conversions.h>
+
+namespace facebook::react {
+
+using namespace yoga;
+
+extern const char TrueSheetContentViewComponentName[] = "TrueSheetContentView";
+
+void TrueSheetContentViewShadowNode::adjustLayoutWithState() {
+  ensureUnsealed();
+
+  auto state = std::static_pointer_cast<
+      const TrueSheetContentViewShadowNode::ConcreteState>(getState());
+  auto stateData = state->getData();
+
+  auto &props = getConcreteProps();
+
+  // When a ScrollView is pinned, fill the container so descendant flex layouts
+  // (flex:1 wrappers, the ScrollView itself) resolve against a definite height
+  // and the viewport is bounded. The natural height for auto detents is
+  // measured from the ScrollView's content size instead (see ContentView's
+  // naturalHeight on each platform).
+  auto flexGrow = stateData.scrollableBounded
+      ? FloatOptional{1.0f}
+      : props.yogaStyle.flexGrow();
+  auto flexShrink = stateData.scrollableBounded
+      ? FloatOptional{1.0f}
+      : props.yogaStyle.flexShrink();
+
+  if (yogaNode_.style().flexGrow() != flexGrow ||
+      yogaNode_.style().flexShrink() != flexShrink) {
+    yoga::Style adjustedStyle = props.yogaStyle;
+    adjustedStyle.setFlexGrow(flexGrow);
+    adjustedStyle.setFlexShrink(flexShrink);
+    yogaNode_.setStyle(adjustedStyle);
+    yogaNode_.setDirty(true);
+  }
+}
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include <react/renderer/components/TrueSheetSpec/EventEmitters.h>
+#include <react/renderer/components/TrueSheetSpec/Props.h>
+#include <react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+
+namespace facebook::react {
+
+JSI_EXPORT extern const char TrueSheetContentViewComponentName[];
+
+/*
+ * `ShadowNode` for <TrueSheetContentView> component.
+ */
+class JSI_EXPORT TrueSheetContentViewShadowNode final
+    : public ConcreteViewShadowNode<
+          TrueSheetContentViewComponentName,
+          TrueSheetContentViewProps,
+          TrueSheetContentViewEventEmitter,
+          TrueSheetContentViewState> {
+  using ConcreteViewShadowNode::ConcreteViewShadowNode;
+
+ public:
+  void adjustLayoutWithState();
+};
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.cpp
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.cpp
@@ -1,0 +1,11 @@
+#include "TrueSheetContentViewState.h"
+
+namespace facebook::react {
+
+#ifdef ANDROID
+folly::dynamic TrueSheetContentViewState::getDynamic() const {
+  return folly::dynamic::object("scrollableBounded", scrollableBounded);
+}
+#endif
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#ifdef ANDROID
+#include <folly/dynamic.h>
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include <react/renderer/mapbuffer/MapBufferBuilder.h>
+#endif
+
+namespace facebook::react {
+
+/*
+ * State for <TrueSheetContentView> component.
+ * Set from native when a ScrollView is pinned so the shadow node bounds the
+ * content to the container via flexShrink (see TrueSheetContentViewShadowNode).
+ */
+class TrueSheetContentViewState final {
+ public:
+  TrueSheetContentViewState() = default;
+
+#ifdef ANDROID
+  TrueSheetContentViewState(
+      TrueSheetContentViewState const &previousState,
+      folly::dynamic data)
+      : scrollableBounded(data["scrollableBounded"].getBool()) {}
+#endif
+
+  bool scrollableBounded{false};
+
+#ifdef ANDROID
+  folly::dynamic getDynamic() const;
+  MapBuffer getMapBuffer() const {
+    return MapBufferBuilder::EMPTY();
+  }
+#endif
+};
+
+} // namespace facebook::react

--- a/example/bare/ios/Podfile.lock
+++ b/example/bare/ios/Podfile.lock
@@ -2049,7 +2049,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNTrueSheet (3.11.6):
+  - RNTrueSheet (3.11.9):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2481,7 +2481,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 2ff61eac036eaf89f6818bf4ed9c39771a17d134
   RNReanimated: f735b1747a7a93bda7ca102c6d37a3cf54b6d5e8
   RNScreens: 991cc417cd396602a6cf59a42139e5a9d91462a9
-  RNTrueSheet: 2fe0b0b375aa0a8e9ec19258503a73cc0da76cfd
+  RNTrueSheet: fa8b104afa2fa9eca2338f879880a147cae322f9
   RNWorklets: 4931990f73bc8f347586918b2e13f11dfadf3b75
   Yoga: 77dfa8673de2874e1855002ae59c68b8be9b007b
 

--- a/example/shared/src/components/sheets/FlatListSheet.tsx
+++ b/example/shared/src/components/sheets/FlatListSheet.tsx
@@ -17,7 +17,7 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
   return (
     <TrueSheet
       ref={ref}
-      detents={[0.5, 1]}
+      detents={['auto', 1]}
       backgroundBlur="dark"
       backgroundColor={DARK}
       scrollableOptions={{
@@ -40,7 +40,7 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
       <View style={styles.wrapper}>
         <FlatList
           ref={scrollRef}
-          data={times(10, (i) => i)}
+          data={times(2, (i) => i)}
           contentContainerStyle={styles.content}
           indicatorStyle="black"
           ItemSeparatorComponent={Spacer}

--- a/example/shared/src/components/sheets/FlatListSheet.tsx
+++ b/example/shared/src/components/sheets/FlatListSheet.tsx
@@ -8,13 +8,14 @@ import { Spacer } from '../Spacer';
 import { Header } from '../Header';
 import { Footer } from '../Footer';
 import { Button } from '../Button';
+import { ButtonGroup } from '../ButtonGroup';
 
 interface FlatListSheetProps extends TrueSheetProps {}
 
 export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, ref) => {
   const testRef = useRef<TrueSheet>(null);
   const scrollRef = useRef<FlatList>(null);
-  const [itemCount, setItemCount] = useState(10);
+  const [itemCount, setItemCount] = useState(3);
 
   return (
     <TrueSheet
@@ -51,7 +52,13 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
           ListFooterComponent={
             <>
               <Spacer />
-              <Button text="Add Item" onPress={() => setItemCount((count) => count + 1)} />
+              <ButtonGroup>
+                <Button text="Add Item" onPress={() => setItemCount((count) => count + 1)} />
+                <Button
+                  text="Remove Item"
+                  onPress={() => setItemCount((count) => Math.max(0, count - 1))}
+                />
+              </ButtonGroup>
             </>
           }
         />

--- a/example/shared/src/components/sheets/FlatListSheet.tsx
+++ b/example/shared/src/components/sheets/FlatListSheet.tsx
@@ -20,7 +20,7 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
   return (
     <TrueSheet
       ref={ref}
-      detents={['auto', 1]}
+      detents={['auto']}
       backgroundBlur="dark"
       backgroundColor={DARK}
       scrollableOptions={{

--- a/example/shared/src/components/sheets/FlatListSheet.tsx
+++ b/example/shared/src/components/sheets/FlatListSheet.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useRef } from 'react';
+import { forwardRef, useRef, useState } from 'react';
 import { StyleSheet, FlatList, View, Platform } from 'react-native';
 import { TrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
 
@@ -7,12 +7,14 @@ import { DemoContent } from '../DemoContent';
 import { Spacer } from '../Spacer';
 import { Header } from '../Header';
 import { Footer } from '../Footer';
+import { Button } from '../Button';
 
 interface FlatListSheetProps extends TrueSheetProps {}
 
 export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, ref) => {
   const testRef = useRef<TrueSheet>(null);
   const scrollRef = useRef<FlatList>(null);
+  const [itemCount, setItemCount] = useState(2);
 
   return (
     <TrueSheet
@@ -40,12 +42,18 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
       <View style={styles.wrapper}>
         <FlatList
           ref={scrollRef}
-          data={times(2, (i) => i)}
+          data={times(itemCount, (i) => i)}
           contentContainerStyle={styles.content}
           indicatorStyle="black"
           ItemSeparatorComponent={Spacer}
           scrollIndicatorInsets={{ bottom: FOOTER_HEIGHT }}
           renderItem={({ item }) => <DemoContent color={DARK_GRAY} text={`Item #${item}`} />}
+          ListFooterComponent={
+            <>
+              <Spacer />
+              <Button text="Add Item" onPress={() => setItemCount((count) => count + 1)} />
+            </>
+          }
         />
       </View>
       <TrueSheet detents={[0.3]} ref={testRef}>

--- a/example/shared/src/components/sheets/FlatListSheet.tsx
+++ b/example/shared/src/components/sheets/FlatListSheet.tsx
@@ -14,7 +14,7 @@ interface FlatListSheetProps extends TrueSheetProps {}
 export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, ref) => {
   const testRef = useRef<TrueSheet>(null);
   const scrollRef = useRef<FlatList>(null);
-  const [itemCount, setItemCount] = useState(2);
+  const [itemCount, setItemCount] = useState(10);
 
   return (
     <TrueSheet

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -107,7 +107,7 @@ using namespace facebook::react;
 #pragma mark - Layout
 
 - (CGFloat)contentHeight {
-  return _contentView ? _contentView.frame.size.height : 0;
+  return _contentView ? _contentView.naturalHeight : 0;
 }
 
 - (CGFloat)headerHeight {

--- a/ios/TrueSheetContentView.h
+++ b/ios/TrueSheetContentView.h
@@ -33,6 +33,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) CGFloat keyboardScrollOffset;
 @property (nonatomic, weak, nullable) TrueSheetKeyboardObserver *keyboardObserver;
 
+/**
+ * Content height with the pinned ScrollView's viewport replaced by its content
+ * size — the height the content wants regardless of container bounds.
+ * Falls back to the frame height when no ScrollView is pinned.
+ */
+@property (nonatomic, readonly) CGFloat naturalHeight;
+
 - (RCTScrollViewComponentView *_Nullable)findScrollView;
 
 /**

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -10,10 +10,11 @@
 
 #import "TrueSheetContentView.h"
 #import <React/RCTScrollViewComponentView.h>
-#import <react/renderer/components/TrueSheetSpec/ComponentDescriptors.h>
 #import <react/renderer/components/TrueSheetSpec/EventEmitters.h>
 #import <react/renderer/components/TrueSheetSpec/Props.h>
 #import <react/renderer/components/TrueSheetSpec/RCTComponentViewHelpers.h>
+#import <react/renderer/components/TrueSheetSpec/TrueSheetContentViewComponentDescriptor.h>
+#import <react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.h>
 #import "TrueSheetContainerView.h"
 #import "TrueSheetView.h"
 #import "TrueSheetViewController.h"
@@ -22,12 +23,18 @@
 
 using namespace facebook::react;
 
+static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
+
 @implementation TrueSheetContentView {
+  TrueSheetContentViewShadowNode::ConcreteState::Shared _state;
   RCTScrollViewComponentView *_pinnedScrollView;
+  UIScrollView *_observedScrollView;
   CGSize _lastSize;
   CGFloat _bottomInset;
   CGFloat _originalIndicatorBottomInset;
   BOOL _observingTextChanges;
+  BOOL _scrollableBounded;
+  BOOL _isReportPending;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider {
@@ -44,6 +51,26 @@ using namespace facebook::react;
 
 - (void)dealloc {
   [self stopObservingTextChanges];
+  [self unobserveScrollViewContentSize];
+}
+
+- (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState {
+  _state = std::static_pointer_cast<TrueSheetContentViewShadowNode::ConcreteState const>(state);
+}
+
+// Tells the shadow node to fill the container (flexGrow/flexShrink) so the
+// pinned ScrollView's viewport is bounded to the visible space.
+- (void)setScrollableBounded:(BOOL)bounded {
+  if (_scrollableBounded == bounded) {
+    return;
+  }
+  _scrollableBounded = bounded;
+
+  if (_state) {
+    TrueSheetContentViewState newState;
+    newState.scrollableBounded = bounded;
+    _state->updateState(std::move(newState));
+  }
 }
 
 #pragma mark - Text Change Observing
@@ -70,15 +97,52 @@ using namespace facebook::react;
 
 #pragma mark - Layout
 
-- (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
-           oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics {
-  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+- (CGFloat)naturalHeight {
+  CGFloat height = self.frame.size.height;
+  if (_pinnedScrollView) {
+    height += _pinnedScrollView.scrollView.contentSize.height - _pinnedScrollView.frame.size.height;
+  }
+  return MAX(0, height);
+}
 
-  CGSize newSize = CGSizeMake(layoutMetrics.frame.size.width, layoutMetrics.frame.size.height);
+- (void)reportSizeIfChanged {
+  // naturalHeight mixes frames from different views; mid-transaction they're
+  // momentarily inconsistent (parent updates before the ScrollView), which
+  // feeds back into the auto detent and oscillates. Coalesce to the next
+  // main-queue tick so frames are settled before measuring.
+  if (_pinnedScrollView) {
+    if (_isReportPending) {
+      return;
+    }
+    _isReportPending = YES;
+
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      __typeof(self) strongSelf = weakSelf;
+      if (!strongSelf) {
+        return;
+      }
+      strongSelf->_isReportPending = NO;
+      [strongSelf reportSizeNow];
+    });
+    return;
+  }
+
+  [self reportSizeNow];
+}
+
+- (void)reportSizeNow {
+  CGSize newSize = CGSizeMake(self.frame.size.width, self.naturalHeight);
   if (!CGSizeEqualToSize(newSize, _lastSize)) {
     _lastSize = newSize;
     [self.delegate contentViewDidChangeSize:newSize];
   }
+}
+
+- (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics {
+  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+  [self reportSizeIfChanged];
 }
 
 #pragma mark - Child Mounting
@@ -118,9 +182,12 @@ using namespace facebook::react;
   if (_pinnedScrollView) {
     [self setScrollViewContentInset:0 indicatorInset:_originalIndicatorBottomInset];
   }
+  [self unobserveScrollViewContentSize];
+  [self setScrollableBounded:NO];
   _pinnedScrollView = nil;
   _bottomInset = 0;
   _originalIndicatorBottomInset = 0;
+  [self reportSizeIfChanged];
 }
 
 - (void)setupScrollableWithBottomInset:(CGFloat)bottomInset {
@@ -143,6 +210,10 @@ using namespace facebook::react;
   if (!_pinnedScrollView) {
     _originalIndicatorBottomInset = scrollView.scrollView.verticalScrollIndicatorInsets.bottom;
     _pinnedScrollView = scrollView;
+
+    [self observeScrollViewContentSize];
+    [self setScrollableBounded:YES];
+    [self reportSizeIfChanged];
   }
 
   _bottomInset = bottomInset;
@@ -154,6 +225,39 @@ using namespace facebook::react;
   if (keyboardHeight > 0) {
     [self setScrollViewContentInset:keyboardHeight indicatorInset:_originalIndicatorBottomInset + keyboardHeight];
   }
+}
+
+// Content growth is invisible to layout once the viewport is bounded, so track
+// the scroll content size directly to keep the auto detent height in sync.
+- (void)observeScrollViewContentSize {
+  UIScrollView *scrollView = _pinnedScrollView.scrollView;
+  if (_observedScrollView == scrollView) {
+    return;
+  }
+  [self unobserveScrollViewContentSize];
+  _observedScrollView = scrollView;
+  [scrollView addObserver:self
+               forKeyPath:@"contentSize"
+                  options:NSKeyValueObservingOptionNew
+                  context:TrueSheetContentSizeContext];
+}
+
+- (void)unobserveScrollViewContentSize {
+  if (_observedScrollView) {
+    [_observedScrollView removeObserver:self forKeyPath:@"contentSize" context:TrueSheetContentSizeContext];
+    _observedScrollView = nil;
+  }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context {
+  if (context == TrueSheetContentSizeContext) {
+    [self reportSizeIfChanged];
+    return;
+  }
+  [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
 }
 
 - (RCTScrollViewComponentView *)findScrollView {
@@ -330,6 +434,9 @@ using namespace facebook::react;
   [super prepareForRecycle];
   [self stopObservingTextChanges];
   [self clearScrollable];
+  _state.reset();
+  _scrollableBounded = NO;
+  _lastSize = CGSizeZero;
 }
 
 @end

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -563,6 +563,9 @@ using namespace facebook::react;
 
   if (_controller.isBeingPresented) {
     _pendingSizeChange = YES;
+    // The auto detent resolves contentHeight lazily — retarget the in-flight
+    // presentation now instead of visibly resizing after didPresent.
+    [_controller invalidateDetents];
     return;
   }
 
@@ -571,6 +574,11 @@ using namespace facebook::react;
   dispatch_async(dispatch_get_main_queue(), ^{
     self->_isSheetUpdatePending = NO;
     if (!self->_containerView)
+      return;
+
+    // Rebuilding detents mid-dismiss perturbs the presentation stack,
+    // visibly glitching the sheet behind. The sheet is going away — drop it.
+    if (self->_controller.isBeingDismissed)
       return;
 
     // Refresh here (not just on peek size events) since the peek's offset

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -19,6 +19,7 @@
 #import "events/TrueSheetFocusEvents.h"
 #import "events/TrueSheetLifecycleEvents.h"
 #import "events/TrueSheetStateEvents.h"
+#import "utils/WindowUtil.h"
 
 #import <react/renderer/components/TrueSheetSpec/EventEmitters.h>
 #import <react/renderer/components/TrueSheetSpec/Props.h>
@@ -275,8 +276,15 @@ using namespace facebook::react;
   _state = std::static_pointer_cast<TrueSheetViewShadowNode::ConcreteState const>(state);
 
   if (_controller) {
-    // Initialize with _controller size to set initial width
-    [self viewControllerDidChangeSize:_controller.view.frame.size];
+    CGSize size = _controller.view.frame.size;
+    if (size.width < 1 || size.height < 1) {
+      // Pre-present the controller has no layout yet. Seed with screen
+      // dimensions so content (e.g. a FlatList viewport) can lay out and
+      // measure before the sheet presents (parity with Android).
+      UIWindow *window = [WindowUtil keyWindow];
+      size = window ? window.bounds.size : UIScreen.mainScreen.bounds.size;
+    }
+    [self viewControllerDidChangeSize:size];
   }
 }
 

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -458,10 +458,23 @@ using namespace facebook::react;
   [_controller setupAnchorViewInView:presentingViewController.view];
   [_controller setupSheetSizing];
   [_controller setupSheetProps];
+
+  // Pin before measuring so a first-time pin doesn't shift sizes mid-animation.
+  [self setupScrollable];
+
+  // Measure synchronously so the presentation starts at the right height —
+  // async size reports would otherwise land mid-animation and force a
+  // detent retarget that snaps the presentation stack.
+  if (_containerView) {
+    _controller.contentHeight = @([_containerView contentHeight]);
+    _controller.headerHeight = @([_containerView headerHeight]);
+    _controller.footerHeight = @([_containerView footerHeight]);
+    _controller.peekContentHeight = @([_containerView peekContentHeight]);
+  }
+  _pendingSizeChange = NO;
+
   [_controller setupSheetDetents];
   [_controller setupActiveDetentWithIndex:index];
-
-  [self setupScrollable];
 
   [_screensEventObserver capturePresenterScreenFromView:self];
   [_screensEventObserver startObservingWithState:_state.get()->getData()];
@@ -558,27 +571,28 @@ using namespace facebook::react;
  * Debounced sheet update to handle rapid content/header size changes.
  */
 - (void)setupSheetDetentsForSizeChange {
-  if (_isSheetUpdatePending)
-    return;
-
+  // Retargeting the in-flight presentation makes UIKit snap the whole stack
+  // (including the sheet behind) instead of animating. Defer to didPresent —
+  // presentAtIndex measured synchronously, so this is usually a no-op.
   if (_controller.isBeingPresented) {
     _pendingSizeChange = YES;
-    // The auto detent resolves contentHeight lazily — retarget the in-flight
-    // presentation now instead of visibly resizing after didPresent.
-    [_controller invalidateDetents];
     return;
   }
+
+  // Not presented: presentAtIndex measures at present time.
+  // Dismissing: the sheet is going away — touching detents perturbs the
+  // presentation stack, visibly glitching the sheet behind.
+  if (!_controller.isPresented || _controller.isBeingDismissed)
+    return;
+
+  if (_isSheetUpdatePending)
+    return;
 
   _isSheetUpdatePending = YES;
 
   dispatch_async(dispatch_get_main_queue(), ^{
     self->_isSheetUpdatePending = NO;
-    if (!self->_containerView)
-      return;
-
-    // Rebuilding detents mid-dismiss perturbs the presentation stack,
-    // visibly glitching the sheet behind. The sheet is going away — drop it.
-    if (self->_controller.isBeingDismissed)
+    if (!self->_containerView || self->_controller.isBeingDismissed)
       return;
 
     // Refresh here (not just on peek size events) since the peek's offset

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -91,7 +91,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setupSheetDetents;
 - (void)setupSheetDetentsForSizeChange;
 - (void)setupSheetDetentsForDetentsChange;
-- (void)invalidateDetents;
 - (void)setupDraggable;
 - (void)setupAnchorViewInView:(UIView *)parentView;
 

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -91,6 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setupSheetDetents;
 - (void)setupSheetDetentsForSizeChange;
 - (void)setupSheetDetentsForDetentsChange;
+- (void)invalidateDetents;
 - (void)setupDraggable;
 - (void)setupAnchorViewInView:(UIView *)parentView;
 

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -56,6 +56,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   TrueSheetPositionState _lastEmittedPositionState;
   CGSize _lastReportedSize;
   CGFloat _autoDetentHeight;
+  CGFloat _peekDetentHeight;
   NSInteger _pendingDetentIndex;
   BOOL _pendingContentSizeChange;
   BOOL _pendingDetentsChange;
@@ -842,23 +843,36 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
 #pragma mark - Sheet Configuration
 
+/**
+ * Applies a content/header/footer/peek size change to the already-built
+ * detents. Auto and peek detents resolve lazily from snapshots, so this only
+ * refreshes the snapshots and invalidates — never reassigns `sheet.detents`,
+ * which would force UIKit to re-layout the whole presentation stack (visibly
+ * perturbing a sheet behind this one).
+ */
 - (void)setupSheetDetentsForSizeChange {
-  [self.sheet animateChanges:^{
-    _pendingContentSizeChange = YES;
-    [self setupSheetDetents];
-  }];
+  if (@available(iOS 16.0, *)) {
+    CGFloat autoHeight = [self.contentHeight floatValue] + [self.headerHeight floatValue];
+    CGFloat peekHeight = [_detentCalculator peekHeight];
+
+    if (fabs(autoHeight - _autoDetentHeight) < 0.5 && fabs(peekHeight - _peekDetentHeight) < 0.5) {
+      return;
+    }
+
+    _autoDetentHeight = autoHeight;
+    _peekDetentHeight = peekHeight;
+
+    [self.sheet animateChanges:^{
+      self->_pendingContentSizeChange = YES;
+      [self.sheet invalidateDetents];
+    }];
+  }
+  // iOS 15: detents are fixed medium/large — size changes can't affect them.
 }
 
 - (void)setupSheetDetentsForDetentsChange {
   _pendingDetentsChange = YES;
   [self setupSheetDetents];
-}
-
-- (void)invalidateDetents {
-  _autoDetentHeight = [self.contentHeight floatValue] + [self.headerHeight floatValue];
-  if (@available(iOS 16.0, *)) {
-    [self.sheet invalidateDetents];
-  }
 }
 
 - (void)setupSheetDetents {
@@ -872,6 +886,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   [_detentCalculator clearResolvedHeights];
 
   _autoDetentHeight = [self.contentHeight floatValue] + [self.headerHeight floatValue];
+  _peekDetentHeight = [_detentCalculator peekHeight];
 
   for (NSInteger index = 0; index < self.detents.count; index++) {
     id detent = self.detents[index];
@@ -909,12 +924,12 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
   CGFloat value = [detent doubleValue];
 
+  // Auto/peek resolve from height snapshots — refreshed only in
+  // setupSheetDetents and setupSheetDetentsForSizeChange — so size changes are
+  // picked up on invalidation, while UIKit's spontaneous re-resolutions (e.g.
+  // while a child sheet dismisses) read a stable value.
   if (value == -1) {
     if (@available(iOS 16.0, *)) {
-      // Resolve from _autoDetentHeight — refreshed only in setupSheetDetents
-      // and invalidateDetents — so content measured mid-presentation is picked
-      // up on invalidation, while UIKit's spontaneous re-resolutions (e.g.
-      // while a child sheet dismisses) read a stable value.
       return [self customDetentWithIdentifier:@"custom-auto"
                                       atIndex:index
                                   heightBlock:^CGFloat {
@@ -927,7 +942,11 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
   if (value == -2) {
     if (@available(iOS 16.0, *)) {
-      return [self customDetentWithIdentifier:@"custom-peek" height:[_detentCalculator peekHeight] atIndex:index];
+      return [self customDetentWithIdentifier:@"custom-peek"
+                                      atIndex:index
+                                  heightBlock:^CGFloat {
+                                    return self->_peekDetentHeight;
+                                  }];
     } else {
       return [UISheetPresentationControllerDetent mediumDetent];
     }

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -55,6 +55,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 @implementation TrueSheetViewController {
   TrueSheetPositionState _lastEmittedPositionState;
   CGSize _lastReportedSize;
+  CGFloat _autoDetentHeight;
   NSInteger _pendingDetentIndex;
   BOOL _pendingContentSizeChange;
   BOOL _pendingDetentsChange;
@@ -853,6 +854,13 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   [self setupSheetDetents];
 }
 
+- (void)invalidateDetents {
+  _autoDetentHeight = [self.contentHeight floatValue] + [self.headerHeight floatValue];
+  if (@available(iOS 16.0, *)) {
+    [self.sheet invalidateDetents];
+  }
+}
+
 - (void)setupSheetDetents {
   UISheetPresentationController *sheet = self.sheet;
   if (!sheet) {
@@ -863,13 +871,11 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   NSMutableArray<UISheetPresentationControllerDetent *> *detents = [NSMutableArray array];
   [_detentCalculator clearResolvedHeights];
 
-  CGFloat autoHeight = [self.contentHeight floatValue] + [self.headerHeight floatValue];
+  _autoDetentHeight = [self.contentHeight floatValue] + [self.headerHeight floatValue];
 
   for (NSInteger index = 0; index < self.detents.count; index++) {
     id detent = self.detents[index];
-    UISheetPresentationControllerDetent *sheetDetent = [self detentForValue:detent
-                                                             withAutoHeight:autoHeight
-                                                                    atIndex:index];
+    UISheetPresentationControllerDetent *sheetDetent = [self detentForValue:detent atIndex:index];
     [detents addObject:sheetDetent];
   }
 
@@ -896,9 +902,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   }
 }
 
-- (UISheetPresentationControllerDetent *)detentForValue:(id)detent
-                                         withAutoHeight:(CGFloat)autoHeight
-                                                atIndex:(NSInteger)index {
+- (UISheetPresentationControllerDetent *)detentForValue:(id)detent atIndex:(NSInteger)index {
   if (![detent isKindOfClass:[NSNumber class]]) {
     return [UISheetPresentationControllerDetent mediumDetent];
   }
@@ -907,7 +911,15 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
   if (value == -1) {
     if (@available(iOS 16.0, *)) {
-      return [self customDetentWithIdentifier:@"custom-auto" height:autoHeight atIndex:index];
+      // Resolve from _autoDetentHeight — refreshed only in setupSheetDetents
+      // and invalidateDetents — so content measured mid-presentation is picked
+      // up on invalidation, while UIKit's spontaneous re-resolutions (e.g.
+      // while a child sheet dismisses) read a stable value.
+      return [self customDetentWithIdentifier:@"custom-auto"
+                                      atIndex:index
+                                  heightBlock:^CGFloat {
+                                    return self->_autoDetentHeight;
+                                  }];
     } else {
       return [UISheetPresentationControllerDetent mediumDetent];
     }
@@ -940,13 +952,25 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 - (UISheetPresentationControllerDetent *)customDetentWithIdentifier:(NSString *)identifier
                                                              height:(CGFloat)height
                                                             atIndex:(NSInteger)index API_AVAILABLE(ios(16.0)) {
-  CGFloat bottomAdjustment = [self detentBottomAdjustmentForHeight:height];
+  return [self customDetentWithIdentifier:identifier
+                                  atIndex:index
+                              heightBlock:^CGFloat {
+                                return height;
+                              }];
+}
+
+- (UISheetPresentationControllerDetent *)customDetentWithIdentifier:(NSString *)identifier
+                                                            atIndex:(NSInteger)index
+                                                        heightBlock:(CGFloat (^)(void))heightBlock
+  API_AVAILABLE(ios(16.0)) {
   return [UISheetPresentationControllerDetent
     customDetentWithIdentifier:identifier
                       resolver:^CGFloat(id<UISheetPresentationControllerDetentResolutionContext> context) {
                         CGFloat maxDetentValue = context.maximumDetentValue;
                         self->_detentCalculator.maxDetentHeight = maxDetentValue;
 
+                        CGFloat height = heightBlock();
+                        CGFloat bottomAdjustment = [self detentBottomAdjustmentForHeight:height];
                         CGFloat maxValue = self.maxContentHeight
                                              ? fmin(maxDetentValue, [self.maxContentHeight floatValue])
                                              : maxDetentValue;

--- a/ios/tvos/TrueSheetStubs.mm
+++ b/ios/tvos/TrueSheetStubs.mm
@@ -18,6 +18,7 @@
 #import <React/RCTViewComponentView.h>
 
 #import <react/renderer/components/TrueSheetSpec/ComponentDescriptors.h>
+#import <react/renderer/components/TrueSheetSpec/TrueSheetContentViewComponentDescriptor.h>
 #import <react/renderer/components/TrueSheetSpec/TrueSheetViewComponentDescriptor.h>
 
 #import <TrueSheetSpec/TrueSheetSpec.h>

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -3,7 +3,10 @@ module.exports = {
     platforms: {
       ios: {},
       android: {
-        componentDescriptors: ['TrueSheetViewComponentDescriptor'],
+        componentDescriptors: [
+          'TrueSheetViewComponentDescriptor',
+          'TrueSheetContentViewComponentDescriptor',
+        ],
         cmakeListsPath: '../android/src/main/jni/CMakeLists.txt',
       },
     },

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -54,6 +54,17 @@ import {
 import { Drawer } from './web/vaul';
 import { DEFAULT_PEEK_HEIGHT, TRANSITIONS } from './web/vaul/constants';
 
+// First vertically scrollable descendant — web mirror of native's
+// findScrollView (RN-web ScrollView/FlatList render a node with
+// `overflow-y: auto`; its first child is the content container).
+const findVerticalScroller = (root: HTMLElement): HTMLElement | null => {
+  for (const el of root.querySelectorAll<HTMLElement>('*')) {
+    const { overflowY } = window.getComputedStyle(el);
+    if (overflowY === 'auto' || overflowY === 'scroll') return el;
+  }
+  return null;
+};
+
 const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, ref) => {
   const {
     children,
@@ -148,6 +159,8 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
 
   const validDetentsRef = useRef(validDetents);
   validDetentsRef.current = validDetents;
+
+  const hasAutoDetent = validDetents.includes('auto');
 
   const handleSetActiveSnapPoint = useCallback((snapPoint: number | string | null) => {
     setActiveSnapPoint(
@@ -262,6 +275,92 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     (header ? headerHeight : 0) + (footer ? footerHeight : 0) + peekContentHeight ||
     DEFAULT_PEEK_HEIGHT;
 
+  // Web mirror of native's scrollable handling for 'auto' detents: a plugged
+  // scrollable keeps the sized (bounded) layout so its viewport is capped to
+  // the visible sheet and can scroll, while the 'auto' height is measured with
+  // the viewport replaced by the scrollable's content size — mirrors native
+  // `naturalHeight`.
+  const [hasBoundedScrollable, setHasBoundedScrollable] = useState(false);
+  const [scrollableAutoHeight, setScrollableAutoHeight] = useState(0);
+  const pinnedScrollerRef = useRef<HTMLElement | null>(null);
+
+  // Natural content height (header + content, with a pinned scrollable's
+  // viewport replaced by its content size) — the height the content wants
+  // regardless of the sheet's bounds.
+  const measureNaturalHeight = useCallback(() => {
+    const contentEl = contentRef.current as unknown as HTMLElement | null;
+    if (!contentEl || !contentEl.isConnected) return 0;
+    const headerEl = headerElRef.current as unknown as HTMLElement | null;
+    let height = (headerEl?.offsetHeight ?? 0) + contentEl.offsetHeight;
+    const scroller = pinnedScrollerRef.current;
+    const scrollContent = scroller?.firstElementChild;
+    if (scroller?.isConnected && scrollContent instanceof HTMLElement) {
+      height += scrollContent.offsetHeight - scroller.clientHeight;
+    }
+    return Math.max(0, height);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen || !hasAutoDetent) return undefined;
+
+    let canceled = false;
+    let rafId = 0;
+    let mutationObserver: MutationObserver | null = null;
+    let resizeObserver: ResizeObserver | null = null;
+
+    const attach = () => {
+      if (canceled) return;
+      const drawerEl = drawerContentRef.current;
+      if (!drawerEl || !drawerEl.isConnected) {
+        // Radix Presence defers the portal mount; poll until the drawer is live.
+        rafId = window.requestAnimationFrame(attach);
+        return;
+      }
+
+      const measure = () => setScrollableAutoHeight(measureNaturalHeight());
+
+      // (Re)pin the first vertical scrollable and observe the nodes whose size
+      // feeds the natural height — content growth inside a bounded scroller is
+      // invisible to the sheet's own layout (mirrors native's contentSize
+      // observation). Resolves the content node live: the layout-branch swap
+      // (natural flow ↔ sized) remounts it.
+      const observe = () => {
+        const contentEl = contentRef.current as unknown as HTMLElement | null;
+        const scroller =
+          contentEl && contentEl.isConnected ? findVerticalScroller(contentEl) : null;
+        pinnedScrollerRef.current = scroller;
+        setHasBoundedScrollable(scroller != null);
+
+        resizeObserver?.disconnect();
+        resizeObserver = new ResizeObserver(measure);
+        if (contentEl?.isConnected) resizeObserver.observe(contentEl);
+        const headerEl = headerElRef.current as unknown as HTMLElement | null;
+        if (headerEl) resizeObserver.observe(headerEl);
+        if (scroller) {
+          resizeObserver.observe(scroller);
+          if (scroller.firstElementChild) resizeObserver.observe(scroller.firstElementChild);
+        }
+        measure();
+      };
+
+      observe();
+      // Watch the whole drawer subtree — catches the scrollable mounting/
+      // unmounting AND the layout-branch swap, which remounts the content node
+      // (a content-scoped observer would go stale after the swap).
+      mutationObserver = new MutationObserver(observe);
+      mutationObserver.observe(drawerEl, { childList: true, subtree: true });
+    };
+
+    rafId = window.requestAnimationFrame(attach);
+
+    return () => {
+      canceled = true;
+      window.cancelAnimationFrame(rafId);
+      mutationObserver?.disconnect();
+      resizeObserver?.disconnect();
+    };
+  }, [isOpen, hasAutoDetent, measureNaturalHeight]);
+
   // Below the last detent a vertical touch pan moves the sheet, not the
   // content — `[data-vaul-scroll-locked]` disables vertical touch panning on
   // the scroll container and everything inside it (see vaul/style.css).
@@ -363,15 +462,12 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       inputs.effectiveMaxContentHeight !== undefined
         ? Math.min(effectiveH, inputs.effectiveMaxContentHeight)
         : effectiveH;
-    // 'auto' resolves to the auto-size wrapper's height. Read it live — the
+    // 'auto' resolves to the content's natural height. Read it live — the
     // `measuredContentHeight` state lags mount by a frame (vaul's initial
     // ref-callback measure runs while the portal subtree is still detached,
     // so it reads 0 until the ResizeObserver fires). Falls back to the state
     // value, then to vaul's pre-measure fallback (effectiveHeight / 2).
-    const autoWrapper = drawerContentRef.current?.querySelector<HTMLElement>(
-      '[data-vaul-auto-size-wrapper]'
-    );
-    const measuredHeight = autoWrapper?.offsetHeight || inputs.measuredContentHeight;
+    const measuredHeight = measureNaturalHeight() || inputs.measuredContentHeight;
     const autoHeight = Math.min(measuredHeight > 0 ? measuredHeight : effectiveH / 2, ceiling);
 
     // 'peek' is measured live from the DOM (offsetHeight is layout-based, so
@@ -406,7 +502,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       values.push(effectiveH > 0 ? h / effectiveH : 0);
     }
     return { windowH, effectiveH, ceiling, positions, values };
-  }, []);
+  }, [measureNaturalHeight]);
 
   // Detent info for lifecycle events. Position/detent come from the active
   // detent's target geometry — not the live DOM rect — so willPresent (drawer
@@ -860,9 +956,9 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   }, [isOpen, descendants.length]);
 
   // Definite-height flex layout (per-detent sizing) unless content must be
-  // measured in natural flow: 'auto' detents and form-sheet content-fit sizing.
-  const hasAutoDetent = validDetents.includes('auto');
-  const useSizedLayout = !hasAutoDetent && !isFormSheet;
+  // measured in natural flow: 'auto' detents (without a plugged scrollable —
+  // those measure via `measureNaturalHeight`) and form-sheet content-fit sizing.
+  const useSizedLayout = (!hasAutoDetent || hasBoundedScrollable) && !isFormSheet;
 
   const effectiveCornerRadius = cornerRadius ?? DEFAULT_CORNER_RADIUS;
 
@@ -894,8 +990,11 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       borderTopRightRadius: effectiveCornerRadius,
       backgroundColor: backgroundColor as string,
       // Clip children to the rounded top so headers/content with their own
-      // background don't bleed past the corners.
-      overflow: 'hidden',
+      // background don't bleed past the corners. `clip` (not `hidden`): a
+      // hidden box is still a scroll container, so browser focus-reveal (e.g.
+      // tapping a button near the sheet bottom) can scroll-offset the drawer —
+      // shifting content and blocking vaul's shouldDrag walk (scrollTop > 0).
+      overflow: 'clip',
       // Lift content above iOS home indicator / bottom safe area when enabled.
       paddingBottom: insetAdjustment === 'automatic' ? 'env(safe-area-inset-bottom, 0px)' : 0,
     }),
@@ -1028,6 +1127,13 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
         initialAnimated={initialDetentAnimated}
         detachedWrapperStyle={wrapperStyle}
         onContentHeightChange={setMeasuredContentHeight}
+        contentHeight={
+          // Bounded scrollable → the auto-size wrapper measures 0 (sized
+          // layout is absolute), so feed vaul the natural height instead.
+          hasAutoDetent && hasBoundedScrollable && scrollableAutoHeight > 0
+            ? scrollableAutoHeight
+            : undefined
+        }
         activeSnapPoint={activeSnapPoint}
         setActiveSnapPoint={handleSetActiveSnapPoint}
         {...snapPointsProps}

--- a/src/fabric/TrueSheetContentViewNativeComponent.ts
+++ b/src/fabric/TrueSheetContentViewNativeComponent.ts
@@ -5,4 +5,8 @@ export interface NativeProps extends ViewProps {
   // No props needed - size will be controlled by parent
 }
 
-export default codegenNativeComponent<NativeProps>('TrueSheetContentView', {});
+// interfaceOnly: shadow node/state/descriptor are custom (common/cpp) so the
+// content can be bounded to the container when a ScrollView is pinned
+export default codegenNativeComponent<NativeProps>('TrueSheetContentView', {
+  interfaceOnly: true,
+});

--- a/src/web/vaul/index.tsx
+++ b/src/web/vaul/index.tsx
@@ -197,6 +197,13 @@ export type DialogProps = {
    * content (e.g. iPad-style form sheets).
    */
   onContentHeightChange?: (height: number) => void;
+  /**
+   * Overrides the measured content height used to resolve the 'auto' snap
+   * point. Used when the caller bounds the content to the visible sheet
+   * (e.g. a plugged scrollable) so the auto-size wrapper can't be measured
+   * from natural flow.
+   */
+  contentHeight?: number;
 } & (WithFadeFromProps | WithoutFadeFromProps);
 
 export function Root({
@@ -239,6 +246,7 @@ export function Root({
   peekHeight,
   initialAnimated = true,
   onContentHeightChange,
+  contentHeight: contentHeightProp,
 }: DialogProps) {
   const [isOpen = false, setIsOpen] = useControllableState({
     defaultProp: defaultOpen,
@@ -273,15 +281,16 @@ export function Root({
   const drawerHeightRef = React.useRef(drawerRef.current?.getBoundingClientRect().height || 0);
   const drawerWidthRef = React.useRef(drawerRef.current?.getBoundingClientRect().width || 0);
   const initialDrawerHeight = React.useRef(0);
-  const [contentHeight, setContentHeight] = React.useState(0);
+  const [measuredContentHeight, setContentHeight] = React.useState(0);
+  const contentHeight = contentHeightProp ?? measuredContentHeight;
 
   const onContentHeightChangeRef = React.useRef(onContentHeightChange);
   React.useEffect(() => {
     onContentHeightChangeRef.current = onContentHeightChange;
   });
   React.useEffect(() => {
-    onContentHeightChangeRef.current?.(contentHeight);
-  }, [contentHeight]);
+    onContentHeightChangeRef.current?.(measuredContentHeight);
+  }, [measuredContentHeight]);
 
   const onSnapPointChange = React.useCallback((activeSnapPointIndex: number) => {
     // Change openTime ref when we reach the last snap point to prevent dragging for 500ms incase it's scrollable.
@@ -771,7 +780,16 @@ export function Root({
     dragEndTime.current = new Date();
     const swipeAmount = getTranslate(drawerRef.current, direction);
 
-    if (!event || !shouldDrag(event.target, false) || !swipeAmount || Number.isNaN(swipeAmount))
+    // Drag overshoot below the lowest snap point translates the detached
+    // wrapper while the drawer stays pinned (see onDrag in use-snap-points) —
+    // common when a clamped 'auto' puts the lowest snap point at 0. Count the
+    // wrapper's translation as movement, or the release is swallowed and the
+    // sheet is left stuck at the overshoot position.
+    const wrapper = drawerRef.current.closest<HTMLElement>('[data-vaul-detached-wrapper]');
+    const wrapperSwipeAmount = wrapper ? getTranslate(wrapper, direction) : null;
+    const hasMoved = Boolean(swipeAmount) || Boolean(wrapperSwipeAmount);
+
+    if (!event || !shouldDrag(event.target, false) || !hasMoved || Number.isNaN(swipeAmount))
       return;
 
     if (dragStartTime.current === null) return;
@@ -825,7 +843,7 @@ export function Root({
 
     const isHorizontalSwipe = direction === 'left' || direction === 'right';
     if (
-      Math.abs(swipeAmount) >=
+      Math.abs(swipeAmount ?? 0) >=
       (isHorizontalSwipe ? visibleDrawerWidth : visibleDrawerHeight) * closeThreshold
     ) {
       closeDrawer();


### PR DESCRIPTION
## Summary

Supports the `auto` detent with plugged scrollables (`ScrollView`/`FlatList`) on iOS and Android — previously circular: the auto height comes from the content, but a bounded scrollable viewport reports the container height, not what the content wants.

- **Bounding**: new `TrueSheetContentView` shadow node/state (`scrollableBounded`) — when a scrollable is pinned, the content fills the container (`flexGrow`/`flexShrink` 1) so the viewport is bounded and scrolls.
- **Natural height**: the auto detent is measured from `naturalHeight` — content height with the scrollable's viewport replaced by its content size. Content growth is tracked directly (`contentSize` KVO on iOS, child layout listener on Android) since it's invisible to layout once bounded.
- **iOS detent stability**: auto/peek detents resolve lazily from snapshots; size changes refresh snapshots + `invalidateDetents` inside `animateChanges` instead of reassigning `sheet.detents` (which re-lays out the whole presentation stack, glitching a sheet behind). Heights are measured synchronously at present time so the presentation starts at the right height, and size updates are dropped while dismissing/not presented — fixes glitches on rapid present/dismiss over a parent sheet.

## Type of Change

- [x] New feature

## Test Plan

- Example `FlatListSheet` with `detents={['auto', 1]}`: presents at content height, scrolls, and the "Add Item" button grows the sheet with the content (animated).
- Rapid present/dismiss over the parent map sheet — no glitching of the sheet behind, presentation animates smoothly.
- Content growth while presented resizes the auto detent; while a child sheet is presenting/dismissing, updates are deferred/dropped.

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)

> Note: web scrolling with `auto` + scrollable is a known gap — will be addressed in a follow-up.