### PR TITLE
refactor!: derive auto detent from container's yoga layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 💥 Breaking changes
 
 - Synchronous per-detent container layout — the container is sized to the sheet's visible height per detent and tracks it in realtime while dragging, on all platforms (previously sized to the screen height / largest detent). The `scrollable` prop is removed — scrollables are auto-detected and work plugged in directly. Requires React Native 0.82+. ([#735](https://github.com/lodev09/react-native-true-sheet/pull/735) by [@lodev09](https://github.com/lodev09))
+- The `auto` detent now derives from the container's Yoga layout. The footer is in-flow by default — it sits below the content, counts toward `auto`, and pinned scrollables shrink to make room for it; float it via `footerStyle` (`position: 'absolute'`) to overlay the content instead. Floating headers/footers no longer inflate `auto`/`peek` heights. ([#745](https://github.com/lodev09/react-native-true-sheet/pull/745) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.9
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
@@ -3,6 +3,8 @@ package com.lodev09.truesheet
 import android.annotation.SuppressLint
 import android.view.View
 import android.view.ViewGroup
+import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.util.RNLog
@@ -16,6 +18,7 @@ interface TrueSheetContainerViewDelegate {
   fun containerViewHeaderDidChangeSize(width: Int, height: Int)
   fun containerViewFooterDidChangeSize(width: Int, height: Int)
   fun containerViewPeekDidChangeSize(width: Int, height: Int)
+  fun containerViewDidLayout()
 }
 
 /**
@@ -31,29 +34,45 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
   TrueSheetPeekViewDelegate {
 
   var delegate: TrueSheetContainerViewDelegate? = null
+  var stateWrapper: StateWrapper? = null
 
   var contentView: TrueSheetContentView? = null
   var headerView: TrueSheetHeaderView? = null
   var footerView: TrueSheetFooterView? = null
   var peekView: TrueSheetPeekView? = null
 
-  var contentHeight: Int = 0
-  var headerHeight: Int = 0
   var footerHeight: Int = 0
 
+  private var scrollableBounded = false
+
   /**
-   * Distance from the top of the content view to the bottom of the peek view.
-   * Includes the peek view's offset within the content (padding, views above it)
-   * so the peek detent reveals everything down to the peek content's bottom edge.
+   * The container's Yoga-resolved natural extent — the height the auto detent
+   * needs. In-flow header/footer count; floating (absolute-positioned) ones
+   * don't. When a pinned ScrollView bounds the layout, the viewport is
+   * replaced by the ScrollView's content size.
+   */
+  val autoHeight: Int
+    get() {
+      val scrollDelta = contentView?.let { it.naturalHeight - it.height } ?: 0
+      return maxOf(0, height + scrollDelta)
+    }
+
+  /**
+   * Distance from the top of the container to the bottom of the peek view.
+   * Includes the peek view's offset within the layout (in-flow header, padding,
+   * views above it) so the peek detent reveals everything down to the peek
+   * content's bottom edge. A floating (absolute) header doesn't offset the
+   * content, so it doesn't count.
    */
   val peekContentHeight: Int
     get() {
-      val peek = peekView ?: return 0
-      val content = contentView ?: return peek.height
+      // No peek view: collapse to the content's layout offset — the bottom of
+      // an in-flow header — so the peek detent reveals just the header.
+      val peek = peekView ?: return contentView?.top ?: 0
 
       var bottom = peek.height
       var view: View = peek
-      while (view !== content) {
+      while (view !== this) {
         bottom += view.top
         view = view.parent as? View ?: return peek.height
       }
@@ -81,6 +100,28 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
   fun setupScrollable() {
     val bottomInset = if (insetAdjustment == TrueSheetInsetAdjustment.AUTOMATIC) scrollViewBottomInset else 0
     contentView?.setupScrollable(bottomInset)
+  }
+
+  /**
+   * Tells the shadow node to fill the sheet (flexGrow/flexShrink) instead of
+   * sizing naturally, so a pinned ScrollView's viewport is bounded.
+   */
+  private fun setScrollableBounded(bounded: Boolean) {
+    if (scrollableBounded == bounded) return
+    scrollableBounded = bounded
+
+    stateWrapper?.let {
+      val newState = WritableNativeMap()
+      newState.putBoolean("scrollableBounded", bounded)
+      it.updateState(newState)
+    }
+  }
+
+  // Any layout change here can move the auto detent height (the container's
+  // natural height IS the auto height) — let the sheet re-evaluate.
+  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    delegate?.containerViewDidLayout()
   }
 
   fun setupKeyboardHandler() {
@@ -179,7 +220,6 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
   // ==================== Delegate Implementations ====================
 
   override fun contentViewDidChangeSize(width: Int, height: Int) {
-    contentHeight = height
     delegate?.containerViewContentDidChangeSize(width, height)
   }
 
@@ -191,8 +231,13 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
     delegate?.containerViewScrollViewDidChange()
   }
 
+  // The container mirrors the content's bounded state so both fill when a
+  // ScrollView is pinned (content bounds the viewport, container fills the sheet).
+  override fun contentViewDidChangeScrollableBounded(bounded: Boolean) {
+    setScrollableBounded(bounded)
+  }
+
   override fun headerViewDidChangeSize(width: Int, height: Int) {
-    headerHeight = height
     delegate?.containerViewHeaderDidChangeSize(width, height)
   }
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerViewManager.kt
@@ -2,6 +2,8 @@ package com.lodev09.truesheet
 
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.PointerEvents
+import com.facebook.react.uimanager.ReactStylesDiffMap
+import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
@@ -16,6 +18,11 @@ class TrueSheetContainerViewManager : ViewGroupManager<TrueSheetContainerView>()
   override fun getName(): String = REACT_CLASS
 
   override fun createViewInstance(reactContext: ThemedReactContext): TrueSheetContainerView = TrueSheetContainerView(reactContext)
+
+  override fun updateState(view: TrueSheetContainerView, props: ReactStylesDiffMap?, stateWrapper: StateWrapper?): Any? {
+    view.stateWrapper = stateWrapper
+    return null
+  }
 
   @ReactProp(name = "pointerEvents")
   fun setPointerEvents(view: TrueSheetContainerView, pointerEventsStr: String?) {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -29,6 +29,7 @@ interface TrueSheetContentViewDelegate {
   fun contentViewDidChangeSize(width: Int, height: Int)
   fun contentViewDidScroll()
   fun contentViewScrollViewDidChange()
+  fun contentViewDidChangeScrollableBounded(bounded: Boolean)
 }
 
 /**
@@ -138,7 +139,8 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
 
   /**
    * Tells the shadow node to fill the container (flexGrow/flexShrink) so the
-   * pinned ScrollView's viewport is bounded to the visible space.
+   * pinned ScrollView's viewport is bounded to the visible space. The
+   * container mirrors this in its own state to fill the sheet (see delegate).
    */
   private fun setScrollableBounded(bounded: Boolean) {
     if (scrollableBounded == bounded) return
@@ -149,6 +151,8 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
       newState.putBoolean("scrollableBounded", bounded)
       it.updateState(newState)
     }
+
+    delegate?.contentViewDidChangeScrollableBounded(bounded)
   }
 
   fun setupScrollable(bottomInset: Int) {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -623,6 +623,12 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     updateSheetIfNeeded()
   }
 
+  // The container's natural layout is the auto detent height — any layout
+  // change re-evaluates it (values refresh inside the debounced update).
+  override fun containerViewDidLayout() {
+    updateSheetIfNeeded()
+  }
+
   // ==================== RNScreensEventObserverDelegate ====================
 
   override fun presenterScreenWillDisappear() {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -270,16 +270,12 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   // Content Measurements
   // Cached values used during dismiss when container is unmounted
-  private var cachedContentHeight: Int = 0
-  private var cachedHeaderHeight: Int = 0
+  private var cachedAutoHeight: Int = 0
   private var cachedFooterHeight: Int = 0
   private var cachedPeekContentHeight: Int = 0
 
-  override val contentHeight: Int
-    get() = containerView?.contentHeight ?: cachedContentHeight
-
-  override val headerHeight: Int
-    get() = containerView?.headerHeight ?: cachedHeaderHeight
+  override val autoHeight: Int
+    get() = containerView?.autoHeight ?: cachedAutoHeight
 
   override val footerHeight: Int
     get() = containerView?.footerHeight ?: cachedFooterHeight
@@ -563,7 +559,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     // On older APIs, use onSlide for footer positioning during keyboard transitions
     val useLegacyKeyboardHandling = Build.VERSION.SDK_INT < Build.VERSION_CODES.R
     if (!isKeyboardTransitioning || useLegacyKeyboardHandling) {
-      positionFooter(slideOffset)
+      positionFooter()
     }
 
     if (!isKeyboardTransitioning) {
@@ -833,8 +829,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     }
 
     containerView?.let {
-      cachedContentHeight = it.contentHeight
-      cachedHeaderHeight = it.headerHeight
+      cachedAutoHeight = it.autoHeight
       cachedFooterHeight = it.footerHeight
       cachedPeekContentHeight = it.peekContentHeight
     }
@@ -906,6 +901,11 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     // behavior state, killing the gesture.
     if (interactionState is InteractionState.Dragging) return
 
+    // Only auto (-1) and peek (-2) detents resolve from sizes — fractional
+    // detents can't change, so skip the churn (the container lays out on
+    // every sheet resize).
+    if (detents.none { it == -1.0 || it == -2.0 }) return
+
     setupSheetDetents()
     positionFooter()
   }
@@ -957,7 +957,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   fun updateDimAmount(sheetTop: Int? = null, animated: Boolean = false) {
     if (!dimmed) return
-    if (contentHeight == 0) return
+    if (autoHeight == 0) return
 
     // While keyboard is active or transitioning, use the target detent position for dim
     val top = if (keyboardInset > 0 || isKeyboardTransitioning) {
@@ -985,26 +985,17 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   var footerKeyboardOffset: Int = 0
 
-  fun positionFooter(slideOffset: Float? = null) {
+  /**
+   * Keyboard slide for the footer. Yoga owns the footer's frame (in flow, or
+   * floated via user styles), so the keyboard shift is carried by a
+   * translation instead of layout — parity with iOS.
+   */
+  fun positionFooter() {
     if (!isPresented) return
     val footerView = containerView?.footerView ?: return
-    val sheet = sheetView ?: return
-
-    val footerHeight = footerView.height
-    val sheetHeight = sheet.height
-    val sheetTop = sheet.top
 
     val keyboardShift = if (currentKeyboardInset > 0) maxOf(0, currentKeyboardInset + footerKeyboardOffset) else 0
-    var footerY = (sheetHeight - sheetTop - footerHeight - keyboardShift).toFloat()
-
-    // Adjust during dismiss animation when slideOffset is negative
-    if (slideOffset != null && slideOffset < 0) {
-      footerY -= (footerHeight * slideOffset)
-    }
-
-    // Clamp to prevent footer going above safe area
-    val maxAllowedY = (sheetHeight - topInset - footerHeight).toFloat()
-    footerView.y = minOf(footerY, maxAllowedY)
+    footerView.translationY = -keyboardShift.toFloat()
   }
 
   // =============================================================================
@@ -1220,9 +1211,9 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
    * Updates position emission, footer, and dim amount together.
    * This pattern is commonly used during animations and state changes.
    */
-  private fun updateSheetVisuals(effectiveTop: Int, slideOffset: Float? = null) {
+  private fun updateSheetVisuals(effectiveTop: Int) {
     emitChangePositionDelegate(effectiveTop)
-    positionFooter(slideOffset)
+    positionFooter()
     updateDimAmount(effectiveTop)
   }
 

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
@@ -13,8 +13,7 @@ interface TrueSheetDetentCalculatorDelegate {
   val screenHeight: Int
   val realScreenHeight: Int
   val detents: MutableList<Double>
-  val contentHeight: Int
-  val headerHeight: Int
+  val autoHeight: Int
   val footerHeight: Int
   val peekContentHeight: Int
   val contentBottomInset: Int
@@ -32,8 +31,7 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
   private val screenHeight: Int get() = delegate?.screenHeight ?: 0
   private val realScreenHeight: Int get() = delegate?.realScreenHeight ?: 0
   private val detents: List<Double> get() = delegate?.detents ?: emptyList()
-  private val contentHeight: Int get() = delegate?.contentHeight ?: 0
-  private val headerHeight: Int get() = delegate?.headerHeight ?: 0
+  private val autoHeight: Int get() = delegate?.autoHeight ?: 0
   private val footerHeight: Int get() = delegate?.footerHeight ?: 0
   private val peekContentHeight: Int get() = delegate?.peekContentHeight ?: 0
   private val contentBottomInset: Int get() = delegate?.contentBottomInset ?: 0
@@ -41,12 +39,12 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
   private val keyboardInset: Int get() = delegate?.keyboardInset ?: 0
 
   /**
-   * Height for peek (-2.0) detents: header + footer + peek content height.
+   * Height for peek (-2.0) detents: peek content + footer height.
    * Falls back to 150dp when none is present.
    */
   private val peekDetentHeight: Int
     get() {
-      val height = headerHeight + footerHeight + peekContentHeight
+      val height = peekContentHeight + footerHeight
       return if (height > 0) height else DEFAULT_PEEK_HEIGHT.dpToPx().toInt()
     }
 
@@ -56,7 +54,7 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
    */
   fun getDetentHeight(detent: Double, includeKeyboard: Boolean = true): Int {
     val baseHeight = if (detent == -1.0) {
-      contentHeight + headerHeight + contentBottomInset
+      autoHeight + contentBottomInset
     } else if (detent == -2.0) {
       peekDetentHeight + contentBottomInset
     } else {
@@ -99,7 +97,7 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
     if (index < 0 || index >= detents.size) return 0f
     val value = detents[index]
     return if (value == -1.0) {
-      (contentHeight + headerHeight).toFloat() / screenHeight.toFloat()
+      autoHeight.toFloat() / screenHeight.toFloat()
     } else if (value == -2.0) {
       peekDetentHeight.toFloat() / screenHeight.toFloat()
     } else {

--- a/android/src/main/jni/TrueSheetSpec.h
+++ b/android/src/main/jni/TrueSheetSpec.h
@@ -3,6 +3,7 @@
 #include <ReactCommon/JavaTurboModule.h>
 #include <ReactCommon/TurboModule.h>
 #include <jsi/jsi.h>
+#include <react/renderer/components/TrueSheetSpec/TrueSheetContainerViewComponentDescriptor.h>
 #include <react/renderer/components/TrueSheetSpec/TrueSheetContentViewComponentDescriptor.h>
 #include <react/renderer/components/TrueSheetSpec/TrueSheetViewComponentDescriptor.h>
 

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContainerViewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContainerViewComponentDescriptor.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <react/renderer/components/TrueSheetSpec/TrueSheetContainerViewShadowNode.h>
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+namespace facebook::react {
+
+/*
+ * Descriptor for <TrueSheetContainerView> component.
+ */
+class TrueSheetContainerViewComponentDescriptor final
+    : public ConcreteComponentDescriptor<TrueSheetContainerViewShadowNode> {
+  using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
+
+  void adopt(ShadowNode &shadowNode) const override {
+    auto &concreteShadowNode =
+        static_cast<TrueSheetContainerViewShadowNode &>(shadowNode);
+    concreteShadowNode.adjustLayoutWithState();
+
+    ConcreteComponentDescriptor::adopt(shadowNode);
+  }
+};
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContainerViewShadowNode.cpp
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContainerViewShadowNode.cpp
@@ -1,0 +1,42 @@
+#include "TrueSheetContainerViewShadowNode.h"
+
+#include <react/renderer/components/view/conversions.h>
+
+namespace facebook::react {
+
+using namespace yoga;
+
+extern const char TrueSheetContainerViewComponentName[] = "TrueSheetContainerView";
+
+void TrueSheetContainerViewShadowNode::adjustLayoutWithState() {
+  ensureUnsealed();
+
+  auto state = std::static_pointer_cast<
+      const TrueSheetContainerViewShadowNode::ConcreteState>(getState());
+  auto stateData = state->getData();
+
+  auto &props = getConcreteProps();
+
+  // Auto detents leave the container at its natural height (its layout IS the
+  // detent height). When a ScrollView is pinned, fill the sheet instead so the
+  // viewport is bounded to the visible space — the natural height is measured
+  // from the ScrollView's content size (see ContainerView's autoHeight on each
+  // platform).
+  auto flexGrow = stateData.scrollableBounded
+      ? FloatOptional{1.0f}
+      : props.yogaStyle.flexGrow();
+  auto flexShrink = stateData.scrollableBounded
+      ? FloatOptional{1.0f}
+      : props.yogaStyle.flexShrink();
+
+  if (yogaNode_.style().flexGrow() != flexGrow ||
+      yogaNode_.style().flexShrink() != flexShrink) {
+    yoga::Style adjustedStyle = props.yogaStyle;
+    adjustedStyle.setFlexGrow(flexGrow);
+    adjustedStyle.setFlexShrink(flexShrink);
+    yogaNode_.setStyle(adjustedStyle);
+    yogaNode_.setDirty(true);
+  }
+}
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContainerViewShadowNode.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContainerViewShadowNode.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include <react/renderer/components/TrueSheetSpec/EventEmitters.h>
+#include <react/renderer/components/TrueSheetSpec/Props.h>
+#include <react/renderer/components/TrueSheetSpec/TrueSheetContainerViewState.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+
+namespace facebook::react {
+
+JSI_EXPORT extern const char TrueSheetContainerViewComponentName[];
+
+/*
+ * `ShadowNode` for <TrueSheetContainerView> component.
+ */
+class JSI_EXPORT TrueSheetContainerViewShadowNode final
+    : public ConcreteViewShadowNode<
+          TrueSheetContainerViewComponentName,
+          TrueSheetContainerViewProps,
+          TrueSheetContainerViewEventEmitter,
+          TrueSheetContainerViewState> {
+  using ConcreteViewShadowNode::ConcreteViewShadowNode;
+
+ public:
+  void adjustLayoutWithState();
+};
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContainerViewState.cpp
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContainerViewState.cpp
@@ -1,0 +1,11 @@
+#include "TrueSheetContainerViewState.h"
+
+namespace facebook::react {
+
+#ifdef ANDROID
+folly::dynamic TrueSheetContainerViewState::getDynamic() const {
+  return folly::dynamic::object("scrollableBounded", scrollableBounded);
+}
+#endif
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContainerViewState.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContainerViewState.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#ifdef ANDROID
+#include <folly/dynamic.h>
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include <react/renderer/mapbuffer/MapBufferBuilder.h>
+#endif
+
+namespace facebook::react {
+
+/*
+ * State for <TrueSheetContainerView> component.
+ * Set from native when a ScrollView is pinned so the shadow node fills the
+ * sheet instead of sizing naturally (see TrueSheetContainerViewShadowNode).
+ */
+class TrueSheetContainerViewState final {
+ public:
+  TrueSheetContainerViewState() = default;
+
+#ifdef ANDROID
+  TrueSheetContainerViewState(
+      TrueSheetContainerViewState const &previousState,
+      folly::dynamic data)
+      : scrollableBounded(data["scrollableBounded"].getBool()) {}
+#endif
+
+  bool scrollableBounded{false};
+
+#ifdef ANDROID
+  folly::dynamic getDynamic() const;
+  MapBuffer getMapBuffer() const {
+    return MapBufferBuilder::EMPTY();
+  }
+#endif
+};
+
+} // namespace facebook::react

--- a/docs/docs/guides/footer.mdx
+++ b/docs/docs/guides/footer.mdx
@@ -1,12 +1,18 @@
 ---
 title: Adding Footer
-description: Add a floating footer component to the bottom sheet.
+description: Add a footer component fixed to the bottom of the sheet.
 keywords: [bottom sheet footer, bottom sheet floating footer, bottom sheet sticky footer]
 ---
 
-Do you need a FAB (Floating Action Button) on the sheet? Or perhaps a small banner at the bottom? We've got you covered!
+Do you need action buttons on the sheet? Or perhaps a small banner at the bottom? We've got you covered!
 
-`TrueSheet` provides first-class support for a `Footer` component. This component will float at the bottom of the sheet.
+`TrueSheet` provides first-class support for a `Footer` component. It sits at the bottom of the sheet, below the content — the content area shrinks to make room for it, and its height counts toward the [`auto`](../reference/types#sheetdetent) detent. To overlay the content instead, float it with [`footerStyle`](../reference/configuration#footerstyle):
+
+```tsx
+<TrueSheet footer={SomeFooter} footerStyle={{ position: 'absolute', left: 0, right: 0, bottom: 0 }}>
+```
+
+A floating footer takes no layout space, so it doesn't count toward `auto` — exactly like a hand-rolled absolute-positioned view.
 
 ## How?
 
@@ -110,4 +116,4 @@ const App = () => {
 }
 ```
 
-Since the footer floats, it stays visible at every detent. See [Peeking Content](peeking) for the full guide.
+The footer stays visible at every detent since the content shrinks to make room for it. See [Peeking Content](peeking) for the full guide.

--- a/docs/docs/reference/01-configuration.mdx
+++ b/docs/docs/reference/01-configuration.mdx
@@ -266,7 +266,7 @@ A component that is fixed at the top of the sheet content. Useful for search bar
 
 ## `headerStyle`
 
-Style for the header container.
+Style for the header container. A floating header (`position: 'absolute'`) overlays the content instead of offsetting it, so it doesn't count toward `auto` and `peek` detent heights.
 
 | Type | Default | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |
@@ -274,7 +274,7 @@ Style for the header container.
 
 ## `footer`
 
-A component that floats at the bottom of the sheet. Accepts a functional `Component` or `ReactElement`.
+A component fixed at the bottom of the sheet, below the content. Its height counts toward `auto` and `peek` detent heights, and pinned scrollables shrink to make room for it. Accepts a functional `Component` or `ReactElement`. See [this guide](../guides/footer) for example.
 
 | Type | Default | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |
@@ -282,7 +282,7 @@ A component that floats at the bottom of the sheet. Accepts a functional `Compon
 
 ## `footerStyle`
 
-Style for the footer container.
+Style for the footer container. A floating footer (`position: 'absolute'`) overlays the content instead of taking layout space, so it doesn't count toward the `auto` detent height. It still counts toward `peek`, which reveals the footer over the peeking content.
 
 | Type | Default | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |

--- a/example/shared/src/components/sheets/BasicSheet.tsx
+++ b/example/shared/src/components/sheets/BasicSheet.tsx
@@ -173,7 +173,7 @@ const styles = StyleSheet.create({
     paddingTop: SPACING,
     paddingBottom: FOOTER_HEIGHT + SPACING,
     gap: GAP,
-  }
+  },
 });
 
 BasicSheet.displayName = 'BasicSheet';

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)containerViewHeaderDidChangeSize:(CGSize)newSize;
 - (void)containerViewFooterDidChangeSize:(CGSize)newSize;
 - (void)containerViewPeekDidChangeSize:(CGSize)newSize;
+- (void)containerViewDidLayout;
 
 @end
 
@@ -56,14 +57,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) ScrollableOptions *scrollableOptions;
 
 /**
- * Returns the current content height
+ * Returns the container's Yoga-resolved natural extent for the auto detent.
+ * In-flow header/footer count; floating (absolute) ones don't.
  */
-- (CGFloat)contentHeight;
-
-/**
- * Returns the current header height
- */
-- (CGFloat)headerHeight;
+- (CGFloat)autoHeight;
 
 /**
  * Returns the current footer height
@@ -71,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (CGFloat)footerHeight;
 
 /**
- * Returns the current height of the peek view within the content
+ * Returns the distance from the top of the container to the bottom of the peek view
  */
 - (CGFloat)peekContentHeight;
 

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -19,10 +19,11 @@
 #import "utils/UIView+ScrollEdgeInteraction.h"
 #import "utils/WindowUtil.h"
 
-#import <react/renderer/components/TrueSheetSpec/ComponentDescriptors.h>
 #import <react/renderer/components/TrueSheetSpec/EventEmitters.h>
 #import <react/renderer/components/TrueSheetSpec/Props.h>
 #import <react/renderer/components/TrueSheetSpec/RCTComponentViewHelpers.h>
+#import <react/renderer/components/TrueSheetSpec/TrueSheetContainerViewComponentDescriptor.h>
+#import <react/renderer/components/TrueSheetSpec/TrueSheetContainerViewShadowNode.h>
 
 #import <React/RCTConversions.h>
 #import <React/RCTLog.h>
@@ -50,11 +51,13 @@ using namespace facebook::react;
 @end
 
 @implementation TrueSheetContainerView {
+  TrueSheetContainerViewShadowNode::ConcreteState::Shared _state;
   TrueSheetContentView *_contentView;
   TrueSheetHeaderView *_headerView;
   TrueSheetFooterView *_footerView;
   TrueSheetPeekView *__weak _peekView;
   TrueSheetKeyboardObserver *_keyboardObserver;
+  BOOL _scrollableBounded;
 }
 
 #pragma mark - Initialization
@@ -72,9 +75,46 @@ using namespace facebook::react;
     _contentView = nil;
     _headerView = nil;
     _footerView = nil;
+    _scrollableBounded = NO;
     self.isAccessibilityElement = NO;
   }
   return self;
+}
+
+- (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState {
+  _state = std::static_pointer_cast<TrueSheetContainerViewShadowNode::ConcreteState const>(state);
+}
+
+// Tells the shadow node to fill the sheet (flexGrow/flexShrink) instead of
+// sizing naturally, so a pinned ScrollView's viewport is bounded.
+- (void)setScrollableBounded:(BOOL)bounded {
+  if (_scrollableBounded == bounded) {
+    return;
+  }
+  _scrollableBounded = bounded;
+
+  if (_state) {
+    TrueSheetContainerViewState newState;
+    newState.scrollableBounded = bounded;
+    _state->updateState(std::move(newState));
+  }
+}
+
+- (void)prepareForRecycle {
+  [super prepareForRecycle];
+  _state.reset();
+  _scrollableBounded = NO;
+}
+
+// Any layout change here can move the auto detent height (the container's
+// natural height IS the auto height) — let the sheet re-evaluate.
+- (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics {
+  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+
+  if ([self.delegate respondsToSelector:@selector(containerViewDidLayout)]) {
+    [self.delegate containerViewDidLayout];
+  }
 }
 
 #pragma mark - Accessibility
@@ -106,31 +146,38 @@ using namespace facebook::react;
 
 #pragma mark - Layout
 
-- (CGFloat)contentHeight {
-  return _contentView ? _contentView.naturalHeight : 0;
-}
-
-- (CGFloat)headerHeight {
-  return _headerView ? _headerView.frame.size.height : 0;
+/**
+ * The container's Yoga-resolved natural extent — the height the auto detent
+ * needs. In-flow header/footer count; floating (absolute-positioned) ones
+ * don't. When a pinned ScrollView bounds the layout, the viewport is replaced
+ * by the ScrollView's content size.
+ */
+- (CGFloat)autoHeight {
+  CGFloat scrollDelta = _contentView ? _contentView.naturalHeight - _contentView.frame.size.height : 0;
+  return MAX(0, self.frame.size.height + scrollDelta);
 }
 
 - (CGFloat)footerHeight {
   return _footerView ? _footerView.frame.size.height : 0;
 }
 
-// Distance from the top of the content view to the bottom of the peek view.
-// Includes the peek view's offset within the content (padding, views above it)
-// so the peek detent reveals everything down to the peek content's bottom edge.
+// Distance from the top of the container to the bottom of the peek view.
+// Includes the peek view's offset within the layout (in-flow header, padding,
+// views above it) so the peek detent reveals everything down to the peek
+// content's bottom edge. A floating (absolute) header doesn't offset the
+// content, so it doesn't count.
 - (CGFloat)peekContentHeight {
   if (!_peekView) {
-    return 0;
+    // No peek view: collapse to the content's layout offset — the bottom of
+    // an in-flow header — so the peek detent reveals just the header.
+    return _contentView ? _contentView.frame.origin.y : 0;
   }
 
-  if (!_contentView || ![_peekView isDescendantOfView:_contentView]) {
+  if (![_peekView isDescendantOfView:self]) {
     return _peekView.frame.size.height;
   }
 
-  return CGRectGetMaxY([_peekView convertRect:_peekView.bounds toView:_contentView]);
+  return CGRectGetMaxY([_peekView convertRect:_peekView.bounds toView:self]);
 }
 
 - (void)updateFooterKeyboardOffset {
@@ -255,6 +302,12 @@ using namespace facebook::react;
 
 - (void)contentViewScrollViewDidChange {
   [self.delegate containerViewScrollViewDidChange];
+}
+
+// The container mirrors the content's bounded state so both fill when a
+// ScrollView is pinned (content bounds the viewport, container fills the sheet).
+- (void)contentViewDidChangeScrollableBounded:(BOOL)bounded {
+  [self setScrollableBounded:bounded];
 }
 
 #pragma mark - TrueSheetHeaderViewDelegate

--- a/ios/TrueSheetContentView.h
+++ b/ios/TrueSheetContentView.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)contentViewDidChangeSize:(CGSize)newSize;
 - (void)contentViewScrollViewDidChange;
+- (void)contentViewDidChangeScrollableBounded:(BOOL)bounded;
 
 @end
 

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -59,7 +59,8 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
 }
 
 // Tells the shadow node to fill the container (flexGrow/flexShrink) so the
-// pinned ScrollView's viewport is bounded to the visible space.
+// pinned ScrollView's viewport is bounded to the visible space. The container
+// mirrors this in its own state to fill the sheet (see delegate).
 - (void)setScrollableBounded:(BOOL)bounded {
   if (_scrollableBounded == bounded) {
     return;
@@ -71,6 +72,8 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
     newState.scrollableBounded = bounded;
     _state->updateState(std::move(newState));
   }
+
+  [self.delegate contentViewDidChangeScrollableBounded:bounded];
 }
 
 #pragma mark - Text Change Observing

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -381,14 +381,9 @@ using namespace facebook::react;
   _controller.accessibilityContentView = _containerView;
   [_controller setupAccessibilityContainer];
 
-  CGFloat contentHeight = [_containerView contentHeight];
-  if (contentHeight > 0) {
-    _controller.contentHeight = @(contentHeight);
-  }
-
-  CGFloat headerHeight = [_containerView headerHeight];
-  if (headerHeight > 0) {
-    _controller.headerHeight = @(headerHeight);
+  CGFloat autoHeight = [_containerView autoHeight];
+  if (autoHeight > 0) {
+    _controller.autoHeight = @(autoHeight);
   }
 
   CGFloat footerHeight = [_containerView footerHeight];
@@ -466,8 +461,7 @@ using namespace facebook::react;
   // async size reports would otherwise land mid-animation and force a
   // detent retarget that snaps the presentation stack.
   if (_containerView) {
-    _controller.contentHeight = @([_containerView contentHeight]);
-    _controller.headerHeight = @([_containerView headerHeight]);
+    _controller.autoHeight = @([_containerView autoHeight]);
     _controller.footerHeight = @([_containerView footerHeight]);
     _controller.peekContentHeight = @([_containerView peekContentHeight]);
   }
@@ -595,20 +589,26 @@ using namespace facebook::react;
     if (!self->_containerView || self->_controller.isBeingDismissed)
       return;
 
-    // Refresh here (not just on peek size events) since the peek's offset
-    // within the content can change without its own size changing.
+    // Refresh here (not just on the originating size events) since layout
+    // offsets can change without the reporting view's own size changing
+    // (e.g. a header resize shifts the content's origin).
+    self->_controller.autoHeight = @([self->_containerView autoHeight]);
     self->_controller.peekContentHeight = @([self->_containerView peekContentHeight]);
     [self->_controller setupSheetDetentsForSizeChange];
   });
 }
 
 - (void)containerViewContentDidChangeSize:(CGSize)newSize {
-  _controller.contentHeight = @(newSize.height);
   [self setupSheetDetentsForSizeChange];
 }
 
 - (void)containerViewHeaderDidChangeSize:(CGSize)newSize {
-  _controller.headerHeight = @(newSize.height);
+  [self setupSheetDetentsForSizeChange];
+}
+
+// The container's natural layout is the auto detent height — any layout
+// change re-evaluates it (values refresh inside the debounced update).
+- (void)containerViewDidLayout {
   [self setupSheetDetentsForSizeChange];
 }
 

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -55,8 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSArray<NSNumber *> *detents;
 @property (nonatomic, strong, nullable) NSNumber *maxContentHeight;
 @property (nonatomic, strong, nullable) NSNumber *maxContentWidth;
-@property (nonatomic, strong, nullable) NSNumber *contentHeight;
-@property (nonatomic, strong, nullable) NSNumber *headerHeight;
+@property (nonatomic, strong, nullable) NSNumber *autoHeight;
 @property (nonatomic, strong, nullable) NSNumber *footerHeight;
 @property (nonatomic, strong, nullable) NSNumber *peekContentHeight;
 @property (nonatomic, strong, nullable) UIColor *backgroundColor;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -88,8 +88,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 - (instancetype)init {
   if (self = [super initWithNibName:nil bundle:nil]) {
     _detents = @[ @0.5, @1 ];
-    _contentHeight = @(0);
-    _headerHeight = @(0);
+    _autoHeight = @(0);
     _footerHeight = @(0);
     _peekContentHeight = @(0);
     _grabber = YES;
@@ -850,7 +849,22 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
  */
 - (void)setupSheetDetentsForSizeChange {
   if (@available(iOS 16.0, *)) {
-    CGFloat autoHeight = [self.contentHeight floatValue] + [self.headerHeight floatValue];
+    // Only auto (-1) and peek (-2) detents resolve from sizes — fractional
+    // detents can't change, so skip the churn (the container lays out on
+    // every sheet resize).
+    BOOL hasSizeDetents = NO;
+    for (NSNumber *detent in self.detents) {
+      double value = [detent doubleValue];
+      if (value == -1 || value == -2) {
+        hasSizeDetents = YES;
+        break;
+      }
+    }
+    if (!hasSizeDetents) {
+      return;
+    }
+
+    CGFloat autoHeight = [self.autoHeight floatValue];
     CGFloat peekHeight = [_detentCalculator peekHeight];
 
     if (fabs(autoHeight - _autoDetentHeight) < 0.5 && fabs(peekHeight - _peekDetentHeight) < 0.5) {
@@ -885,7 +899,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   NSMutableArray<UISheetPresentationControllerDetent *> *detents = [NSMutableArray array];
   [_detentCalculator clearResolvedHeights];
 
-  _autoDetentHeight = [self.contentHeight floatValue] + [self.headerHeight floatValue];
+  _autoDetentHeight = [self.autoHeight floatValue];
   _peekDetentHeight = [_detentCalculator peekHeight];
 
   for (NSInteger index = 0; index < self.detents.count; index++) {

--- a/ios/core/TrueSheetDetentCalculator.h
+++ b/ios/core/TrueSheetDetentCalculator.h
@@ -19,8 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) CGFloat screenHeight;
 @property (nonatomic, readonly) CGFloat currentPosition;
 @property (nonatomic, strong, readonly) NSArray<NSNumber *> *detents;
-@property (nonatomic, strong, readonly, nullable) NSNumber *contentHeight;
-@property (nonatomic, strong, readonly, nullable) NSNumber *headerHeight;
+@property (nonatomic, strong, readonly, nullable) NSNumber *autoHeight;
 @property (nonatomic, strong, readonly, nullable) NSNumber *footerHeight;
 @property (nonatomic, strong, readonly, nullable) NSNumber *peekContentHeight;
 
@@ -37,13 +36,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Returns the detent value (0-1 fraction) for a given index.
- For auto (-1) detents, calculates based on content + header height.
- For peek (-2) detents, calculates based on header + footer height.
+ For auto (-1) detents, calculates based on the content's layout extent.
+ For peek (-2) detents, calculates based on peek content + footer height.
  */
 - (CGFloat)detentValueForIndex:(NSInteger)index;
 
 /**
- Returns the height for peek (-2) detents: header + footer + peek content height.
+ Returns the height for peek (-2) detents: peek content + footer height.
  Falls back to 150 when none is present — matches the iOS 26
  floating small-detent threshold.
  */

--- a/ios/core/TrueSheetDetentCalculator.mm
+++ b/ios/core/TrueSheetDetentCalculator.mm
@@ -19,8 +19,7 @@
   if (index >= 0 && index < (NSInteger)detents.count) {
     CGFloat value = [detents[index] doubleValue];
     if (value == -1) {
-      CGFloat autoHeight = [self.delegate.contentHeight floatValue] + [self.delegate.headerHeight floatValue];
-      return autoHeight / self.delegate.screenHeight;
+      return [self.delegate.autoHeight floatValue] / self.delegate.screenHeight;
     }
     if (value == -2) {
       return [self peekHeight] / self.delegate.screenHeight;
@@ -31,8 +30,7 @@
 }
 
 - (CGFloat)peekHeight {
-  CGFloat height = [self.delegate.headerHeight floatValue] + [self.delegate.footerHeight floatValue] +
-                   [self.delegate.peekContentHeight floatValue];
+  CGFloat height = [self.delegate.peekContentHeight floatValue] + [self.delegate.footerHeight floatValue];
   return height > 0 ? height : 150;
 }
 

--- a/ios/tvos/TrueSheetStubs.mm
+++ b/ios/tvos/TrueSheetStubs.mm
@@ -18,6 +18,7 @@
 #import <React/RCTViewComponentView.h>
 
 #import <react/renderer/components/TrueSheetSpec/ComponentDescriptors.h>
+#import <react/renderer/components/TrueSheetSpec/TrueSheetContainerViewComponentDescriptor.h>
 #import <react/renderer/components/TrueSheetSpec/TrueSheetContentViewComponentDescriptor.h>
 #import <react/renderer/components/TrueSheetSpec/TrueSheetViewComponentDescriptor.h>
 

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -5,6 +5,7 @@ module.exports = {
       android: {
         componentDescriptors: [
           'TrueSheetViewComponentDescriptor',
+          'TrueSheetContainerViewComponentDescriptor',
           'TrueSheetContentViewComponentDescriptor',
         ],
         cmakeListsPath: '../android/src/main/jni/CMakeLists.txt',

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -482,9 +482,10 @@ export class TrueSheet
       return Math.min(1, detent);
     });
 
-    // `auto` detents derive the sheet height from the content's natural height,
-    // so the content can't fill the container. Otherwise fill so flex layouts
-    // and ScrollViews/FlatLists work as-is, like a regular bounded view.
+    // `auto` detents derive the sheet height from the container's natural
+    // layout (header + content + footer as resolved by Yoga), so the container
+    // can't fill the sheet. Otherwise fill so flex layouts and
+    // ScrollViews/FlatLists work as-is, like a regular bounded view.
     const hasAutoDetent = resolvedDetents.includes(-1);
 
     // Cache grabberOptions to avoid creating a new object every render
@@ -539,7 +540,9 @@ export class TrueSheet
         onVisibilityChange={this.onVisibilityChange}
       >
         {this.state.shouldRenderNativeView && (
-          <TrueSheetContainerViewNativeComponent style={styles.container}>
+          <TrueSheetContainerViewNativeComponent
+            style={hasAutoDetent ? undefined : styles.container}
+          >
             {header && (
               <TrueSheetHeaderViewNativeComponent style={[styles.header, headerStyle]}>
                 {isValidElement(header) ? header : createElement(header)}
@@ -571,7 +574,9 @@ const styles = StyleSheet.create({
     zIndex: -9999,
     pointerEvents: 'box-none',
   },
-  // Fill the sheet so flex layouts track the sheet's size per detent
+  // Fill the sheet so flex layouts track the sheet's size per detent.
+  // Skipped for auto detents, where the container's natural height IS the
+  // detent height.
   container: {
     ...StyleSheet.absoluteFill,
   },
@@ -581,13 +586,10 @@ const styles = StyleSheet.create({
   header: {
     pointerEvents: 'box-none',
   },
-  // Pinned to the sheet's bottom edge via Yoga since the container tracks the
-  // sheet's visible height
+  // In flow below the content — content's flex:1 pushes it to the sheet's
+  // bottom edge when the container fills. Float it via `footerStyle`
+  // (position: 'absolute') to overlay the content instead.
   footer: {
     pointerEvents: 'box-none',
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    bottom: 0,
   },
 });

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -11,7 +11,7 @@ import {
   useState,
 } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
-import { useColorScheme, useWindowDimensions, View } from 'react-native';
+import { StyleSheet, useColorScheme, useWindowDimensions, View } from 'react-native';
 
 import type {
   DetentChangeEvent,
@@ -192,10 +192,8 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       e.preventDefault();
       return;
     }
-    // The footer is rendered via vaul's `detachedSiblings` as a sibling of
-    // Drawer.Content inside [data-vaul-detached-wrapper], so Radix treats
-    // clicks on it as "outside" the content. Don't dismiss for clicks that
-    // landed inside the wrapper.
+    // Don't dismiss for clicks that landed inside the drawer's wrapper
+    // (Radix can treat portal-adjacent nodes as "outside" the content).
     if (target instanceof Element) {
       const wrapper = drawerContentRef.current?.closest('[data-vaul-detached-wrapper]');
       if (wrapper && wrapper.contains(target)) {
@@ -245,7 +243,8 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   const drawerContentRef = useRef<HTMLDivElement | null>(null);
 
   // Measured header/footer heights drive the 'peek' snap point — mirrors
-  // native, where the controller tracks headerHeight/footerHeight.
+  // native, where the peek height derives from the layout's peek extent
+  // plus the footer height.
   const [headerHeight, setHeaderHeight] = useState(0);
   const [footerHeight, setFooterHeight] = useState(0);
 
@@ -271,9 +270,23 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   const peekElRef = useRef<View>(null);
   const peekContext = useMemo(() => ({ contentRef, peekRef: peekElRef, setPeekContentHeight }), []);
 
+  // A floating (absolute-positioned) header/footer overlays the content
+  // instead of taking flow space, so it doesn't count toward 'auto'/'peek'
+  // heights — mirrors native, where the container's yoga-resolved layout is
+  // the measured value.
+  const headerFloating = useMemo(
+    () => StyleSheet.flatten(headerStyle)?.position === 'absolute',
+    [headerStyle]
+  );
+  const footerFloating = useMemo(
+    () => StyleSheet.flatten(footerStyle)?.position === 'absolute',
+    [footerStyle]
+  );
+
   const peekHeight =
-    (header ? headerHeight : 0) + (footer ? footerHeight : 0) + peekContentHeight ||
-    DEFAULT_PEEK_HEIGHT;
+    (header && !headerFloating ? headerHeight : 0) +
+      (footer ? footerHeight : 0) +
+      peekContentHeight || DEFAULT_PEEK_HEIGHT;
 
   // Web mirror of native's scrollable handling for 'auto' detents: a plugged
   // scrollable keeps the sized (bounded) layout so its viewport is capped to
@@ -291,14 +304,18 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     const contentEl = contentRef.current as unknown as HTMLElement | null;
     if (!contentEl || !contentEl.isConnected) return 0;
     const headerEl = headerElRef.current as unknown as HTMLElement | null;
-    let height = (headerEl?.offsetHeight ?? 0) + contentEl.offsetHeight;
+    const footerEl = footerElRef.current as unknown as HTMLElement | null;
+    let height =
+      (headerFloating ? 0 : (headerEl?.offsetHeight ?? 0)) +
+      contentEl.offsetHeight +
+      (footerFloating ? 0 : (footerEl?.offsetHeight ?? 0));
     const scroller = pinnedScrollerRef.current;
     const scrollContent = scroller?.firstElementChild;
     if (scroller?.isConnected && scrollContent instanceof HTMLElement) {
       height += scrollContent.offsetHeight - scroller.clientHeight;
     }
     return Math.max(0, height);
-  }, []);
+  }, [headerFloating, footerFloating]);
 
   useEffect(() => {
     if (!isOpen || !hasAutoDetent) return undefined;
@@ -336,6 +353,8 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
         if (contentEl?.isConnected) resizeObserver.observe(contentEl);
         const headerEl = headerElRef.current as unknown as HTMLElement | null;
         if (headerEl) resizeObserver.observe(headerEl);
+        const footerEl = footerElRef.current as unknown as HTMLElement | null;
+        if (footerEl) resizeObserver.observe(footerEl);
         if (scroller) {
           resizeObserver.observe(scroller);
           if (scroller.firstElementChild) resizeObserver.observe(scroller.firstElementChild);
@@ -485,8 +504,9 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       peekEl && contentEl ? measurePeekContentHeight(peekEl, contentEl) : inputs.peekContentHeight;
     const livePeekHeight =
       headerEl || footerEl || peekEl
-        ? (headerEl?.offsetHeight ?? 0) + (footerEl?.offsetHeight ?? 0) + livePeekContentHeight ||
-          DEFAULT_PEEK_HEIGHT
+        ? (headerFloating ? 0 : (headerEl?.offsetHeight ?? 0)) +
+            (footerEl?.offsetHeight ?? 0) +
+            livePeekContentHeight || DEFAULT_PEEK_HEIGHT
         : inputs.peekHeight;
 
     const positions: number[] = [];
@@ -502,7 +522,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
       values.push(effectiveH > 0 ? h / effectiveH : 0);
     }
     return { windowH, effectiveH, ceiling, positions, values };
-  }, [measureNaturalHeight]);
+  }, [measureNaturalHeight, headerFloating]);
 
   // Detent info for lifecycle events. Position/detent come from the active
   // detent's target geometry — not the live DOM rect — so willPresent (drawer
@@ -1006,22 +1026,6 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
 
   const grabberHeight = grabberOptions?.height ?? DEFAULT_GRABBER_HEIGHT;
 
-  // Footer is rendered inside the wrapper via `detachedSiblings`, so it
-  // follows the wrapper on dismiss and drag-overshoot. Positioning is
-  // relative to the wrapper (contain: paint creates the containing block).
-  const footerFloatStyle = useMemo<React.CSSProperties>(
-    () => ({
-      position: 'fixed',
-      left: 0,
-      right: 0,
-      bottom: 0,
-      // Wrapper has `pointer-events: none` to let clicks fall through; the
-      // footer must opt back in.
-      pointerEvents: 'auto',
-    }),
-    []
-  );
-
   // Form-sheet style (presentation='form'): centered floating card with a
   // default width and a height fit to content. We reuse the existing detached
   // mechanic so drag/snap math stays correct — the wrapper is bottom-attached
@@ -1144,15 +1148,6 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
             ref={drawerContentRef}
             style={mergedContentStyle}
             onPointerDownOutside={handlePointerDownOutside}
-            detachedSiblings={
-              footer ? (
-                <div style={footerFloatStyle}>
-                  <View ref={footerElRef} style={footerStyle} onLayout={handleFooterLayout}>
-                    {isValidElement(footer) ? footer : createElement(footer)}
-                  </View>
-                </div>
-              ) : undefined
-            }
           >
             <Drawer.Title style={visuallyHiddenStyle}>Sheet</Drawer.Title>
             {grabber && <Drawer.Handle style={handleStyle} />}
@@ -1178,6 +1173,11 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
                 <View ref={contentRef} style={[contentFillStyle, style]}>
                   {children}
                 </View>
+                {footer && (
+                  <View ref={footerElRef} style={footerStyle} onLayout={handleFooterLayout}>
+                    {isValidElement(footer) ? footer : createElement(footer)}
+                  </View>
+                )}
               </div>
             ) : (
               // Natural flow so vaul can measure content height — required for
@@ -1191,6 +1191,11 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
                 <View ref={contentRef} style={style}>
                   {children}
                 </View>
+                {footer && (
+                  <View ref={footerElRef} style={footerStyle} onLayout={handleFooterLayout}>
+                    {isValidElement(footer) ? footer : createElement(footer)}
+                  </View>
+                )}
               </>
             )}
           </Drawer.Content>

--- a/src/fabric/TrueSheetContainerViewNativeComponent.ts
+++ b/src/fabric/TrueSheetContainerViewNativeComponent.ts
@@ -5,4 +5,9 @@ export interface NativeProps extends ViewProps {
   // No props needed - container accesses props from parent TrueSheetView
 }
 
-export default codegenNativeComponent<NativeProps>('TrueSheetContainerView');
+// interfaceOnly: shadow node/state/descriptor are custom (common/cpp) so the
+// container can fill the sheet when a ScrollView is pinned — its natural
+// layout otherwise defines the auto detent height
+export default codegenNativeComponent<NativeProps>('TrueSheetContainerView', {
+  interfaceOnly: true,
+});

--- a/src/web/vaul/index.tsx
+++ b/src/web/vaul/index.tsx
@@ -1576,7 +1576,11 @@ Content.displayName = 'Drawer.Content';
 // margin-top (e.g. a grabber) stays inside the wrapper instead of collapsing
 // out — otherwise `offsetHeight` under-reports and the drawer positions the
 // wrapper below where the content actually ends.
-const autoSizeWrapperStyle: React.CSSProperties = { display: 'flow-root' };
+// `position: relative` makes the wrapper the containing block for
+// absolute-positioned children (e.g. a floated footer), so they pin to the
+// content's natural extent — parity with native, where the container is the
+// measured layout box.
+const autoSizeWrapperStyle: React.CSSProperties = { display: 'flow-root', position: 'relative' };
 
 export type HandleProps = React.ComponentPropsWithoutRef<'div'> & {
   preventCycle?: boolean;


### PR DESCRIPTION
## Summary

The container is now a plain yoga flex column (header, content, footer) whose natural height **is** the `auto` detent — replacing the `contentHeight + headerHeight` summing on all platforms. Yoga itself decides what counts: in-flow header/footer take layout space and count; floating (`position: 'absolute'`) ones overlay and don't. Full layout parity with hand-rolled views — the `header`/`footer` props are now purely behavior slots (edge effects, keyboard handling, a11y).

### Breaking changes

- **Footer is in-flow by default** — it sits below the content (content's `flex: 1` pushes it to the sheet's bottom edge) instead of overlaying it, counts toward `auto`, and pinned scrollables shrink to make room for it (no more manual `paddingBottom` compensation). Float it via `footerStyle` (`position: 'absolute'`) to restore the overlay behavior.
- **Floating headers no longer inflate `auto`/`peek` heights** — previously a `headerStyle` with `position: 'absolute'` still added its height to the auto detent, which was visually incorrect.
- With `auto` detents the container is content-sized, so floated children pin to the content's box — the same thing a hand-rolled absolute view would do.

### Implementation

- `TrueSheetContainerView` gets a custom shadow node/state (`interfaceOnly`): sizes naturally for `auto`, fills the sheet when a ScrollView is pinned (mirrors the content's bounded state via delegate)
- `autoHeight = container height + pinned ScrollView content delta`, measured on the container — one formula, valid in both regimes; `headerHeight`/`contentHeight` plumbing deleted everywhere
- `peek` derives from the container-relative peek extent + footer height; without a `TrueSheetPeek` it falls back to the content's layout offset (collapse-to-header preserved)
- Android `positionFooter` reduced from per-frame y-pinning to a pure keyboard `translationY` slide (parity with iOS) — yoga owns the footer's frame now
- Web: footer renders in the drawer flow instead of vaul's `detachedSiblings` float; vaul's auto-size wrapper is now `position: relative` so floated children get native-equivalent containing-block semantics
- Detent invalidation is skipped when all detents are fractional (the container lays out on every sheet resize now)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

## Test Plan

- `yarn typecheck`, `yarn lint`, `yarn test` (44 passing), objc/ktlint clean
- Pending on-device verification (iOS/Android/Web): auto detent with in-flow/floating header and footer, auto + scrollables, peek with/without `TrueSheetPeek`, footer keyboard slide, drag tracking

## Screenshots / Videos

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)