### PR TITLE
feat!: content lays out naturally like a regular view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 💥 Breaking changes
 
+- Content now lays out naturally like a regular view or a react-navigation screen — it wraps its children's height by default instead of filling the sheet. Pass `flex: 1` via `style` to fill, and bound scrollables the same way (except `auto` detents, which stay auto-sized). ([#746](https://github.com/lodev09/react-native-true-sheet/pull/746) by [@lodev09](https://github.com/lodev09))
 - Synchronous per-detent container layout — the container is sized to the sheet's visible height per detent and tracks it in realtime while dragging, on all platforms (previously sized to the screen height / largest detent). The `scrollable` prop is removed — scrollables are auto-detected and work plugged in directly. Requires React Native 0.82+. ([#735](https://github.com/lodev09/react-native-true-sheet/pull/735) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.9

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
@@ -69,6 +69,12 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
       contentView?.scrollableOptions = value
     }
 
+  var hasAutoDetent = false
+    set(value) {
+      field = value
+      contentView?.hasAutoDetent = value
+    }
+
   override val eventDispatcher: EventDispatcher?
     get() = delegate?.eventDispatcher
 
@@ -98,6 +104,7 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
       is TrueSheetContentView -> {
         child.delegate = this
         child.scrollableOptions = scrollableOptions
+        child.hasAutoDetent = hasAutoDetent
         contentView = child
 
         // Children mount bottom-up, so the content subtree is complete here.

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -87,6 +87,20 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
       keyboardScrollOffset = value?.keyboardScrollOffset?.dpToPx() ?: 0f
     }
 
