### PR TITLE
feat: relative footer owns the bottom inset for auto detent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **iOS**: `onPositionChange` now tracks the sheet's actual on-screen position everywhere — detent snaps, programmatic resizes, and sheets moving behind a child sheet emit realtime frames from a single native tracker (previously approximated with a JS-side spring or only emitted once settled). `onDetentChange` for programmatic resizes now fires when the animation actually ends instead of after a fixed delay. ([#744](https://github.com/lodev09/react-native-true-sheet/pull/744) by [@lodev09](https://github.com/lodev09))
 - The `auto` detent now works with plugged scrollables — the sheet sizes to the scrollable's content height and resizes as content grows or shrinks. ([#743](https://github.com/lodev09/react-native-true-sheet/pull/743) by [@lodev09](https://github.com/lodev09))
 - New `headerOptions` prop with a `position` option — set to `'absolute'` to float the header over the content (pinned to the top edge) and exclude it from the `auto` detent height. ([#747](https://github.com/lodev09/react-native-true-sheet/pull/747) by [@lodev09](https://github.com/lodev09))
+- A relative footer now owns the bottom safe-area inset at the `auto` detent — the inset is no longer added to the auto height, so the footer sits flush at the sheet's bottom edge (pad it yourself, e.g. for the home indicator). ([#749](https://github.com/lodev09/react-native-true-sheet/pull/749) by [@lodev09](https://github.com/lodev09))
 
 ### 💥 Breaking changes
 

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
@@ -53,6 +53,13 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
       (if (delegate?.absoluteFooter == true) 0 else footerHeight)
 
   /**
+   * Bottom inset for auto detents. A relative footer owns the sheet's bottom
+   * edge, so it absorbs the inset instead of adding it to the auto height.
+   */
+  private val autoDetentBottomInset: Int
+    get() = if (footerHeight > 0 && delegate?.absoluteFooter == false) 0 else contentBottomInset
+
+  /**
    * Height for peek (-2.0) detents: header + footer + peek content height.
    * A relative footer is pushed off-screen at peek, so it contributes no height.
    * Falls back to 150dp when none is present.
@@ -71,7 +78,7 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
    */
   fun getDetentHeight(detent: Double, includeKeyboard: Boolean = true): Int {
     val baseHeight = if (detent == -1.0) {
-      autoDetentHeight + contentBottomInset
+      autoDetentHeight + autoDetentBottomInset
     } else if (detent == -2.0) {
       peekDetentHeight + contentBottomInset
     } else {

--- a/example/shared/src/components/sheets/BasicSheet.tsx
+++ b/example/shared/src/components/sheets/BasicSheet.tsx
@@ -7,7 +7,7 @@ import {
   type TrueSheetProps,
 } from '@lodev09/react-native-true-sheet';
 
-import { BLUE, DARK, DARK_BLUE, FOOTER_HEIGHT, GAP, SPACING, times } from '../../utils';
+import { BLUE, DARK, DARK_BLUE, GAP, SPACING, times } from '../../utils';
 import { DemoContent } from '../DemoContent';
 import { Footer } from '../Footer';
 import { Button } from '../Button';
@@ -165,12 +165,11 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
 const styles = StyleSheet.create({
   content: {
     paddingHorizontal: SPACING,
+    paddingBottom: SPACING,
     gap: GAP,
   },
   childContent: {
-    paddingHorizontal: SPACING,
-    paddingTop: SPACING,
-    paddingBottom: FOOTER_HEIGHT + SPACING,
+    padding: SPACING,
     gap: GAP,
   },
 });

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -195,6 +195,10 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     return 0;
   }
 
+  return [self bottomSafeAreaForHeight:height];
+}
+
+- (CGFloat)bottomSafeAreaForHeight:(CGFloat)height {
   if (UIDevice.currentDevice.userInterfaceIdiom != UIUserInterfaceIdiomPhone) {
     return 0;
   }
@@ -209,6 +213,24 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
   UIWindow *window = [WindowUtil keyWindow];
   return window ? window.safeAreaInsets.bottom : 0;
+}
+
+/**
+ * Bottom inset excluded from the auto detent. A relative footer owns the
+ * sheet's bottom edge, so it absorbs the inset — UIKit lays custom detents out
+ * above the safe area, which would otherwise gap the content from the footer.
+ */
+- (CGFloat)autoDetentBottomInsetForHeight:(CGFloat)height {
+  if (_insetAdjustment != TrueSheetViewInsetAdjustment::Automatic) {
+    // 'none' already excludes the inset for every detent
+    return 0;
+  }
+
+  if (_absoluteFooter || [self.footerHeight floatValue] <= 0) {
+    return 0;
+  }
+
+  return [self bottomSafeAreaForHeight:height];
 }
 
 - (BOOL)isDesignCompatibilityMode {
@@ -933,7 +955,8 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
       return [self customDetentWithIdentifier:@"custom-auto"
                                       atIndex:index
                                   heightBlock:^CGFloat {
-                                    return self->_autoDetentHeight;
+                                    CGFloat height = self->_autoDetentHeight;
+                                    return height - [self autoDetentBottomInsetForHeight:height];
                                   }];
     } else {
       return [UISheetPresentationControllerDetent mediumDetent];


### PR DESCRIPTION
## Summary

Follow-up to #748. When a relative footer is present, the `auto` detent now excludes the bottom safe-area inset — the footer owns it.

Previously the inset was added on top of content + header + footer, leaving an inset-sized gap between the content and the footer (which is pinned to the sheet's bottom edge). Now the footer sits flush at the physical bottom and should account for the home indicator itself (e.g. its own bottom padding).

- **iOS**: the auto detent resolver subtracts the bottom safe area when `insetAdjustment` is `'automatic'` and a relative footer is present — UIKit lays custom detents out above the safe area, which produced the gap. `'none'` already excludes the inset for every detent, so nothing changes there.
- **Android**: `getDetentHeight` skips `contentBottomInset` for the auto detent when a relative footer is present.
- **Web**: no change needed — the auto measurement never included the inset.
- Absolute footers and sheets without a footer are unchanged (inset still applies).
- Example: BasicSheet drops the footer-height/inset padding workarounds.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Example app BasicSheet (relative footer): `auto` detent — no gap between content and footer, footer flush at the bottom edge; peek/large unchanged
- FlatListSheet/ScrollViewSheet (absolute footers): unchanged
- `insetAdjustment: 'none'`: unchanged

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)
