### PR TITLE
feat!: add footerOptions prop with relative footer position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💥 Breaking changes
 
-- The footer now lays out relative by default — it takes up space below the content (still pinned to the bottom edge) and its height is included in the `auto` detent calculation. Set the new `footerOptions.position` to `'absolute'` to restore the previous floating behavior. ([#748](https://github.com/lodev09/react-native-true-sheet/pull/748) by [@lodev09](https://github.com/lodev09))
+- The footer now lays out relative by default — it takes up space below the content (still pinned to the bottom edge) and its height is included in the `auto` detent calculation, but excluded from the `peek` detent (it's pushed off-screen at peek). Set the new `footerOptions.position` to `'absolute'` to restore the previous floating behavior. ([#748](https://github.com/lodev09/react-native-true-sheet/pull/748) by [@lodev09](https://github.com/lodev09))
 - Content now lays out naturally like a regular view or a react-navigation screen — it wraps its children's height by default instead of filling the sheet. Pass `flex: 1` via `style` to fill, and bound scrollables the same way (except `auto` detents, which stay auto-sized). ([#746](https://github.com/lodev09/react-native-true-sheet/pull/746) by [@lodev09](https://github.com/lodev09))
 - Synchronous per-detent container layout — the container is sized to the sheet's visible height per detent and tracks it in realtime while dragging, on all platforms (previously sized to the screen height / largest detent). The `scrollable` prop is removed — scrollables are auto-detected and work plugged in directly. Requires React Native 0.82+. ([#735](https://github.com/lodev09/react-native-true-sheet/pull/735) by [@lodev09](https://github.com/lodev09))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💥 Breaking changes
 
+- The footer now lays out relative by default — it takes up space below the content (still pinned to the bottom edge) and its height is included in the `auto` detent calculation. Set the new `footerOptions.position` to `'absolute'` to restore the previous floating behavior. ([#748](https://github.com/lodev09/react-native-true-sheet/pull/748) by [@lodev09](https://github.com/lodev09))
 - Content now lays out naturally like a regular view or a react-navigation screen — it wraps its children's height by default instead of filling the sheet. Pass `flex: 1` via `style` to fill, and bound scrollables the same way (except `auto` detents, which stay auto-sized). ([#746](https://github.com/lodev09/react-native-true-sheet/pull/746) by [@lodev09](https://github.com/lodev09))
 - Synchronous per-detent container layout — the container is sized to the sheet's visible height per detent and tracks it in realtime while dragging, on all platforms (previously sized to the screen height / largest detent). The `scrollable` prop is removed — scrollables are auto-detected and work plugged in directly. Requires React Native 0.82+. ([#735](https://github.com/lodev09/react-native-true-sheet/pull/735) by [@lodev09](https://github.com/lodev09))
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -284,6 +284,10 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     viewController.absoluteHeader = absolute
   }
 
+  fun setAbsoluteFooter(absolute: Boolean) {
+    viewController.absoluteFooter = absolute
+  }
+
   fun setFooterKeyboardOffset(offset: Float) {
     viewController.footerKeyboardOffset = offset.dpToPx().toInt()
     viewController.positionFooter()

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -286,6 +286,8 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   override val footerHeight: Int
     get() = containerView?.footerHeight ?: cachedFooterHeight
 
+  override var absoluteFooter: Boolean = false
+
   override val peekContentHeight: Int
     get() = containerView?.peekContentHeight ?: cachedPeekContentHeight
 
@@ -992,11 +994,19 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     val footerView = containerView?.footerView ?: return
     val sheet = sheetView ?: return
 
+    val keyboardShift = if (currentKeyboardInset > 0) maxOf(0, currentKeyboardInset + footerKeyboardOffset) else 0
+
+    // A relative footer is laid out by Yoga (pinned to the container's bottom
+    // edge), so only the keyboard slide is carried via translation — like iOS
+    if (!absoluteFooter) {
+      footerView.translationY = -keyboardShift.toFloat()
+      return
+    }
+
     val footerHeight = footerView.height
     val sheetHeight = sheet.height
     val sheetTop = sheet.top
 
-    val keyboardShift = if (currentKeyboardInset > 0) maxOf(0, currentKeyboardInset + footerKeyboardOffset) else 0
     var footerY = (sheetHeight - sheetTop - footerHeight - keyboardShift).toFloat()
 
     // Adjust during dismiss animation when slideOffset is negative

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -233,6 +233,9 @@ class TrueSheetViewManager :
 
   @ReactProp(name = "footerOptions")
   override fun setFooterOptions(view: TrueSheetView, options: ReadableMap?) {
+    val position = if (options != null && options.hasKey("footerPosition")) options.getString("footerPosition") else null
+    view.setAbsoluteFooter(position == "absolute")
+
     val keyboardOffset =
       if (options != null && options.hasKey("keyboardOffset")) options.getDouble("keyboardOffset").toFloat() else 0f
     view.setFooterKeyboardOffset(keyboardOffset)

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
@@ -17,6 +17,7 @@ interface TrueSheetDetentCalculatorDelegate {
   val headerHeight: Int
   val absoluteHeader: Boolean
   val footerHeight: Int
+  val absoluteFooter: Boolean
   val peekContentHeight: Int
   val contentBottomInset: Int
   val maxContentHeight: Int?
@@ -43,11 +44,13 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
   private val keyboardInset: Int get() = delegate?.keyboardInset ?: 0
 
   /**
-   * Height for auto (-1.0) detents: content + header height.
-   * An absolute (floating) header overlaps the content, so it contributes no height.
+   * Height for auto (-1.0) detents: content + header + footer height.
+   * An absolute (floating) header or footer overlaps the content, so it contributes no height.
    */
   private val autoDetentHeight: Int
-    get() = contentHeight + if (delegate?.absoluteHeader == true) 0 else headerHeight
+    get() = contentHeight +
+      (if (delegate?.absoluteHeader == true) 0 else headerHeight) +
+      (if (delegate?.absoluteFooter == true) 0 else footerHeight)
 
   /**
    * Height for peek (-2.0) detents: header + footer + peek content height.

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
@@ -54,11 +54,14 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
 
   /**
    * Height for peek (-2.0) detents: header + footer + peek content height.
+   * A relative footer is pushed off-screen at peek, so it contributes no height.
    * Falls back to 150dp when none is present.
    */
   private val peekDetentHeight: Int
     get() {
-      val height = headerHeight + footerHeight + peekContentHeight
+      val height = headerHeight +
+        (if (delegate?.absoluteFooter == true) footerHeight else 0) +
+        peekContentHeight
       return if (height > 0) height else DEFAULT_PEEK_HEIGHT.dpToPx().toInt()
     }
 

--- a/docs/docs/guides/footer.mdx
+++ b/docs/docs/guides/footer.mdx
@@ -124,15 +124,16 @@ A relative footer is laid out below the content — if your content is taller th
 
 ## Collapsing to the Footer
 
-The footer height counts toward the [`"peek"`](../reference/types#sheetdetent) detent — collapse the sheet down to just the [`header`](header), footer, and any peeking content.
+An **absolute** footer's height counts toward the [`"peek"`](../reference/types#sheetdetent) detent — collapse the sheet down to just the [`header`](header), footer, and any peeking content.
 
-```tsx {4-4}
+```tsx {4-6}
 const App = () => {
   return (
     <TrueSheet
       detents={['peek', 0.9]}
       initialDetentIndex={0}
       footer={<SheetActions />}
+      footerOptions={{ position: 'absolute' }}
     >
       <BookingDetails />
     </TrueSheet>
@@ -140,4 +141,4 @@ const App = () => {
 }
 ```
 
-Since the footer is pinned to the bottom edge, it stays visible at every detent. See [Peeking Content](peeking) for the full guide.
+Since an absolute footer floats over the content, it stays visible at every detent. A relative footer is laid out below the content, so it's pushed off-screen at the peek detent and is excluded from the peek height. See [Peeking Content](peeking) for the full guide.

--- a/docs/docs/guides/footer.mdx
+++ b/docs/docs/guides/footer.mdx
@@ -1,12 +1,12 @@
 ---
 title: Adding Footer
-description: Add a floating footer component to the bottom sheet.
+description: Add a footer component pinned to the bottom of the sheet.
 keywords: [bottom sheet footer, bottom sheet floating footer, bottom sheet sticky footer]
 ---
 
-Do you need a FAB (Floating Action Button) on the sheet? Or perhaps a small banner at the bottom? We've got you covered!
+Do you need action buttons on the sheet? Or perhaps a small banner at the bottom? We've got you covered!
 
-`TrueSheet` provides first-class support for a `Footer` component. This component will float at the bottom of the sheet.
+`TrueSheet` provides first-class support for a `Footer` component. The footer is pinned to the bottom of the sheet, takes up space below the content, and its height is included in the [`auto`](../reference/types#sheetdetent) detent calculation.
 
 ## How?
 
@@ -92,6 +92,36 @@ When the keyboard opens, that bottom padding leaves a gap above the keyboard. Pa
 On iPad, the sheet is displayed as a floating modal, so bottom padding is not needed.
 :::
 
+## Floating Footer
+
+By default, the footer takes up space below the content and its height is included in the [`auto`](../reference/types#sheetdetent) detent calculation. Set `footerOptions.position` to `'absolute'` to float the footer over the content instead — it stays pinned to the bottom edge but no longer adds to the `auto` detent height.
+
+```tsx {5-5}
+const App = () => {
+  return (
+    <TrueSheet
+      detents={['auto']}
+      footerOptions={{ position: 'absolute' }}
+      footer={<Fab />}
+    >
+      <FlatList
+        data={items}
+        contentContainerStyle={{ paddingBottom: FOOTER_HEIGHT }}
+        renderItem={({ item }) => <ItemRow item={item} />}
+      />
+    </TrueSheet>
+  )
+}
+```
+
+:::tip
+Since the footer overlaps the content, add bottom padding to your content (e.g. `contentContainerStyle`) so it ends above the footer.
+:::
+
+:::info
+A relative footer is laid out below the content — if your content is taller than the sheet's visible height (e.g. fixed detents), bound it with `flex: 1` so the footer stays visible. Use `'absolute'` if you want the footer to float regardless of the content's height.
+:::
+
 ## Collapsing to the Footer
 
 The footer height counts toward the [`"peek"`](../reference/types#sheetdetent) detent — collapse the sheet down to just the [`header`](header), footer, and any peeking content.
@@ -110,4 +140,4 @@ const App = () => {
 }
 ```
 
-Since the footer floats, it stays visible at every detent. See [Peeking Content](peeking) for the full guide.
+Since the footer is pinned to the bottom edge, it stays visible at every detent. See [Peeking Content](peeking) for the full guide.

--- a/docs/docs/guides/header.mdx
+++ b/docs/docs/guides/header.mdx
@@ -93,7 +93,7 @@ Since the header overlaps the content, add top padding to your content (e.g. `co
 
 ## Collapsing to the Header
 
-Use the [`"peek"`](../reference/types#sheetdetent) detent to collapse the sheet down to just the header (plus [`footer`](footer), if provided). Great for map-style sheets with a compact summary that expands into full content.
+Use the [`"peek"`](../reference/types#sheetdetent) detent to collapse the sheet down to just the header (plus an [absolute `footer`](footer#floating-footer), if provided). Great for map-style sheets with a compact summary that expands into full content.
 
 ```tsx {4-4}
 const App = () => {
@@ -103,6 +103,7 @@ const App = () => {
       initialDetentIndex={0}
       header={<BookingSummary />}
       footer={<SheetActions />}
+      footerOptions={{ position: 'absolute' }}
     >
       <BookingDetails />
     </TrueSheet>

--- a/docs/docs/guides/peeking.mdx
+++ b/docs/docs/guides/peeking.mdx
@@ -8,7 +8,7 @@ Building a map-style sheet with a compact summary that expands into full content
 
 ## The `"peek"` Detent
 
-Add `"peek"` to your [`detents`](../reference/configuration#detents) to get a collapsed size based on the measured [`header`](header) and [`footer`](footer) heights.
+Add `"peek"` to your [`detents`](../reference/configuration#detents) to get a collapsed size based on the measured [`header`](header) height, plus an [absolute footer](footer#floating-footer) if provided — a relative footer is laid out below the content, so it's pushed off-screen at peek and doesn't count.
 
 ```tsx {4-4}
 const App = () => {
@@ -18,6 +18,7 @@ const App = () => {
       initialDetentIndex={0}
       header={<BookingSummary />}
       footer={<SheetActions />}
+      footerOptions={{ position: 'absolute' }}
     >
       <BookingDetails />
     </TrueSheet>
@@ -25,7 +26,7 @@ const App = () => {
 }
 ```
 
-The peek height automatically follows the measured header and footer sizes. When neither `header` nor `footer` is provided, it falls back to a fixed height of `150`.
+The peek height automatically follows the measured header and footer sizes. When no `header`, absolute `footer`, or peeking content is provided, it falls back to a fixed height of `150`.
 
 ## Peeking Part of the Content
 

--- a/docs/docs/reference/01-configuration.mdx
+++ b/docs/docs/reference/01-configuration.mdx
@@ -282,7 +282,7 @@ Options for customizing header behavior.
 
 ## `footer`
 
-A component that floats at the bottom of the sheet. Accepts a functional `Component` or `ReactElement`.
+A component that is pinned at the bottom of the sheet. The footer height is automatically accounted for in layout calculations. Accepts a functional `Component` or `ReactElement`. See [this guide](../guides/footer) for example.
 
 | Type | Default | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |
@@ -302,7 +302,7 @@ Options for customizing footer behavior.
 
 | Type | Default | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |
-| [`FooterOptions`](types#footeroptions) | | ✅ | ✅ | |
+| [`FooterOptions`](types#footeroptions) | | ✅ | ✅ | ✅ |
 
 ## `scrollableOptions`
 

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -15,7 +15,7 @@ keywords: [bottom sheet types, bottom sheet typescript, bottom sheet definitions
 | Value | Description | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |
 | `"auto"` | Auto resize based on content height. | **_16+_** | ✅ | ✅ |
-| `"peek"` | Collapsed height based on the combined [`header`](configuration#header) and [`footer`](configuration#footer) heights, plus the content up to the bottom of a [`TrueSheetPeek`](../guides/peeking) component rendered within it. Falls back to a fixed height of `150` when none is provided. | **_16+_** | ✅ | ✅ |
+| `"peek"` | Collapsed height based on the combined [`header`](configuration#header) and absolute [`footer`](configuration#footer) heights, plus the content up to the bottom of a [`TrueSheetPeek`](../guides/peeking) component rendered within it. Falls back to a fixed height of `150` when none is provided. | **_16+_** | ✅ | ✅ |
 | `number` | Fractional height (0-1) representing percentage of screen height. | ✅ | ✅ | ✅ |
 
 :::info
@@ -137,7 +137,7 @@ Options for customizing footer behavior.
 
 | Property | Type | Description | Default |
 | - | - | - | - |
-| `position` | `'relative' \| 'absolute'` | How the footer participates in the sheet layout. `'relative'` takes up space below the content, pinned to the bottom edge, and is included in the `auto` detent height. `'absolute'` floats over the content, pinned to the bottom edge, and is excluded from the `auto` detent height. | `'relative'` |
+| `position` | `'relative' \| 'absolute'` | How the footer participates in the sheet layout. `'relative'` takes up space below the content, pinned to the bottom edge — included in the `auto` detent height but excluded from the `peek` detent height (it's pushed off-screen at peek). `'absolute'` floats over the content, pinned to the bottom edge — excluded from the `auto` detent height but included in the `peek` detent height. | `'relative'` |
 | `keyboardOffset` | `number` | Adjusts how far the footer rises when the keyboard opens. Positive values raise it higher; pass `-insets.bottom` to tuck its safe-area padding behind the keyboard instead of leaving a gap. | `0` |
 
 ## `ScrollEdgeEffect`

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -127,6 +127,7 @@ Options for customizing footer behavior.
 <TrueSheet
   footer={<Footer />}
   footerOptions={{
+    position: 'absolute',
     keyboardOffset: -insets.bottom,
   }}
 >
@@ -136,6 +137,7 @@ Options for customizing footer behavior.
 
 | Property | Type | Description | Default |
 | - | - | - | - |
+| `position` | `'relative' \| 'absolute'` | How the footer participates in the sheet layout. `'relative'` takes up space below the content, pinned to the bottom edge, and is included in the `auto` detent height. `'absolute'` floats over the content, pinned to the bottom edge, and is excluded from the `auto` detent height. | `'relative'` |
 | `keyboardOffset` | `number` | Adjusts how far the footer rises when the keyboard opens. Positive values raise it higher; pass `-insets.bottom` to tuck its safe-area padding behind the keyboard instead of leaving a gap. | `0` |
 
 ## `ScrollEdgeEffect`

--- a/example/shared/src/components/sheets/BasicSheet.tsx
+++ b/example/shared/src/components/sheets/BasicSheet.tsx
@@ -165,7 +165,6 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
 const styles = StyleSheet.create({
   content: {
     paddingHorizontal: SPACING,
-    paddingBottom: FOOTER_HEIGHT + SPACING,
     gap: GAP,
   },
   childContent: {

--- a/example/shared/src/components/sheets/FlatListSheet.tsx
+++ b/example/shared/src/components/sheets/FlatListSheet.tsx
@@ -38,6 +38,7 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
           onPress={() => testRef.current?.present()}
         />
       }
+      footerOptions={{ position: 'absolute' }}
       {...props}
     >
       <View style={styles.wrapper}>
@@ -47,7 +48,6 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
           contentContainerStyle={styles.content}
           indicatorStyle="black"
           ItemSeparatorComponent={Spacer}
-          scrollIndicatorInsets={{ bottom: FOOTER_HEIGHT }}
           renderItem={({ item }) => <DemoContent color={DARK_GRAY} text={`Item #${item}`} />}
           ListFooterComponent={
             <>

--- a/example/shared/src/components/sheets/PromptSheet.tsx
+++ b/example/shared/src/components/sheets/PromptSheet.tsx
@@ -84,8 +84,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
       <ScrollView
         nestedScrollEnabled
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={[styles.content, { paddingBottom: FOOTER_HEIGHT + GAP + SPACING }]}
-        scrollIndicatorInsets={{ bottom: FOOTER_HEIGHT + GAP }}
+        contentContainerStyle={styles.content}
       >
         <Input
           ref={input1Ref}

--- a/example/shared/src/components/sheets/ScrollViewSheet.tsx
+++ b/example/shared/src/components/sheets/ScrollViewSheet.tsx
@@ -15,7 +15,6 @@ import {
   BORDER_RADIUS,
   DARK,
   DARK_GRAY,
-  FOOTER_HEIGHT,
   GAP,
   HEADER_HEIGHT,
   LIGHT_GRAY,
@@ -87,7 +86,6 @@ export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((prop
         <ScrollView
           contentContainerStyle={styles.content}
           indicatorStyle="black"
-          scrollIndicatorInsets={{ bottom: FOOTER_HEIGHT }}
           keyboardDismissMode="on-drag"
           refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
         >
@@ -113,7 +111,6 @@ const styles = StyleSheet.create({
   content: {
     padding: SPACING,
     paddingTop: HEADER_HEIGHT + SPACING,
-    paddingBottom: FOOTER_HEIGHT + SPACING,
     gap: GAP,
   },
   footer: {

--- a/example/shared/src/components/sheets/ScrollViewSheet.tsx
+++ b/example/shared/src/components/sheets/ScrollViewSheet.tsx
@@ -78,6 +78,7 @@ export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((prop
           <Button text="Toggle ListView" onPress={() => setShowList(!showList)} />
         </Footer>
       }
+      footerOptions={{ position: 'absolute' }}
       onDidDismiss={() => console.log('Sheet ScrollView dismissed!')}
       onDidPresent={() => console.log(`Sheet ScrollView presented!`)}
       {...props}

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -266,6 +266,7 @@ using namespace facebook::react;
   _controller.scrollingExpandsSheet = scrollingExpandsSheet;
 
   _controller.absoluteHeader = newProps.headerOptions.position == TrueSheetViewPosition::Absolute;
+  _controller.absoluteFooter = newProps.footerOptions.footerPosition == TrueSheetViewFooterPosition::Absolute;
 
   CGFloat footerKeyboardOffset = newProps.footerOptions.keyboardOffset;
   if (_controller.footerKeyboardOffset != footerKeyboardOffset) {

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -59,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSNumber *headerHeight;
 @property (nonatomic, assign) BOOL absoluteHeader;
 @property (nonatomic, strong, nullable) NSNumber *footerHeight;
+@property (nonatomic, assign) BOOL absoluteFooter;
 @property (nonatomic, strong, nullable) NSNumber *peekContentHeight;
 @property (nonatomic, strong, nullable) UIColor *backgroundColor;
 @property (nonatomic, strong, nullable) NSNumber *cornerRadius;

--- a/ios/core/TrueSheetDetentCalculator.h
+++ b/ios/core/TrueSheetDetentCalculator.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly, nullable) NSNumber *headerHeight;
 @property (nonatomic, readonly) BOOL absoluteHeader;
 @property (nonatomic, strong, readonly, nullable) NSNumber *footerHeight;
+@property (nonatomic, readonly) BOOL absoluteFooter;
 @property (nonatomic, strong, readonly, nullable) NSNumber *peekContentHeight;
 
 @end
@@ -44,8 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (CGFloat)detentValueForIndex:(NSInteger)index;
 
 /**
- Returns the height for auto (-1) detents: content + header height.
- An absolute (floating) header contributes no height.
+ Returns the height for auto (-1) detents: content + header + footer height.
+ An absolute (floating) header or footer contributes no height.
  */
 - (CGFloat)autoHeight;
 

--- a/ios/core/TrueSheetDetentCalculator.h
+++ b/ios/core/TrueSheetDetentCalculator.h
@@ -52,6 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Returns the height for peek (-2) detents: header + footer + peek content height.
+ A relative footer is pushed off-screen at peek, so it contributes no height.
  Falls back to 150 when none is present — matches the iOS 26
  floating small-detent threshold.
  */

--- a/ios/core/TrueSheetDetentCalculator.mm
+++ b/ios/core/TrueSheetDetentCalculator.mm
@@ -30,9 +30,10 @@
 }
 
 - (CGFloat)autoHeight {
-  // An absolute (floating) header overlaps the content, so it contributes no height
+  // An absolute (floating) header or footer overlaps the content, so it contributes no height
   CGFloat headerHeight = self.delegate.absoluteHeader ? 0 : [self.delegate.headerHeight floatValue];
-  return [self.delegate.contentHeight floatValue] + headerHeight;
+  CGFloat footerHeight = self.delegate.absoluteFooter ? 0 : [self.delegate.footerHeight floatValue];
+  return [self.delegate.contentHeight floatValue] + headerHeight + footerHeight;
 }
 
 - (CGFloat)peekHeight {

--- a/ios/core/TrueSheetDetentCalculator.mm
+++ b/ios/core/TrueSheetDetentCalculator.mm
@@ -37,8 +37,11 @@
 }
 
 - (CGFloat)peekHeight {
-  CGFloat height = [self.delegate.headerHeight floatValue] + [self.delegate.footerHeight floatValue] +
-                   [self.delegate.peekContentHeight floatValue];
+  // A relative footer is laid out below the content, so it's pushed off-screen
+  // at the peek detent and contributes no height
+  CGFloat footerHeight = self.delegate.absoluteFooter ? [self.delegate.footerHeight floatValue] : 0;
+  CGFloat height =
+    [self.delegate.headerHeight floatValue] + footerHeight + [self.delegate.peekContentHeight floatValue];
   return height > 0 ? height : 150;
 }
 

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -516,7 +516,10 @@ export class TrueSheet
         anchorOffset={anchorOffset}
         scrollableOptions={scrollableOptions}
         headerOptions={headerOptions}
-        footerOptions={footerOptions}
+        footerOptions={{
+          footerPosition: footerOptions?.position,
+          keyboardOffset: footerOptions?.keyboardOffset,
+        }}
         presentation={presentation}
         insetAdjustment={insetAdjustment}
         onMount={this.onMount}
@@ -552,7 +555,15 @@ export class TrueSheet
               {children}
             </TrueSheetContentViewNativeComponent>
             {footer && (
-              <TrueSheetFooterViewNativeComponent style={[styles.footer, footerStyle]}>
+              <TrueSheetFooterViewNativeComponent
+                style={[
+                  styles.footer,
+                  footerOptions?.position === 'absolute'
+                    ? styles.absoluteFooter
+                    : styles.relativeFooter,
+                  footerStyle,
+                ]}
+              >
                 {isValidElement(footer) ? footer : createElement(footer)}
               </TrueSheetFooterViewNativeComponent>
             )}
@@ -587,10 +598,16 @@ const styles = StyleSheet.create({
     right: 0,
     zIndex: 1,
   },
-  // Pinned to the sheet's bottom edge via Yoga since the container tracks the
-  // sheet's visible height
   footer: {
     pointerEvents: 'box-none',
+  },
+  // Pinned to the sheet's bottom edge via Yoga since the container tracks the
+  // sheet's visible height — takes up layout space below the content
+  relativeFooter: {
+    marginTop: 'auto',
+  },
+  // Floats over the content so it doesn't take up layout space
+  absoluteFooter: {
     position: 'absolute',
     left: 0,
     right: 0,

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -154,6 +154,18 @@ export interface HeaderOptions {
  */
 export interface FooterOptions {
   /**
+   * How the footer participates in the sheet layout.
+   *
+   * - `'relative'`: The footer takes up space below the content, pinned to the
+   *   bottom edge, and its height is included in the `auto` detent calculation.
+   * - `'absolute'`: The footer floats over the content, pinned to the bottom
+   *   edge, and is excluded from the `auto` detent calculation.
+   *
+   * @default 'relative'
+   */
+  position?: 'relative' | 'absolute';
+
+  /**
    * Adjusts how far the footer rises when the keyboard opens.
    * Positive values raise it higher; negative values reduce the rise.
    * Pass `-insets.bottom` to tuck the footer's safe-area padding behind the keyboard.

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -157,9 +157,11 @@ export interface FooterOptions {
    * How the footer participates in the sheet layout.
    *
    * - `'relative'`: The footer takes up space below the content, pinned to the
-   *   bottom edge, and its height is included in the `auto` detent calculation.
+   *   bottom edge. Its height is included in the `auto` detent calculation but
+   *   excluded from the `peek` detent (it's pushed off-screen at peek).
    * - `'absolute'`: The footer floats over the content, pinned to the bottom
-   *   edge, and is excluded from the `auto` detent calculation.
+   *   edge. Its height is excluded from the `auto` detent calculation but
+   *   included in the `peek` detent.
    *
    * @default 'relative'
    */

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -89,6 +89,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     headerOptions,
     footer,
     footerStyle,
+    footerOptions,
     presentation = 'page',
     detached = false,
     detachedOffset = DEFAULT_DETACHED_OFFSET,
@@ -280,6 +281,12 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
 
   const resolvedHeaderStyle = absoluteHeader ? [absoluteHeaderStyle, headerStyle] : headerStyle;
 
+  // Same for an absolute (floating) footer — rendered via vaul's
+  // `detachedSiblings` instead of in the content flow.
+  const absoluteFooter = footerOptions?.position === 'absolute';
+  const absoluteFooterRef = useRef(absoluteFooter);
+  absoluteFooterRef.current = absoluteFooter;
+
   const peekHeight =
     (header ? headerHeight : 0) + (footer ? footerHeight : 0) + peekContentHeight ||
     DEFAULT_PEEK_HEIGHT;
@@ -293,16 +300,20 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   const [scrollableAutoHeight, setScrollableAutoHeight] = useState(0);
   const pinnedScrollerRef = useRef<HTMLElement | null>(null);
 
-  // Natural content height (header + content, with a pinned scrollable's
-  // viewport replaced by its content size) — the height the content wants
-  // regardless of the sheet's bounds.
+  // Natural content height (header + content + footer, with a pinned
+  // scrollable's viewport replaced by its content size) — the height the
+  // content wants regardless of the sheet's bounds.
   const measureNaturalHeight = useCallback(() => {
     const contentEl = contentRef.current as unknown as HTMLElement | null;
     if (!contentEl || !contentEl.isConnected) return 0;
     const headerEl = absoluteHeaderRef.current
       ? null
       : (headerElRef.current as unknown as HTMLElement | null);
-    let height = (headerEl?.offsetHeight ?? 0) + contentEl.offsetHeight;
+    const footerEl = absoluteFooterRef.current
+      ? null
+      : (footerElRef.current as unknown as HTMLElement | null);
+    let height =
+      (headerEl?.offsetHeight ?? 0) + (footerEl?.offsetHeight ?? 0) + contentEl.offsetHeight;
     const scroller = pinnedScrollerRef.current;
     const scrollContent = scroller?.firstElementChild;
     if (scroller?.isConnected && scrollContent instanceof HTMLElement) {
@@ -1156,7 +1167,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
             style={mergedContentStyle}
             onPointerDownOutside={handlePointerDownOutside}
             detachedSiblings={
-              footer ? (
+              footer && absoluteFooter ? (
                 <div style={footerFloatStyle}>
                   <View ref={footerElRef} style={footerStyle} onLayout={handleFooterLayout}>
                     {isValidElement(footer) ? footer : createElement(footer)}
@@ -1194,6 +1205,15 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
                 >
                   {children}
                 </View>
+                {footer && !absoluteFooter && (
+                  <View
+                    ref={footerElRef}
+                    style={[relativeFooterStyle, footerStyle]}
+                    onLayout={handleFooterLayout}
+                  >
+                    {isValidElement(footer) ? footer : createElement(footer)}
+                  </View>
+                )}
               </div>
             ) : (
               // Natural flow so vaul can measure content height — required for
@@ -1207,6 +1227,11 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
                 <View ref={contentRef} style={style}>
                   {children}
                 </View>
+                {footer && !absoluteFooter && (
+                  <View ref={footerElRef} style={footerStyle} onLayout={handleFooterLayout}>
+                    {isValidElement(footer) ? footer : createElement(footer)}
+                  </View>
+                )}
               </>
             )}
           </Drawer.Content>
@@ -1221,6 +1246,11 @@ const overlayStyle: React.CSSProperties = {
   inset: 0,
   backgroundColor: 'rgba(0, 0, 0, 0.5)',
 };
+
+// Pinned to the sheet's bottom edge — takes up layout space below the content
+const relativeFooterStyle = {
+  marginTop: 'auto',
+} as const;
 
 // Floats over the content so it doesn't take up layout space
 const absoluteHeaderStyle = {

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -287,9 +287,12 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   const absoluteFooterRef = useRef(absoluteFooter);
   absoluteFooterRef.current = absoluteFooter;
 
+  // A relative footer is laid out below the content, so it's pushed off-screen
+  // at the peek detent and contributes no height.
   const peekHeight =
-    (header ? headerHeight : 0) + (footer ? footerHeight : 0) + peekContentHeight ||
-    DEFAULT_PEEK_HEIGHT;
+    (header ? headerHeight : 0) +
+      (footer && absoluteFooter ? footerHeight : 0) +
+      peekContentHeight || DEFAULT_PEEK_HEIGHT;
 
   // Web mirror of native's scrollable handling for 'auto' detents: a plugged
   // scrollable keeps the sized (bounded) layout so its viewport is capped to
@@ -500,7 +503,10 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     // Geometry only runs while the drawer is mounted, so the elements are
     // measurable here; fall back to the state value when they're absent.
     const headerEl = headerElRef.current as unknown as HTMLElement | null;
-    const footerEl = footerElRef.current as unknown as HTMLElement | null;
+    // A relative footer is pushed off-screen at the peek detent — excluded
+    const footerEl = absoluteFooterRef.current
+      ? (footerElRef.current as unknown as HTMLElement | null)
+      : null;
     const peekEl = peekElRef.current as unknown as HTMLElement | null;
     const contentEl = contentRef.current as unknown as HTMLElement | null;
     const livePeekContentHeight =

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -31,6 +31,9 @@ type ScrollableOptionsType = Readonly<{
 }>;
 
 type FooterOptionsType = Readonly<{
+  // Named uniquely across option structs — codegen derives the enum name from
+  // the field name, so a second `position` would redefine TrueSheetViewPosition
+  footerPosition?: WithDefault<'relative' | 'absolute', 'relative'>;
   keyboardOffset?: WithDefault<Double, 0>;
 }>;
 


### PR DESCRIPTION
## Summary

The footer now lays out **relative** by default — it takes up space below the content (still pinned to the bottom edge via Yoga) and its height is included in the `auto` detent calculation, but excluded from the `peek` detent (it's pushed off-screen at peek). This is what most users expect: content is no longer overlapped by the footer, and no manual `paddingBottom` compensation is needed.

Set the new `footerOptions.position` to `'absolute'` to restore the previous floating behavior — mirrors `headerOptions.position` from #747.

- **JS**: relative footer uses `marginTop: 'auto'` so Yoga pins it to the container's bottom edge (the container tracks the sheet's visible height per detent)
- **iOS/Android**: `autoHeight` includes the footer when relative; `peekHeight` includes it only when absolute
- **Android**: skips manual footer floating (`positionFooter`) when relative — Yoga owns the frame; the keyboard slide is carried via `translationY` like iOS
- **Web**: relative footer renders in the content flow (absolute keeps vaul's `detachedSiblings` float); natural height and peek measurements updated
- Codegen note: the spec field is `footerPosition` — codegen derives the enum name from the field name, so a second `position` would redefine `TrueSheetViewPosition`

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update

## Test Plan

- `yarn typecheck`, `yarn test`, ktlint, objclint pass
- Example app: BasicSheet (relative footer with `peek`/`auto`/1 detents), PromptSheet (relative footer + keyboard), FlatListSheet/ScrollViewSheet (absolute footer)

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)