### PR TITLE
fix(ios): skip size reports while stacked behind a child sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: A sheet stacked behind a child sheet no longer resizes its content in the background — UIKit's push-back scaling was reported as a size change, triggering spurious `onLayout`. ([#753](https://github.com/lodev09/react-native-true-sheet/pull/753) by [@lodev09](https://github.com/lodev09))
 - The keyboard-driven scroll inset now accounts for an absolute footer's height — focused inputs clear both the keyboard and the footer instead of hiding behind it. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))
 
 ### 💥 Breaking changes

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -283,7 +283,7 @@ using namespace facebook::react;
 - (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState {
   _state = std::static_pointer_cast<TrueSheetViewShadowNode::ConcreteState const>(state);
 
-  if (_controller) {
+  if (_controller && !_controller.isStackedBehindChild) {
     CGSize size = _controller.view.frame.size;
     if (size.width < 1 || size.height < 1) {
       // Pre-present the controller has no layout yet. Seed with screen

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -80,6 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL isPresented;
 @property (nonatomic, assign) NSInteger activeDetentIndex;
 @property (nonatomic, readonly) BOOL isTopmostPresentedController;
+@property (nonatomic, readonly) BOOL isStackedBehindChild;
 @property (nonatomic, weak, nullable) UIView *accessibilityContentView;
 
 @property (nonatomic, readonly) CGFloat screenHeight;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -134,6 +134,13 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   return self.presentedViewController == nil;
 }
 
+// YES while a child controller is stacked on top (e.g. a nested sheet) —
+// UIKit's push-back scaling mutates the frame while the sheet is backgrounded.
+- (BOOL)isStackedBehindChild {
+  UIViewController *presented = self.presentedViewController;
+  return presented != nil && !presented.isBeingDismissed;
+}
+
 - (UIView *)presentedView {
   return self.sheet.presentedView;
 }
@@ -561,6 +568,13 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
+
+  // Skip while backgrounded behind a stacked child — the push-back scaling
+  // changes the frame and would needlessly resize content. _lastReportedSize
+  // stays stale so the restore pass re-reports any real change.
+  if (self.isStackedBehindChild) {
+    return;
+  }
 
   // Report any size change (detent resize, keyboard, rotation) so Yoga
   // relayouts the container synchronously with the sheet.


### PR DESCRIPTION
## Summary

When a child sheet is stacked on top, UIKit's push-back scaling mutates the parent sheet's frame. The backgrounded sheet reported this as a real size change into Fabric state, so Yoga resized the container and emitted spurious `onLayout` while the sheet sat in the background.

- Add `isStackedBehindChild` to the controller (`presentedViewController != nil && !isBeingDismissed`)
- Skip the size report in `viewDidLayoutSubviews` while stacked behind — `_lastReportedSize` stays stale so the restore pass re-reports any real change (e.g. rotation while backgrounded)
- Guard the `updateState:` path too, which reads the scaled `frame.size` directly on JS commits

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Present a sheet, stack a child sheet on top — parent content no longer resizes / emits `onLayout` while backgrounded
- Dismiss the child — parent re-syncs size on the restore layout pass
- Rotate while the child is on top — parent picks up the new size once foregrounded

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)