### PR TITLE
fix: relative footer stays in the layout flow behind the keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - **iOS**: A sheet stacked behind a child sheet no longer resizes its content in the background — UIKit's push-back scaling was reported as a size change, triggering spurious `onLayout`. ([#753](https://github.com/lodev09/react-native-true-sheet/pull/753) by [@lodev09](https://github.com/lodev09))
 - The keyboard-driven scroll inset now accounts for an absolute footer's height — focused inputs clear both the keyboard and the footer instead of hiding behind it. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))
+- A relative footer no longer floats above the keyboard — it stays in the layout flow behind it and keeps its safe-area inset. Only an absolute footer rises above the keyboard (`footerOptions.keyboardOffset` now only applies there). ([#754](https://github.com/lodev09/react-native-true-sheet/pull/754) by [@lodev09](https://github.com/lodev09))
 
 ### 💥 Breaking changes
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
@@ -203,7 +203,7 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
   }
 
   override val footerKeyboardOcclusion: Int
-    get() = if (absoluteFooter) footerView?.keyboardOcclusionHeight ?: 0 else 0
+    get() = if (absoluteFooter) footerView?.keyboardOcclusionHeight ?: 0 else -(footerView?.height ?: 0)
 
   override fun contentViewDidScroll() {
     delegate?.containerViewContentDidScroll()

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -31,8 +31,9 @@ interface TrueSheetContentViewDelegate {
   fun contentViewScrollViewDidChange()
 
   /**
-   * Extra keyboard occlusion below the content — an absolute footer risen
-   * above the keyboard covers the content's bottom edge.
+   * Keyboard occlusion adjustment below the content — positive for an absolute
+   * footer risen above the keyboard covering the content's bottom edge,
+   * negative for a relative footer sitting behind the keyboard shielding it.
    */
   val footerKeyboardOcclusion: Int
 }
@@ -332,10 +333,10 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
 
     // An absolute footer rises above the keyboard and covers the content's
     // bottom edge — include it so the caret clears the footer, not just the
-    // keyboard. A relative footer takes up layout space below the content,
-    // so the keyboard alone measures its occlusion.
+    // keyboard. A relative footer stays behind the keyboard below the content,
+    // so its height shields that much of the keyboard's overlap.
     val totalBottomInset = if (keyboardHeight > 0) {
-      keyboardHeight + (delegate?.footerKeyboardOcclusion ?: 0)
+      maxOf(0, keyboardHeight + (delegate?.footerKeyboardOcclusion ?: 0))
     } else {
       bottomInset
     }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetFooterView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetFooterView.kt
@@ -47,8 +47,8 @@ class TrueSheetFooterView(private val reactContext: ThemedReactContext) :
   private var bottomInset = 0
 
   /**
-   * Skips the inset while the keyboard is open — the footer rises above the
-   * keyboard, so the inset would leave a gap.
+   * Skips the inset while the keyboard is open — an absolute footer rises
+   * above the keyboard, so the inset would leave a gap.
    */
   var keyboardVisible = false
     set(value) {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -998,9 +998,10 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     val keyboardShift = if (currentKeyboardInset > 0) maxOf(0, currentKeyboardInset + footerKeyboardOffset) else 0
 
     // A relative footer is laid out by Yoga (pinned to the container's bottom
-    // edge), so only the keyboard slide is carried via translation — like iOS
+    // edge) and stays in the layout flow behind the keyboard — only an
+    // absolute footer floats above it
     if (!absoluteFooter) {
-      footerView.translationY = -keyboardShift.toFloat()
+      footerView.translationY = 0f
       return
     }
 
@@ -1062,9 +1063,9 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
       delegate = object : TrueSheetKeyboardObserverDelegate {
         override fun keyboardWillShow(height: Int) {
           if (!shouldHandleKeyboard()) return
-          // The footer rises above the keyboard, so it drops the bottom inset
-          // padding — before detents are configured against its height
-          containerView?.footerView?.keyboardVisible = true
+          // An absolute footer rises above the keyboard, so it drops the bottom
+          // inset padding — before detents are configured against its height
+          if (absoluteFooter) containerView?.footerView?.keyboardVisible = true
           // If a resize is in flight, restore to its target — not the stale current
           detentIndexBeforeKeyboard = if (pendingDetentIndex >= 0) pendingDetentIndex else currentDetentIndex
           pendingDetentIndex = -1
@@ -1124,7 +1125,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
           // Handle case where keyboard is already visible and focus moves into the sheet
           if (!shouldHandleKeyboard()) return
           if (detentIndexBeforeKeyboard < 0 && (keyboardObserver?.currentHeight ?: 0) > 0) {
-            containerView?.footerView?.keyboardVisible = true
+            if (absoluteFooter) containerView?.footerView?.keyboardVisible = true
             detentIndexBeforeKeyboard = currentDetentIndex
             currentDetentIndex = detents.size - 1
             setupSheetDetents()

--- a/docs/docs/guides/footer.mdx
+++ b/docs/docs/guides/footer.mdx
@@ -76,7 +76,7 @@ const MyFooter = () => {
 
 The inset is applied to the footer component itself, so set your background via [`footerStyle`](../reference/configuration#footerstyle) (or on your footer's root view) for it to fill the safe area.
 
-When the keyboard opens, the footer rises above it and the inset is skipped automatically — no gap above the keyboard. See [Keyboard Handling](./keyboard#footer-behavior).
+When the keyboard opens, an absolute footer rises above it and the inset is skipped automatically — no gap above the keyboard. A relative footer stays in the layout flow and keeps its inset. See [Keyboard Handling](./keyboard#footer-behavior).
 
 :::note
 On iPad, the sheet is displayed as a floating modal, so no inset is applied. Set `insetAdjustment="never"` to opt out entirely.

--- a/docs/docs/guides/keyboard.mdx
+++ b/docs/docs/guides/keyboard.mdx
@@ -54,14 +54,14 @@ This is especially useful for forms with multiple inputs — as the user taps be
 
 ## Footer Behavior
 
-When using a [`footer`](../reference/configuration#footer) component, it automatically repositions above the keyboard, staying visible while the user types. With an absolute footer, the automatic scroll accounts for the footer's height — focused inputs clear both the keyboard and the footer.
+A relative [`footer`](../reference/configuration#footer) (the default) stays in the layout flow — it doesn't float above the keyboard. The keyboard simply covers it, and it's revealed again when the keyboard hides.
 
-The footer's built-in [safe-area inset](./footer#safe-area-handling) is skipped while the keyboard is open — the footer hugs the keyboard with no gap, and the inset is restored when the keyboard hides.
+An absolute footer automatically repositions above the keyboard, staying visible while the user types. The automatic scroll accounts for the footer's height — focused inputs clear both the keyboard and the footer. Its built-in [safe-area inset](./footer#safe-area-handling) is skipped while the keyboard is open — the footer hugs the keyboard with no gap, and the inset is restored when the keyboard hides.
 
-If your footer renders its own bottom padding, that padding leaves a gap above the keyboard. Use `keyboardOffset` in [`footerOptions`](../reference/configuration#footeroptions) to adjust the rise — pass a negative value to tuck it behind the keyboard:
+If your absolute footer renders its own bottom padding, that padding leaves a gap above the keyboard. Use `keyboardOffset` in [`footerOptions`](../reference/configuration#footeroptions) to adjust the rise — pass a negative value to tuck it behind the keyboard:
 
 ```tsx
-<TrueSheet footer={<Footer />} footerOptions={{ keyboardOffset: -16 }}>
+<TrueSheet footer={<Footer />} footerOptions={{ position: 'absolute', keyboardOffset: -16 }}>
   {/* ... */}
 </TrueSheet>
 ```

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -138,7 +138,7 @@ Options for customizing footer behavior.
 | Property | Type | Description | Default |
 | - | - | - | - |
 | `position` | `'relative' \| 'absolute'` | How the footer participates in the sheet layout. `'relative'` takes up space below the content, pinned to the bottom edge — included in the `auto` detent height but excluded from the `peek` detent height (it's pushed off-screen at peek). `'absolute'` floats over the content, pinned to the bottom edge — excluded from the `auto` detent height but included in the `peek` detent height. | `'relative'` |
-| `keyboardOffset` | `number` | Adjusts how far the footer rises when the keyboard opens. Positive values raise it higher; negative values tuck the footer's own bottom padding behind the keyboard instead of leaving a gap. The built-in safe-area inset is skipped automatically while the keyboard is open. | `0` |
+| `keyboardOffset` | `number` | Adjusts how far an `absolute` footer rises when the keyboard opens. Positive values raise it higher; negative values tuck the footer's own bottom padding behind the keyboard instead of leaving a gap. The built-in safe-area inset is skipped automatically while the keyboard is open. A `relative` footer stays in the layout flow behind the keyboard, so this has no effect. | `0` |
 
 ## `ScrollEdgeEffect`
 

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -243,13 +243,16 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
 
 // An absolute footer rises above the keyboard and covers the content's bottom
 // edge — include it so the caret clears the footer, not just the keyboard.
-// A relative footer takes up layout space below the content, so the keyboard
-// alone measures its occlusion.
+// A relative footer stays behind the keyboard below the content, so its
+// height shields that much of the keyboard's overlap.
 - (CGFloat)keyboardInsetWithHeight:(CGFloat)height {
-  if (_keyboardObserver.viewController.absoluteFooter && self.footerView) {
-    height += [self.footerView keyboardOcclusionHeight];
+  if (!self.footerView) {
+    return height;
   }
-  return height;
+  if (_keyboardObserver.viewController.absoluteFooter) {
+    return height + [self.footerView keyboardOcclusionHeight];
+  }
+  return MAX(0, height - self.footerView.frame.size.height);
 }
 
 // Content growth is invisible to layout once the viewport is bounded, so track

--- a/ios/TrueSheetFooterView.mm
+++ b/ios/TrueSheetFooterView.mm
@@ -62,8 +62,8 @@ using namespace facebook::react;
   [self pushBottomInsetState];
 }
 
-// Skipped while the keyboard is open — the footer rises above the keyboard,
-// so the inset would leave a gap.
+// Skipped while the keyboard is open — an absolute footer rises above the
+// keyboard, so the inset would leave a gap.
 - (void)setKeyboardVisible:(BOOL)keyboardVisible {
   if (_keyboardVisible == keyboardVisible) {
     return;
@@ -147,8 +147,14 @@ using namespace facebook::react;
 #pragma mark - TrueSheetKeyboardObserverDelegate
 
 // Yoga owns the footer's frame (pinned to the container's bottom edge), so the
-// keyboard slide is carried by a transform instead of layout.
+// keyboard slide is carried by a transform instead of layout. Only an absolute
+// footer floats above the keyboard — a relative footer stays in the layout
+// flow behind it.
 - (void)keyboardWillShow:(CGFloat)height duration:(NSTimeInterval)duration curve:(UIViewAnimationOptions)curve {
+  if (!self.keyboardObserver.viewController.absoluteFooter) {
+    return;
+  }
+
   [self setKeyboardVisible:YES];
 
   CGFloat keyboardOffset = self.keyboardObserver.viewController.footerKeyboardOffset;
@@ -179,7 +185,7 @@ using namespace facebook::react;
 
 - (void)applyKeyboardOffset {
   CGFloat height = self.keyboardObserver.currentHeight;
-  if (height <= 0) {
+  if (height <= 0 || !self.keyboardObserver.viewController.absoluteFooter) {
     return;
   }
 

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -168,9 +168,10 @@ export interface FooterOptions {
   position?: 'relative' | 'absolute';
 
   /**
-   * Adjusts how far the footer rises when the keyboard opens.
+   * Adjusts how far an `absolute` footer rises when the keyboard opens.
    * Positive values raise it higher; negative values reduce the rise.
    * Pass `-insets.bottom` to tuck the footer's safe-area padding behind the keyboard.
+   * A `relative` footer stays in the layout flow behind the keyboard, so this has no effect.
    *
    * @default 0
    */


### PR DESCRIPTION
## Summary

A relative footer (the default) no longer floats above the keyboard — it stays in the layout flow behind it, on both platforms. Only an absolute footer keeps the float behavior.

- **iOS**: `keyboardWillShow`/`applyKeyboardOffset` skip the transform and the safe-area inset drop unless the footer is absolute.
- **Android**: `positionFooter` resets `translationY` for relative footers; `keyboardVisible` (inset drop) is only set for absolute footers.
- The keyboard scroll inset now subtracts a relative footer's height — the footer sits behind the keyboard below the content, shielding that much of the overlap (clamped at 0).
- `footerOptions.keyboardOffset` now only applies to absolute footers — docs and types updated.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Test Plan

- Present a sheet with a relative footer and focus an input — the footer stays put behind the keyboard, content scrolls clear of the keyboard with no gap.
- Same with `footerOptions={{ position: 'absolute' }}` — the footer still rises above the keyboard, inset skipped.

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)