### PR TITLE
fix: keyboard scroll misses the bottom inset with a footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - A relative footer now owns the bottom safe-area inset at the `auto` detent — the inset is no longer added to the auto height, so the footer sits flush at the sheet's bottom edge. ([#749](https://github.com/lodev09/react-native-true-sheet/pull/749) by [@lodev09](https://github.com/lodev09))
 - The footer now absorbs the bottom safe-area inset as padding when `insetAdjustment` is `automatic`, regardless of `footerOptions.position` — content stays above the home indicator while the footer's background fills the inset, so no manual safe-area padding is needed. The inset is skipped while the keyboard is open. ([#750](https://github.com/lodev09/react-native-true-sheet/pull/750) by [@lodev09](https://github.com/lodev09))
 
+### 🐛 Bug fixes
+
+- The keyboard-driven scroll inset now accounts for an absolute footer's height — focused inputs clear both the keyboard and the footer instead of hiding behind it. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))
+
 ### 💥 Breaking changes
 
 - The footer now lays out relative by default — it takes up space below the content (still pinned to the bottom edge) and its height is included in the `auto` detent calculation, but excluded from the `peek` detent (it's pushed off-screen at peek). Set the new `footerOptions.position` to `'absolute'` to restore the previous floating behavior. ([#748](https://github.com/lodev09/react-native-true-sheet/pull/748) by [@lodev09](https://github.com/lodev09))

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
@@ -63,6 +63,7 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
 
   var insetAdjustment: TrueSheetInsetAdjustment = TrueSheetInsetAdjustment.AUTOMATIC
   var scrollViewBottomInset: Int = 0
+  var absoluteFooter: Boolean = false
 
   /**
    * Bottom safe-area inset the footer absorbs as padding — the footer
@@ -200,6 +201,9 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
     contentHeight = height
     delegate?.containerViewContentDidChangeSize(width, height)
   }
+
+  override val footerKeyboardOcclusion: Int
+    get() = if (absoluteFooter) footerView?.keyboardOcclusionHeight ?: 0 else 0
 
   override fun contentViewDidScroll() {
     delegate?.containerViewContentDidScroll()

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -29,6 +29,12 @@ interface TrueSheetContentViewDelegate {
   fun contentViewDidChangeSize(width: Int, height: Int)
   fun contentViewDidScroll()
   fun contentViewScrollViewDidChange()
+
+  /**
+   * Extra keyboard occlusion below the content — an absolute footer risen
+   * above the keyboard covers the content's bottom edge.
+   */
+  val footerKeyboardOcclusion: Int
 }
 
 /**
@@ -208,7 +214,7 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     // If keyboard is currently showing, re-apply the keyboard inset to the new ScrollView
     val keyboardHeight = keyboardObserver?.currentHeight ?: 0
     if (keyboardHeight > 0) {
-      setScrollViewPaddingBottom(originalScrollViewPaddingBottom + keyboardHeight)
+      updateScrollViewInsetForKeyboard(keyboardHeight)
     }
   }
 
@@ -324,7 +330,15 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
   private fun updateScrollViewInsetForKeyboard(keyboardHeight: Int) {
     val scrollView = pinnedScrollView ?: return
 
-    val totalBottomInset = if (keyboardHeight > 0) keyboardHeight else bottomInset
+    // An absolute footer rises above the keyboard and covers the content's
+    // bottom edge — include it so the caret clears the footer, not just the
+    // keyboard. A relative footer takes up layout space below the content,
+    // so the keyboard alone measures its occlusion.
+    val totalBottomInset = if (keyboardHeight > 0) {
+      keyboardHeight + (delegate?.footerKeyboardOcclusion ?: 0)
+    } else {
+      bottomInset
+    }
     setScrollViewPaddingBottom(originalScrollViewPaddingBottom + totalBottomInset)
 
     scrollView.post { nudgeScrollView() }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetFooterView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetFooterView.kt
@@ -58,6 +58,13 @@ class TrueSheetFooterView(private val reactContext: ThemedReactContext) :
     }
 
   /**
+   * Height the footer occupies above the keyboard — its layout height minus
+   * the safe-area inset it drops while the keyboard is open.
+   */
+  val keyboardOcclusionHeight: Int
+    get() = maxOf(0, height - if (keyboardVisible) 0 else bottomInset)
+
+  /**
    * Tells the shadow node to pad the footer's bottom edge with the sheet's
    * bottom safe-area inset — the footer owns the sheet's bottom edge, so it
    * absorbs the inset and its background fills it.

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -300,6 +300,7 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
       it.scrollableOptions = viewController.scrollableOptions
       it.hasAutoDetent = viewController.detents.contains(-1.0)
       it.footerBottomInset = viewController.contentBottomInset
+      it.absoluteFooter = viewController.absoluteFooter
       it.setupScrollable()
     }
   }

--- a/docs/docs/guides/keyboard.mdx
+++ b/docs/docs/guides/keyboard.mdx
@@ -54,7 +54,7 @@ This is especially useful for forms with multiple inputs — as the user taps be
 
 ## Footer Behavior
 
-When using a [`footer`](../reference/configuration#footer) component, it automatically repositions above the keyboard, staying visible while the user types.
+When using a [`footer`](../reference/configuration#footer) component, it automatically repositions above the keyboard, staying visible while the user types. With an absolute footer, the automatic scroll accounts for the footer's height — focused inputs clear both the keyboard and the footer.
 
 The footer's built-in [safe-area inset](./footer#safe-area-handling) is skipped while the keyboard is open — the footer hugs the keyboard with no gap, and the inset is restored when the keyboard hides.
 

--- a/example/shared/src/components/sheets/PromptSheet.tsx
+++ b/example/shared/src/components/sheets/PromptSheet.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useRef, type Ref, useImperativeHandle } from 'react';
-import { ScrollView, StyleSheet, TextInput, View } from 'react-native';
+import { ScrollView, StyleSheet, TextInput } from 'react-native';
 import { TrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
 
 import { DARK, BUTTON_HEIGHT as FOOTER_HEIGHT, GAP, SPACING } from '../../utils';
@@ -45,7 +45,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
       detents={[0.75, 1]}
       style={styles.sheet}
       scrollableOptions={{
-        keyboardScrollOffset: FOOTER_HEIGHT + SPACING,
+        keyboardScrollOffset: SPACING,
         topScrollEdgeEffect: 'soft',
         bottomScrollEdgeEffect: 'soft',
       }}
@@ -70,11 +70,12 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
       }}
       header={<Header />}
       footer={
-        <View style={styles.footer}>
+        <>
           <Button style={styles.button} text="Dismiss" onPress={handleDismissPress} />
           <Button style={styles.button} text="Submit" onPress={handleSubmitPress} />
-        </View>
+        </>
       }
+      footerStyle={styles.footer}
       footerOptions={{ position: 'absolute' }}
       {...props}
     >

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -198,6 +198,7 @@ using namespace facebook::react;
     }
     _contentView = (TrueSheetContentView *)childComponentView;
     _contentView.delegate = self;
+    _contentView.footerView = _footerView;
 
     // Children mount bottom-up, so the content subtree is complete here.
     // Late-mounted peek views attach themselves instead (see TrueSheetPeekView).
@@ -224,6 +225,7 @@ using namespace facebook::react;
     }
     _footerView = (TrueSheetFooterView *)childComponentView;
     _footerView.delegate = self;
+    _contentView.footerView = _footerView;
     [_footerView setBottomInset:_footerBottomInset];
     [self footerViewDidChangeSize:_footerView.frame.size];
   }
@@ -244,6 +246,7 @@ using namespace facebook::react;
   if ([childComponentView isKindOfClass:[TrueSheetFooterView class]]) {
     _footerView.delegate = nil;
     _footerView = nil;
+    _contentView.footerView = nil;
     [self footerViewDidChangeSize:CGSizeZero];
   }
 

--- a/ios/TrueSheetContentView.h
+++ b/ios/TrueSheetContentView.h
@@ -15,6 +15,7 @@
 #import "core/TrueSheetKeyboardObserver.h"
 
 @class TrueSheetViewController;
+@class TrueSheetFooterView;
 @class RCTScrollViewComponentView;
 @class ScrollableOptions;
 
@@ -32,6 +33,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, nullable) id<TrueSheetContentViewDelegate> delegate;
 @property (nonatomic, assign) CGFloat keyboardScrollOffset;
 @property (nonatomic, weak, nullable) TrueSheetKeyboardObserver *keyboardObserver;
+
+/**
+ * Sibling footer view — an absolute footer rises above the keyboard and
+ * occludes the content's bottom edge, so it counts toward the keyboard inset.
+ */
+@property (nonatomic, weak, nullable) TrueSheetFooterView *footerView;
 
 /**
  * Whether the sheet has an `auto` detent. Deriving the sheet height from the

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -16,6 +16,7 @@
 #import <react/renderer/components/TrueSheetSpec/TrueSheetContentViewComponentDescriptor.h>
 #import <react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.h>
 #import "TrueSheetContainerView.h"
+#import "TrueSheetFooterView.h"
 #import "TrueSheetView.h"
 #import "TrueSheetViewController.h"
 #import "utils/PlatformUtil.h"
@@ -235,8 +236,20 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
   // If keyboard is currently showing, re-apply the keyboard inset to the new ScrollView
   CGFloat keyboardHeight = _keyboardObserver ? _keyboardObserver.currentHeight : 0;
   if (keyboardHeight > 0) {
-    [self setScrollViewContentInset:keyboardHeight indicatorInset:_originalIndicatorBottomInset + keyboardHeight];
+    CGFloat inset = [self keyboardInsetWithHeight:keyboardHeight];
+    [self setScrollViewContentInset:inset indicatorInset:_originalIndicatorBottomInset + inset];
   }
+}
+
+// An absolute footer rises above the keyboard and covers the content's bottom
+// edge — include it so the caret clears the footer, not just the keyboard.
+// A relative footer takes up layout space below the content, so the keyboard
+// alone measures its occlusion.
+- (CGFloat)keyboardInsetWithHeight:(CGFloat)height {
+  if (_keyboardObserver.viewController.absoluteFooter && self.footerView) {
+    height += [self.footerView keyboardOcclusionHeight];
+  }
+  return height;
 }
 
 // Content growth is invisible to layout once the viewport is bounded, so track
@@ -357,12 +370,13 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
   TrueSheetViewController *sheetController = _keyboardObserver.viewController;
   UIView *firstResponder = sheetController ? [sheetController.view findFirstResponder] : nil;
 
+  CGFloat inset = [self keyboardInsetWithHeight:height];
   [UIView animateWithDuration:duration
                         delay:0
                       options:curve | UIViewAnimationOptionBeginFromCurrentState
                    animations:^{
-                     [self setScrollViewContentInset:height
-                                      indicatorInset:self->_originalIndicatorBottomInset + height];
+                     [self setScrollViewContentInset:inset
+                                      indicatorInset:self->_originalIndicatorBottomInset + inset];
                    }
                    completion:nil];
 

--- a/ios/TrueSheetFooterView.h
+++ b/ios/TrueSheetFooterView.h
@@ -39,6 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setBottomInset:(CGFloat)bottomInset;
 
+/**
+ * Height the footer occupies above the keyboard — its layout height minus
+ * the safe-area inset it drops while the keyboard is open.
+ */
+- (CGFloat)keyboardOcclusionHeight;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/TrueSheetFooterView.mm
+++ b/ios/TrueSheetFooterView.mm
@@ -79,7 +79,17 @@ using namespace facebook::react;
 
   TrueSheetFooterViewState newState;
   newState.bottomInset = _keyboardVisible ? 0 : _bottomInset;