+  /**
+   * Whether the sheet has an `auto` detent. Deriving the sheet height from the
+   * scroll content is circular with natural layout, so the pinned ScrollView's
+   * viewport is force-bounded to the container only in this case.
+   */
+  var hasAutoDetent = false
+    set(value) {
+      if (field == value) return
+      field = value
+      if (pinnedScrollView != null) {
+        setScrollableBounded(value)
+      }
+    }
+
   override fun addView(child: View?, index: Int) {
     super.addView(child, index)
     checkScrollViewChanged()
@@ -138,7 +152,8 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
 
   /**
    * Tells the shadow node to fill the container (flexGrow/flexShrink) so the
-   * pinned ScrollView's viewport is bounded to the visible space.
+   * pinned ScrollView's viewport is bounded to the visible space. Only applied
+   * for auto detents — otherwise content lays out naturally like a regular view.
    */
   private fun setScrollableBounded(bounded: Boolean) {
     if (scrollableBounded == bounded) return
@@ -182,7 +197,7 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
         observedScrollChild = child
         child.addOnLayoutChangeListener(scrollChildLayoutListener)
       }
-      setScrollableBounded(true)
+      setScrollableBounded(hasAutoDetent)
       reportSizeIfChanged()
     }
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -267,6 +267,7 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
 
   fun setDetents(newDetents: MutableList<Double>) {
     viewController.detents = newDetents
+    setupScrollable()
   }
 
   fun setInsetAdjustment(insetAdjustment: String) {
@@ -289,6 +290,7 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
       it.insetAdjustment = viewController.insetAdjustment
       it.scrollViewBottomInset = viewController.contentBottomInset
       it.scrollableOptions = viewController.scrollableOptions
+      it.hasAutoDetent = viewController.detents.contains(-1.0)
       it.setupScrollable()
     }
   }

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.cpp
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.cpp
@@ -17,11 +17,12 @@ void TrueSheetContentViewShadowNode::adjustLayoutWithState() {
 
   auto &props = getConcreteProps();
 
-  // When a ScrollView is pinned, fill the container so descendant flex layouts
-  // (flex:1 wrappers, the ScrollView itself) resolve against a definite height
-  // and the viewport is bounded. The natural height for auto detents is
-  // measured from the ScrollView's content size instead (see ContentView's
-  // naturalHeight on each platform).
+  // When a ScrollView is pinned under an auto detent, fill the container so
+  // descendant flex layouts (flex:1 wrappers, the ScrollView itself) resolve
+  // against a definite height and the viewport is bounded — natural layout is
+  // circular there since the sheet height derives from the ScrollView's content
+  // size instead (see ContentView's naturalHeight on each platform). For fixed
+  // detents, content lays out naturally like a regular view.
   auto flexGrow = stateData.scrollableBounded
       ? FloatOptional{1.0f}
       : props.yogaStyle.flexGrow();

--- a/docs/docs/guides/scrolling.mdx
+++ b/docs/docs/guides/scrolling.mdx
@@ -6,7 +6,7 @@ keywords: [bottom sheet scrolling, bottom sheet scrollview, bottom sheet flatlis
 
 import scrolling from './assets/scrolling.gif'
 
-Scrolling content within the sheet works out of the box — plug a `ScrollView` or `FlatList` in directly, like a regular view.
+Scrolling content within the sheet works like a regular view — bound the scroll view's height with `flex: 1` and plug a `ScrollView` or `FlatList` in directly.
 
 <img alt="scrolling" src={scrolling} width="300"/>
 
@@ -14,12 +14,14 @@ Scrolling content within the sheet works out of the box — plug a `ScrollView` 
 
 Scroll views (including `ScrollView` and `FlatList`) are **automatically detected**. Insets, keyboard handling, and nested scrolling are all wired for you — no props needed.
 
+Like any scroll view in React Native, it needs a bounded height to scroll. Pass `flex: 1` via the sheet's [`style`](../reference/configuration#style) prop so the content fills the sheet's visible height per detent — resizing in realtime while dragging:
+
 ```tsx
 const App = () => {
   const sheet = useRef<TrueSheet>(null)
 
   return (
-    <TrueSheet ref={sheet} detents={[0.5, 1]}>
+    <TrueSheet ref={sheet} style={{ flex: 1 }} detents={[0.5, 1]}>
       <ScrollView>
         <View />
       </ScrollView>
@@ -28,10 +30,10 @@ const App = () => {
 }
 ```
 
-The sheet container is sized to the sheet's visible height per detent — resizing in realtime while dragging — so flex layouts bound the scroll view naturally. Wrapping it in a container `View` works too:
+Wrapping it in a container `View` works too:
 
 ```tsx
-<TrueSheet detents={[0.5, 1]}>
+<TrueSheet style={{ flex: 1 }} detents={[0.5, 1]}>
   <View style={{ flex: 1 }}>
     <View>{/* Header content */}</View>
     <FlatList data={data} renderItem={renderItem} />
@@ -43,8 +45,8 @@ The sheet container is sized to the sheet's visible height per detent — resizi
 On Android, nested scrolling is managed internally — any `nestedScrollEnabled` prop on your `ScrollView` or `FlatList` is ignored. `RefreshControl` is also fully supported.
 :::
 
-:::warning
-The [`auto`](../reference/types#sheetdetent) detent derives the sheet height from the content's natural height, so it doesn't work with scrolling content. Use fixed fractional detents (e.g., `0.5`, `0.8`, `1`) instead.
+:::info
+The [`auto`](../reference/types#sheetdetent) detent works with scrolling content too — no `flex: 1` needed. The sheet sizes to the scroll view's content height and resizes as content grows or shrinks, while the viewport is automatically bounded to the sheet's visible height.
 :::
 
 ## Preventing Scroll-to-Expand

--- a/docs/docs/reference/01-configuration.mdx
+++ b/docs/docs/reference/01-configuration.mdx
@@ -343,7 +343,9 @@ The offset from the bottom edge when [`detached`](#detached) is enabled.
 
 ## `style`
 
-The sheet's container style override.
+The sheet's content style override.
+
+Content lays out naturally by default — like a regular view or a screen. Pass `flex: 1` to fill the sheet's visible height per detent.
 
 | Type | Default | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -18,8 +18,8 @@ keywords: [bottom sheet types, bottom sheet typescript, bottom sheet definitions
 | `"peek"` | Collapsed height based on the combined [`header`](configuration#header) and [`footer`](configuration#footer) heights, plus the content up to the bottom of a [`TrueSheetPeek`](../guides/peeking) component rendered within it. Falls back to a fixed height of `150` when none is provided. | **_16+_** | ✅ | ✅ |
 | `number` | Fractional height (0-1) representing percentage of screen height. | ✅ | ✅ | ✅ |
 
-:::warning
-The `"auto"` detent derives the sheet height from the content's natural height, so it doesn't work with scrolling content. Use fixed fractional detents (e.g., `0.5`, `0.8`, `1`) instead.
+:::info
+The `"auto"` detent derives the sheet height from the content's natural height. With scrolling content, it sizes to the scroll view's content height and resizes as content grows or shrinks. See [Scrolling Content](../guides/scrolling).
 :::
 
 ## `BackgroundBlur`

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -61,7 +61,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler'
 ```
 
 :::warning
-Use `flexGrow: 1` instead of `flex: 1` to avoid layout issues.
+Use `flexGrow: 1` instead of `flex: 1` — the sheet's content wraps its natural height by default, so a `flex: 1` child collapses to zero height. Alternatively, pass `flex: 1` via the sheet's [`style`](reference/configuration#style) prop to fill the sheet. See [Content Layout](usage#content-layout).
 :::
 
 [Learn more](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation#android) about gesture handler setup on Android.
@@ -106,9 +106,12 @@ function HomeScreen() {
 
 ## Weird layout render
 
-The sheet does not have control over how React Native renders components and may lead to rendering issues. To resolve this, try to minimize the use of `flex=1` in your content styles. Instead, use fixed `height` or employ `flexGrow`, `flexBasis`, etc., to manage your layout requirements.
+The sheet's content lays out naturally — like a regular view or a screen — wrapping its children's natural height. Common symptoms and fixes:
 
-Try moving the sheet component up to a higher level in the component tree as some container may interfere with the sheet's content rendering.
+- **`flex: 1` children render with zero height** — the content isn't filled by default. Pass `flex: 1` via the sheet's [`style`](reference/configuration#style) prop so the content fills the sheet's visible height. See [Content Layout](usage#content-layout).
+- **Content taller than the sheet gets clipped** — use a `ScrollView` with `flex: 1` on the sheet's `style` (see [Scrolling Content](guides/scrolling)) or size your layout with `flexGrow`, `flexBasis`, or fixed heights.
+
+If layout still misbehaves, try moving the sheet component up to a higher level in the component tree as some container may interfere with the sheet's content rendering.
 
 ## Xcode and EAS Build Issues
 

--- a/docs/docs/usage.mdx
+++ b/docs/docs/usage.mdx
@@ -48,6 +48,18 @@ export const App = () => {
 
 Simple, right? Head over to [Configuration](reference/configuration) to learn more about configuring your sheet.
 
+## Content Layout
+
+Content lays out naturally — just like a regular view or a screen in [React Navigation](https://reactnavigation.org). By default, the sheet's content wraps its children's natural height. To fill the sheet's visible height (e.g. for `flex: 1` children, centered content, or `justifyContent` layouts), pass `flex: 1` via the [`style`](reference/configuration#style) prop:
+
+```tsx
+<TrueSheet style={{ flex: 1 }} detents={[0.5, 1]}>
+  <View style={{ flex: 1 }}>{/* Fills the sheet at every detent */}</View>
+</TrueSheet>
+```
+
+Scroll views work the same way — bound them with `flex: 1` like above. They're only special-cased for keyboard handling and [`auto`](reference/types#sheetdetent) sizing, where the sheet derives its height from the scroll content. See [Scrolling Content](guides/scrolling).
+
 ## Skills
 
 Skills are reusable AI capabilities that give your AI coding agent knowledge about TrueSheet. With the right skill loaded, your agent can pick the right patterns, avoid common mistakes, and generate correct code without you having to explain the library every time.

--- a/example/shared/src/components/sheets/PromptSheet.tsx
+++ b/example/shared/src/components/sheets/PromptSheet.tsx
@@ -46,6 +46,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
       ref={sheetRef}
       name="prompt-sheet"
       detents={[0.75, 1]}
+      style={styles.sheet}
       scrollableOptions={{
         keyboardScrollOffset: FOOTER_HEIGHT + SPACING,
         topScrollEdgeEffect: 'soft',
@@ -166,6 +167,9 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
 });
 
 const styles = StyleSheet.create({
+  sheet: {
+    flex: 1,
+  },
   content: {
     padding: SPACING,
     gap: GAP,

--- a/example/shared/src/components/sheets/ScrollViewSheet.tsx
+++ b/example/shared/src/components/sheets/ScrollViewSheet.tsx
@@ -65,6 +65,7 @@ export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((prop
       ref={ref}
       detents={[0.8, 1]}
       name="scrollview"
+      style={styles.sheet}
       scrollableOptions={{
         scrollingExpandsSheet: false,
         bottomScrollEdgeEffect: 'soft',
@@ -106,6 +107,9 @@ export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((prop
 ScrollViewSheet.displayName = 'ScrollViewSheet';
 
 const styles = StyleSheet.create({
+  sheet: {
+    flex: 1,
+  },
   content: {
     padding: SPACING,
     paddingTop: HEADER_HEIGHT + SPACING,

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -56,6 +56,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) ScrollableOptions *scrollableOptions;
 
 /**
+ * Whether the sheet has an `auto` detent — bounds the pinned scrollable's
+ * viewport to the container so the sheet height can derive from its content size
+ */
+@property (nonatomic, assign) BOOL hasAutoDetent;
+
+/**
  * Returns the current content height
  */
 - (CGFloat)contentHeight;

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -148,6 +148,7 @@ using namespace facebook::react;
     if (_insetAdjustment == TrueSheetViewInsetAdjustment::Automatic) {
       bottomInset = [WindowUtil keyWindow].safeAreaInsets.bottom;
     }
+    _contentView.hasAutoDetent = _hasAutoDetent;
     [_contentView setupScrollableWithBottomInset:bottomInset];
     [_contentView applyScrollEdgeEffects:_scrollableOptions];
     if (@available(iOS 26.0, *)) {

--- a/ios/TrueSheetContentView.h
+++ b/ios/TrueSheetContentView.h
@@ -34,6 +34,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, nullable) TrueSheetKeyboardObserver *keyboardObserver;
 
 /**
+ * Whether the sheet has an `auto` detent. Deriving the sheet height from the
+ * scroll content is circular with natural layout, so the pinned ScrollView's
+ * viewport is force-bounded to the container only in this case.
+ */
+@property (nonatomic, assign) BOOL hasAutoDetent;
+
+/**
  * Content height with the pinned ScrollView's viewport replaced by its content
  * size — the height the content wants regardless of container bounds.
  * Falls back to the frame height when no ScrollView is pinned.

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -59,7 +59,8 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
 }
 
 // Tells the shadow node to fill the container (flexGrow/flexShrink) so the
-// pinned ScrollView's viewport is bounded to the visible space.
+// pinned ScrollView's viewport is bounded to the visible space. Only applied
+// for auto detents — otherwise content lays out naturally like a regular view.
 - (void)setScrollableBounded:(BOOL)bounded {
   if (_scrollableBounded == bounded) {
     return;
@@ -70,6 +71,17 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
     TrueSheetContentViewState newState;
     newState.scrollableBounded = bounded;
     _state->updateState(std::move(newState));
+  }
+}
+
+- (void)setHasAutoDetent:(BOOL)hasAutoDetent {
+  if (_hasAutoDetent == hasAutoDetent) {
+    return;
+  }
+  _hasAutoDetent = hasAutoDetent;
+
+  if (_pinnedScrollView) {
+    [self setScrollableBounded:hasAutoDetent];
   }
 }
 
@@ -212,7 +224,7 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
     _pinnedScrollView = scrollView;
 
     [self observeScrollViewContentSize];
-    [self setScrollableBounded:YES];
+    [self setScrollableBounded:_hasAutoDetent];
     [self reportSizeIfChanged];
   }
 
@@ -436,6 +448,7 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
   [self clearScrollable];
   _state.reset();
   _scrollableBounded = NO;
+  _hasAutoDetent = NO;
   _lastSize = CGSizeZero;
 }
 

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -52,6 +52,7 @@ using namespace facebook::react;
   NSInteger _initialDetentIndex;
   TrueSheetViewInsetAdjustment _insetAdjustment;
   ScrollableOptions *_scrollableOptions;
+  BOOL _hasAutoDetent;
   BOOL _initialDetentAnimated;
   BOOL _isSheetUpdatePending;
   BOOL _pendingLayoutUpdate;
@@ -161,8 +162,12 @@ using namespace facebook::react;
 
   // Detents (-1 represents "auto")
   NSMutableArray *detents = [NSMutableArray new];
+  _hasAutoDetent = NO;
   for (const auto &detent : newProps.detents) {
     [detents addObject:@(detent)];
+    if (detent == -1) {
+      _hasAutoDetent = YES;
+    }
   }
 
   if (oldProps) {
@@ -771,6 +776,7 @@ using namespace facebook::react;
 
   _containerView.insetAdjustment = _insetAdjustment;
   _containerView.scrollableOptions = _scrollableOptions;
+  _containerView.hasAutoDetent = _hasAutoDetent;
   [_containerView setupScrollable];
 }
 

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -482,11 +482,6 @@ export class TrueSheet
       return Math.min(1, detent);
     });
 
-    // `auto` detents derive the sheet height from the content's natural height,
-    // so the content can't fill the container. Otherwise fill so flex layouts
-    // and ScrollViews/FlatLists work as-is, like a regular bounded view.
-    const hasAutoDetent = resolvedDetents.includes(-1);
-
     // Cache grabberOptions to avoid creating a new object every render
     if (grabberOptions !== this.cachedGrabberOptions) {
       this.cachedGrabberOptions = grabberOptions;
@@ -545,9 +540,7 @@ export class TrueSheet
                 {isValidElement(header) ? header : createElement(header)}
               </TrueSheetHeaderViewNativeComponent>
             )}
-            <TrueSheetContentViewNativeComponent
-              style={hasAutoDetent ? style : [styles.contentFill, style]}
-            >
+            <TrueSheetContentViewNativeComponent style={style}>
               {children}
             </TrueSheetContentViewNativeComponent>
             {footer && (
@@ -574,9 +567,6 @@ const styles = StyleSheet.create({
   // Fill the sheet so flex layouts track the sheet's size per detent
   container: {
     ...StyleSheet.absoluteFill,
-  },
-  contentFill: {
-    flex: 1,
   },
   header: {
     pointerEvents: 'box-none',

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -1173,9 +1173,14 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
                     {isValidElement(header) ? header : createElement(header)}
                   </View>
                 )}
-                {/* Fill the sized layout so plugged ScrollViews/FlatLists have
-                    a bounded height — mirrors native content fill. */}
-                <View ref={contentRef} style={[contentFillStyle, style]}>
+                {/* Content lays out naturally like native — fill only for auto
+                    detents with a plugged scrollable, where natural layout is
+                    circular (sheet height derives from the scroll content size).
+                    Mirrors the native shadow node's scrollableBounded behavior. */}
+                <View
+                  ref={contentRef}
+                  style={hasAutoDetent && hasBoundedScrollable ? [contentFillStyle, style] : style}
+                >
                   {children}
                 </View>
               </div>


### PR DESCRIPTION
## Summary

Makes sheet content consistent with a regular `View` or a react-navigation screen.

Previously, content was implicitly filled (`flex: 1`) unless the sheet had an `auto` detent — an inconsistency where adding/removing `'auto'` silently flipped the content layout. Now content **wraps its children's natural height by default**, and you opt into filling with `flex: 1` via the `style` prop — exactly like a screen.

Scroll views are only special-cased where they genuinely need to be:
- **Keyboard handling** — insets, scroll-to-focused-input (unchanged)
- **`auto` sizing** — the sheet derives its height from the scroll content, which is circular with natural layout, so the viewport is force-bounded (via the content shadow node's `scrollableBounded` state). Gated on `hasAutoDetent`, plumbed `TrueSheetView → ContainerView → ContentView` on both platforms.

For **fixed detents**, bound a scrollable with `flex: 1` like any regular view — RN's `ScrollView`/`FlatList` already ship `flexGrow: 1, flexShrink: 1`, so a bounded content view is all they need.

### Migration

```tsx
// Before — implicitly filled
<TrueSheet detents={[0.5, 1]}>
  <ScrollView>{/* ... */}</ScrollView>
</TrueSheet>

// After — bound it like a regular view
<TrueSheet style={{ flex: 1 }} detents={[0.5, 1]}>
  <ScrollView>{/* ... */}</ScrollView>
</TrueSheet>
```

`auto` detents need no change — still work with or without scrollables.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update

## Test Plan

- `yarn typecheck` + `yarn test` (44 passing)
- Example sheets updated: `ScrollViewSheet` / `PromptSheet` (fixed detents) now pass `style={{ flex: 1 }}`; `FlatListSheet` (`auto`) unchanged.
- ⚠️ Native not yet run on-device — needs manual verification.

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)