### PR TITLE
feat: add headerOptions prop with absolute header position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **iOS**: `onPositionChange` now tracks the sheet's actual on-screen position everywhere — detent snaps, programmatic resizes, and sheets moving behind a child sheet emit realtime frames from a single native tracker (previously approximated with a JS-side spring or only emitted once settled). `onDetentChange` for programmatic resizes now fires when the animation actually ends instead of after a fixed delay. ([#744](https://github.com/lodev09/react-native-true-sheet/pull/744) by [@lodev09](https://github.com/lodev09))
 - The `auto` detent now works with plugged scrollables — the sheet sizes to the scrollable's content height and resizes as content grows or shrinks. ([#743](https://github.com/lodev09/react-native-true-sheet/pull/743) by [@lodev09](https://github.com/lodev09))
+- New `headerOptions` prop with a `position` option — set to `'absolute'` to float the header over the content (pinned to the top edge) and exclude it from the `auto` detent height. ([#747](https://github.com/lodev09/react-native-true-sheet/pull/747) by [@lodev09](https://github.com/lodev09))
 
 ### 💥 Breaking changes
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -280,6 +280,10 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     setupScrollable()
   }
 
+  fun setAbsoluteHeader(absolute: Boolean) {
+    viewController.absoluteHeader = absolute
+  }
+
   fun setFooterKeyboardOffset(offset: Float) {
     viewController.footerKeyboardOffset = offset.dpToPx().toInt()
     viewController.positionFooter()

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -281,6 +281,8 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   override val headerHeight: Int
     get() = containerView?.headerHeight ?: cachedHeaderHeight
 
+  override var absoluteHeader: Boolean = false
+
   override val footerHeight: Int
     get() = containerView?.footerHeight ?: cachedFooterHeight
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -225,6 +225,12 @@ class TrueSheetViewManager :
     view.setScrollableOptions(scrollableOptions)
   }
 
+  @ReactProp(name = "headerOptions")
+  override fun setHeaderOptions(view: TrueSheetView, options: ReadableMap?) {
+    val position = if (options != null && options.hasKey("position")) options.getString("position") else null
+    view.setAbsoluteHeader(position == "absolute")
+  }
+
   @ReactProp(name = "footerOptions")
   override fun setFooterOptions(view: TrueSheetView, options: ReadableMap?) {
     val keyboardOffset =

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
@@ -15,6 +15,7 @@ interface TrueSheetDetentCalculatorDelegate {
   val detents: MutableList<Double>
   val contentHeight: Int
   val headerHeight: Int
+  val absoluteHeader: Boolean
   val footerHeight: Int
   val peekContentHeight: Int
   val contentBottomInset: Int
@@ -33,12 +34,20 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
   private val realScreenHeight: Int get() = delegate?.realScreenHeight ?: 0
   private val detents: List<Double> get() = delegate?.detents ?: emptyList()
   private val contentHeight: Int get() = delegate?.contentHeight ?: 0
+
   private val headerHeight: Int get() = delegate?.headerHeight ?: 0
   private val footerHeight: Int get() = delegate?.footerHeight ?: 0
   private val peekContentHeight: Int get() = delegate?.peekContentHeight ?: 0
   private val contentBottomInset: Int get() = delegate?.contentBottomInset ?: 0
   private val maxContentHeight: Int? get() = delegate?.maxContentHeight
   private val keyboardInset: Int get() = delegate?.keyboardInset ?: 0
+
+  /**
+   * Height for auto (-1.0) detents: content + header height.
+   * An absolute (floating) header overlaps the content, so it contributes no height.
+   */
+  private val autoDetentHeight: Int
+    get() = contentHeight + if (delegate?.absoluteHeader == true) 0 else headerHeight
 
   /**
    * Height for peek (-2.0) detents: header + footer + peek content height.
@@ -56,7 +65,7 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
    */
   fun getDetentHeight(detent: Double, includeKeyboard: Boolean = true): Int {
     val baseHeight = if (detent == -1.0) {
-      contentHeight + headerHeight + contentBottomInset
+      autoDetentHeight + contentBottomInset
     } else if (detent == -2.0) {
       peekDetentHeight + contentBottomInset
     } else {
@@ -99,7 +108,7 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
     if (index < 0 || index >= detents.size) return 0f
     val value = detents[index]
     return if (value == -1.0) {
-      (contentHeight + headerHeight).toFloat() / screenHeight.toFloat()
+      autoDetentHeight.toFloat() / screenHeight.toFloat()
     } else if (value == -2.0) {
       peekDetentHeight.toFloat() / screenHeight.toFloat()
     } else {

--- a/docs/docs/guides/header.mdx
+++ b/docs/docs/guides/header.mdx
@@ -65,6 +65,32 @@ const App = () => {
 When using `header` with `FlatList` or `ScrollView`, the content area height is automatically adjusted to account for the header height. This ensures proper scrolling behavior on both iOS and Android.
 :::
 
+## Floating Header
+
+By default, the header takes up space above the content and its height is included in the [`auto`](../reference/types#sheetdetent) detent calculation. Set `headerOptions.position` to `'absolute'` to float the header over the content instead — it gets pinned to the top edge and no longer adds to the `auto` detent height.
+
+```tsx {5-5}
+const App = () => {
+  return (
+    <TrueSheet
+      detents={['auto']}
+      headerOptions={{ position: 'absolute' }}
+      header={<SearchBar />}
+    >
+      <FlatList
+        data={items}
+        contentContainerStyle={{ paddingTop: HEADER_HEIGHT }}
+        renderItem={({ item }) => <ItemRow item={item} />}
+      />
+    </TrueSheet>
+  )
+}
+```
+
+:::tip
+Since the header overlaps the content, add top padding to your content (e.g. `contentContainerStyle`) so it starts below the header.
+:::
+
 ## Collapsing to the Header
 
 Use the [`"peek"`](../reference/types#sheetdetent) detent to collapse the sheet down to just the header (plus [`footer`](footer), if provided). Great for map-style sheets with a compact summary that expands into full content.

--- a/docs/docs/reference/01-configuration.mdx
+++ b/docs/docs/reference/01-configuration.mdx
@@ -272,6 +272,14 @@ Style for the header container.
 | - | - | - | - | - |
 | `StyleProp<ViewStyle>` | | ✅ | ✅ | ✅ |
 
+## `headerOptions`
+
+Options for customizing header behavior.
+
+| Type | Default | 🍎 | 🤖 | 🌐 |
+| - | - | - | - | - |
+| [`HeaderOptions`](types#headeroptions) | | ✅ | ✅ | ✅ |
+
 ## `footer`
 
 A component that floats at the bottom of the sheet. Accepts a functional `Component` or `ReactElement`.

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -100,6 +100,25 @@ Options for customizing scrollable behavior. Applies when the sheet contains a `
 | `topScrollEdgeEffect` | [`ScrollEdgeEffect`](#scrolledgeeffect) | The scroll edge effect applied to the top edge of the scroll view and header. iOS 26+ only. | `'hidden'` |
 | `bottomScrollEdgeEffect` | [`ScrollEdgeEffect`](#scrolledgeeffect) | The scroll edge effect applied to the bottom edge of the scroll view and footer. iOS 26+ only. | `'hidden'` |
 
+## `HeaderOptions`
+
+Options for customizing header behavior.
+
+```tsx
+<TrueSheet
+  header={<Header />}
+  headerOptions={{
+    position: 'absolute',
+  }}
+>
+  {/* ... */}
+</TrueSheet>
+```
+
+| Property | Type | Description | Default |
+| - | - | - | - |
+| `position` | `'relative' \| 'absolute'` | How the header participates in the sheet layout. `'relative'` takes up space above the content and is included in the `auto` detent height. `'absolute'` floats over the content, pinned to the top edge, and is excluded from the `auto` detent height. | `'relative'` |
+
 ## `FooterOptions`
 
 Options for customizing footer behavior.

--- a/example/shared/src/components/sheets/BasicSheet.tsx
+++ b/example/shared/src/components/sheets/BasicSheet.tsx
@@ -173,7 +173,7 @@ const styles = StyleSheet.create({
     paddingTop: SPACING,
     paddingBottom: FOOTER_HEIGHT + SPACING,
     gap: GAP,
-  }
+  },
 });
 
 BasicSheet.displayName = 'BasicSheet';

--- a/example/shared/src/components/sheets/FlatListSheet.tsx
+++ b/example/shared/src/components/sheets/FlatListSheet.tsx
@@ -28,7 +28,7 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
         topScrollEdgeEffect: 'soft',
       }}
       header={<Header />}
-      headerStyle={styles.header}
+      headerOptions={{ position: 'absolute' }}
       onDidDismiss={() => console.log('Sheet FlatList dismissed!')}
       onDidPresent={() => console.log(`Sheet FlatList presented!`)}
       footer={
@@ -81,12 +81,6 @@ const styles = StyleSheet.create({
       default: DARK_GRAY,
       ios: undefined,
     }),
-  },
-  header: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    zIndex: 1,
   },
   content: {
     padding: SPACING,

--- a/example/shared/src/components/sheets/ScrollViewSheet.tsx
+++ b/example/shared/src/components/sheets/ScrollViewSheet.tsx
@@ -73,7 +73,7 @@ export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((prop
       }}
       backgroundColor={Platform.select({ android: DARK })}
       header={<Header />}
-      headerStyle={styles.header}
+      headerOptions={{ position: 'absolute' }}
       footer={
         <Footer wrapperStyle={styles.footer}>
           <Button text="Toggle ListView" onPress={() => setShowList(!showList)} />
@@ -115,12 +115,6 @@ const styles = StyleSheet.create({
     paddingTop: HEADER_HEIGHT + SPACING,
     paddingBottom: FOOTER_HEIGHT + SPACING,
     gap: GAP,
-  },
-  header: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    zIndex: 1,
   },
   footer: {
     backgroundColor: Platform.select({

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -265,6 +265,8 @@ using namespace facebook::react;
 
   _controller.scrollingExpandsSheet = scrollingExpandsSheet;
 
+  _controller.absoluteHeader = newProps.headerOptions.position == TrueSheetViewPosition::Absolute;
+
   CGFloat footerKeyboardOffset = newProps.footerOptions.keyboardOffset;
   if (_controller.footerKeyboardOffset != footerKeyboardOffset) {
     _controller.footerKeyboardOffset = footerKeyboardOffset;

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -57,6 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSNumber *maxContentWidth;
 @property (nonatomic, strong, nullable) NSNumber *contentHeight;
 @property (nonatomic, strong, nullable) NSNumber *headerHeight;
+@property (nonatomic, assign) BOOL absoluteHeader;
 @property (nonatomic, strong, nullable) NSNumber *footerHeight;
 @property (nonatomic, strong, nullable) NSNumber *peekContentHeight;
 @property (nonatomic, strong, nullable) UIColor *backgroundColor;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -850,7 +850,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
  */
 - (void)setupSheetDetentsForSizeChange {
   if (@available(iOS 16.0, *)) {
-    CGFloat autoHeight = [self.contentHeight floatValue] + [self.headerHeight floatValue];
+    CGFloat autoHeight = [_detentCalculator autoHeight];
     CGFloat peekHeight = [_detentCalculator peekHeight];
 
     if (fabs(autoHeight - _autoDetentHeight) < 0.5 && fabs(peekHeight - _peekDetentHeight) < 0.5) {
@@ -885,7 +885,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   NSMutableArray<UISheetPresentationControllerDetent *> *detents = [NSMutableArray array];
   [_detentCalculator clearResolvedHeights];
 
-  _autoDetentHeight = [self.contentHeight floatValue] + [self.headerHeight floatValue];
+  _autoDetentHeight = [_detentCalculator autoHeight];
   _peekDetentHeight = [_detentCalculator peekHeight];
 
   for (NSInteger index = 0; index < self.detents.count; index++) {

--- a/ios/core/TrueSheetDetentCalculator.h
+++ b/ios/core/TrueSheetDetentCalculator.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSArray<NSNumber *> *detents;
 @property (nonatomic, strong, readonly, nullable) NSNumber *contentHeight;
 @property (nonatomic, strong, readonly, nullable) NSNumber *headerHeight;
+@property (nonatomic, readonly) BOOL absoluteHeader;
 @property (nonatomic, strong, readonly, nullable) NSNumber *footerHeight;
 @property (nonatomic, strong, readonly, nullable) NSNumber *peekContentHeight;
 
@@ -41,6 +42,12 @@ NS_ASSUME_NONNULL_BEGIN
  For peek (-2) detents, calculates based on header + footer height.
  */
 - (CGFloat)detentValueForIndex:(NSInteger)index;
+
+/**
+ Returns the height for auto (-1) detents: content + header height.
+ An absolute (floating) header contributes no height.
+ */
+- (CGFloat)autoHeight;
 
 /**
  Returns the height for peek (-2) detents: header + footer + peek content height.

--- a/ios/core/TrueSheetDetentCalculator.mm
+++ b/ios/core/TrueSheetDetentCalculator.mm
@@ -19,8 +19,7 @@
   if (index >= 0 && index < (NSInteger)detents.count) {
     CGFloat value = [detents[index] doubleValue];
     if (value == -1) {
-      CGFloat autoHeight = [self.delegate.contentHeight floatValue] + [self.delegate.headerHeight floatValue];
-      return autoHeight / self.delegate.screenHeight;
+      return [self autoHeight] / self.delegate.screenHeight;
     }
     if (value == -2) {
       return [self peekHeight] / self.delegate.screenHeight;
@@ -28,6 +27,12 @@
     return value;
   }
   return 0;
+}
+
+- (CGFloat)autoHeight {
+  // An absolute (floating) header overlaps the content, so it contributes no height
+  CGFloat headerHeight = self.delegate.absoluteHeader ? 0 : [self.delegate.headerHeight floatValue];
+  return [self.delegate.contentHeight floatValue] + headerHeight;
 }
 
 - (CGFloat)peekHeight {

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -464,6 +464,7 @@ export class TrueSheet
       style,
       header,
       headerStyle,
+      headerOptions,
       footer,
       footerStyle,
       insetAdjustment = 'automatic',
@@ -514,6 +515,7 @@ export class TrueSheet
         anchor={anchor}
         anchorOffset={anchorOffset}
         scrollableOptions={scrollableOptions}
+        headerOptions={headerOptions}
         footerOptions={footerOptions}
         presentation={presentation}
         insetAdjustment={insetAdjustment}
@@ -536,7 +538,13 @@ export class TrueSheet
         {this.state.shouldRenderNativeView && (
           <TrueSheetContainerViewNativeComponent style={styles.container}>
             {header && (
-              <TrueSheetHeaderViewNativeComponent style={[styles.header, headerStyle]}>
+              <TrueSheetHeaderViewNativeComponent
+                style={[
+                  styles.header,
+                  headerOptions?.position === 'absolute' && styles.absoluteHeader,
+                  headerStyle,
+                ]}
+              >
                 {isValidElement(header) ? header : createElement(header)}
               </TrueSheetHeaderViewNativeComponent>
             )}
@@ -570,6 +578,14 @@ const styles = StyleSheet.create({
   },
   header: {
     pointerEvents: 'box-none',
+  },
+  // Floats over the content so it doesn't take up layout space
+  absoluteHeader: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 1,
   },
   // Pinned to the sheet's bottom edge via Yoga since the container tracks the
   // sheet's visible height

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -133,6 +133,23 @@ export interface ScrollableOptions {
 }
 
 /**
+ * Options for header behavior
+ */
+export interface HeaderOptions {
+  /**
+   * How the header participates in the sheet layout.
+   *
+   * - `'relative'`: The header takes up space above the content, and its height
+   *   is included in the `auto` detent calculation.
+   * - `'absolute'`: The header floats over the content, pinned to the top edge,
+   *   and is excluded from the `auto` detent calculation.
+   *
+   * @default 'relative'
+   */
+  position?: 'relative' | 'absolute';
+}
+
+/**
  * Options for footer behavior
  */
 export interface FooterOptions {
@@ -449,6 +466,11 @@ export interface TrueSheetProps extends ViewProps {
    * Style for the header container.
    */
   headerStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * Options for header behavior.
+   */
+  headerOptions?: HeaderOptions;
 
   /**
    * A component that floats at the bottom of the Sheet.

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -86,6 +86,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     initialDetentIndex = -1,
     header,
     headerStyle,
+    headerOptions,
     footer,
     footerStyle,
     presentation = 'page',
@@ -271,6 +272,14 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   const peekElRef = useRef<View>(null);
   const peekContext = useMemo(() => ({ contentRef, peekRef: peekElRef, setPeekContentHeight }), []);
 
+  // An absolute (floating) header overlaps the content, so it contributes no
+  // height to the 'auto' detent measurement.
+  const absoluteHeader = headerOptions?.position === 'absolute';
+  const absoluteHeaderRef = useRef(absoluteHeader);
+  absoluteHeaderRef.current = absoluteHeader;
+
+  const resolvedHeaderStyle = absoluteHeader ? [absoluteHeaderStyle, headerStyle] : headerStyle;
+
   const peekHeight =
     (header ? headerHeight : 0) + (footer ? footerHeight : 0) + peekContentHeight ||
     DEFAULT_PEEK_HEIGHT;
@@ -290,7 +299,9 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   const measureNaturalHeight = useCallback(() => {
     const contentEl = contentRef.current as unknown as HTMLElement | null;
     if (!contentEl || !contentEl.isConnected) return 0;
-    const headerEl = headerElRef.current as unknown as HTMLElement | null;
+    const headerEl = absoluteHeaderRef.current
+      ? null
+      : (headerElRef.current as unknown as HTMLElement | null);
     let height = (headerEl?.offsetHeight ?? 0) + contentEl.offsetHeight;
     const scroller = pinnedScrollerRef.current;
     const scrollContent = scroller?.firstElementChild;
@@ -1169,7 +1180,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
                 data-vaul-scroll-locked={isScrollLocked ? '' : undefined}
               >
                 {header && (
-                  <View ref={headerElRef} style={headerStyle} onLayout={handleHeaderLayout}>
+                  <View ref={headerElRef} style={resolvedHeaderStyle} onLayout={handleHeaderLayout}>
                     {isValidElement(header) ? header : createElement(header)}
                   </View>
                 )}
@@ -1189,7 +1200,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
               // 'auto' detents and form-sheet content-fit sizing.
               <>
                 {header && (
-                  <View ref={headerElRef} style={headerStyle} onLayout={handleHeaderLayout}>
+                  <View ref={headerElRef} style={resolvedHeaderStyle} onLayout={handleHeaderLayout}>
                     {isValidElement(header) ? header : createElement(header)}
                   </View>
                 )}
@@ -1210,6 +1221,15 @@ const overlayStyle: React.CSSProperties = {
   inset: 0,
   backgroundColor: 'rgba(0, 0, 0, 0.5)',
 };
+
+// Floats over the content so it doesn't take up layout space
+const absoluteHeaderStyle = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  zIndex: 1,
+} as const;
 
 const SIZED_LAYOUT_HEIGHT = 'calc(100% - var(--snap-point-height, 0px))';
 

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -34,6 +34,10 @@ type FooterOptionsType = Readonly<{
   keyboardOffset?: WithDefault<Double, 0>;
 }>;
 
+type HeaderOptionsType = Readonly<{
+  position?: WithDefault<'relative' | 'absolute', 'relative'>;
+}>;
+
 export interface DetentInfoEventPayload {
   index: Int32;
   position: Double;
@@ -104,6 +108,7 @@ export interface NativeProps extends ViewProps {
   dimmed?: WithDefault<boolean, true>;
   initialDetentAnimated?: WithDefault<boolean, true>;
   scrollableOptions?: ScrollableOptionsType;
+  headerOptions?: HeaderOptionsType;
   footerOptions?: FooterOptionsType;
   presentation?: WithDefault<'page' | 'form', 'page'>;
 


### PR DESCRIPTION
## Summary

Adds a new `headerOptions` prop with a `position` option (`'relative' | 'absolute'`, default `'relative'`).

When `'absolute'`, the header floats over the content — pinned to the top edge (`position: 'absolute', top: 0, left: 0, right: 0, zIndex: 1` applied automatically) and excluded from the `auto` detent height calculation. Previously this required manual `headerStyle` positioning, and the `auto` detent would still incorrectly include the header height.

`peek` detent calculation is unaffected — the header is always included there.

- **iOS**: `absoluteHeader` on controller/detent calculator; new `autoHeight` helper dedupes the `content + header` calc
- **Android**: `absoluteHeader` on detent calculator delegate; new `autoDetentHeight` used by `auto` branches
- **Web**: header excluded from natural height measurement when absolute
- Example `FlatListSheet` and `ScrollViewSheet` updated to use the new prop

## Type of Change

- [x] New feature

## Test Plan

- `yarn typecheck`, `yarn lint`, `yarn test` (44 passed), objclint/ktlint
- Example sheets (`FlatListSheet`, `ScrollViewSheet`) with `auto` detents and floating headers

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)