-  _state->updateState(std::move(newState));
+  // Immediate so the inset lands before anything reads the footer's height —
+  // the async path races the keyboard caret scroll and detent setup, leaving
+  // them an inset stale (same reason Android bridges through
+  // TrueSheetStateUpdater).
+  _state->updateState(std::move(newState), EventQueue::UpdateMode::unstable_Immediate);
+}
+
+// Height the footer occupies above the keyboard — its layout height minus the
+// safe-area inset it drops while the keyboard is open.
+- (CGFloat)keyboardOcclusionHeight {
+  return MAX(0, _lastHeight - (_keyboardVisible ? 0 : _bottomInset));
 }
 
 #pragma mark - Accessibility


### PR DESCRIPTION
## Summary

When an absolute footer is present, the keyboard-driven scroll inset only accounted for the keyboard height — the footer rises above the keyboard and occludes the content's bottom edge, so focused inputs could hide behind the footer.

- Add `keyboardOcclusionHeight` to the footer view (iOS + Android): its layout height minus the safe-area inset it drops while the keyboard is open
- Include it in the keyboard content inset when `footerOptions.position` is `absolute` (relative footers occupy layout space, so keyboard height alone is correct)
- iOS: push the footer's bottom inset state immediately so the caret scroll and detent setup don't read a stale inset
- Example: drop the manual `keyboardScrollOffset` footer workaround in `PromptSheet`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Example app `PromptSheet` (absolute footer): focus inputs at the bottom of the scrollable content — caret clears both the keyboard and the footer on iOS and Android
- Relative footer sheets: keyboard inset unchanged
- Re-pin path (scrollable changing while keyboard is open) applies the same inset

## Screenshots / Videos

N/A

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)