### PR TITLE
refactor(ios): restore per-path position tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🎉 New features
 
-- **iOS**: `onPositionChange` now tracks the sheet's actual on-screen position everywhere — detent snaps, programmatic resizes, and sheets moving behind a child sheet emit realtime frames from a single native tracker (previously approximated with a JS-side spring or only emitted once settled). `onDetentChange` for programmatic resizes now fires when the animation actually ends instead of after a fixed delay. ([#744](https://github.com/lodev09/react-native-true-sheet/pull/744) by [@lodev09](https://github.com/lodev09))
+- **iOS**: `onPositionChange` now reports a sheet's live position while it moves behind a dragging child sheet. ([#744](https://github.com/lodev09/react-native-true-sheet/pull/744) by [@lodev09](https://github.com/lodev09))
 - The `auto` detent now works with plugged scrollables — the sheet sizes to the scrollable's content height and resizes as content grows or shrinks. ([#743](https://github.com/lodev09/react-native-true-sheet/pull/743) by [@lodev09](https://github.com/lodev09))
 - New `headerOptions` prop with a `position` option — set to `'absolute'` to float the header over the content (pinned to the top edge) and exclude it from the `auto` detent height. ([#747](https://github.com/lodev09/react-native-true-sheet/pull/747) by [@lodev09](https://github.com/lodev09))
 - A relative footer now owns the bottom safe-area inset at the `auto` detent — the inset is no longer added to the auto height, so the footer sits flush at the sheet's bottom edge. ([#749](https://github.com/lodev09/react-native-true-sheet/pull/749) by [@lodev09](https://github.com/lodev09))
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Smoother, more reliable `onPositionChange` — drags emit at the touch rate, transitions track at the display's native refresh rate (120Hz on ProMotion), and a sheet behind a presenting child animates to its collapsed position instead of jumping or going stale. `onWillDismiss` now fires only when a drag-to-dismiss is committed on release, not prematurely mid-drag. ([#756](https://github.com/lodev09/react-native-true-sheet/pull/756) by [@lodev09](https://github.com/lodev09))
 - **iOS**: A sheet stacked behind a child sheet no longer resizes its content in the background — UIKit's push-back scaling was reported as a size change, triggering spurious `onLayout`. ([#753](https://github.com/lodev09/react-native-true-sheet/pull/753) by [@lodev09](https://github.com/lodev09))
 - The keyboard-driven scroll inset now accounts for an absolute footer's height — focused inputs clear both the keyboard and the footer instead of hiding behind it. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))
 - A relative footer no longer floats above the keyboard — it stays in the layout flow behind it and keeps its safe-area inset. Only an absolute footer rises above the keyboard (`footerOptions.keyboardOffset` now only applies there). ([#754](https://github.com/lodev09/react-native-true-sheet/pull/754) by [@lodev09](https://github.com/lodev09))

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -583,13 +583,12 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     [self settleAtDetentIndex:self.currentDetentIndex debug:@"layout"];
   } else {
     // Drag moves the frame directly and lays out on every touch move, so this
-    // emits at the touch rate. Behind a child, the deck effect relayouts this
-    // sheet as it moves — sample the live on-screen position there since the
-    // push-back transform skews the model frame.
-    BOOL stacked = self.presentedViewController != nil;
-    [self emitChangePositionDelegateWithPosition:(stacked ? self.livePosition : self.currentPosition)
-                                        realtime:YES
-                                           debug:@"layout"];
+    // emits at the touch rate. A child on top moves this sheet two ways: an
+    // animated collapse/restore step (presenting/dismissing) — emit the target
+    // non-realtime so JS animates to it — or direct per-frame re-layouts while
+    // the child drags, which stay realtime.
+    BOOL realtime = self.presentedViewController == nil || !self.isPresentedViewAnimating;
+    [self emitChangePositionDelegateWithPosition:self.currentPosition realtime:realtime debug:@"layout"];
   }
 }
 

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -700,7 +700,12 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   _lastSampledPosition = position;
 
   if (self.isBeingDismissed) {
-    [self emitWillDismissEvents];
+    // Emit only once the dismiss is committed: on release UIKit moves the
+    // model frame off-screen, while a cancelled drag rewinds it back to the
+    // detent (isBeingDismissed stays YES during the rewind).
+    if (!_isDragging && self.currentPosition >= self.screenHeight) {
+      [self emitWillDismissEvents];
+    }
 
     // Hide blur at the end of dismiss to prevent UIVisualEffectView
     // from causing a flicker/flash at the bottom edge of the sheet.

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -40,6 +40,9 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 @interface TrueSheetViewController ()
 
 - (UIViewController *)accessibilityPresentingViewController;
+- (void)setupTransitionTracker;
+- (void)settleAtDetentIndex:(NSInteger)index debug:(NSString *)debug;
+- (void)emitDeckPosition;
 - (void)restoreWindowAccessibilityElements;
 - (void)setSheetAccessibilityElementsHidden:(BOOL)hidden;
 - (void)setAccessibilityContentElement:(UIView *)contentView;
@@ -58,12 +61,16 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   CGFloat _peekDetentHeight;
   NSInteger _pendingDetentIndex;
 
-  // Single source of truth for position: a display link that samples the
-  // presented view's on-screen position and settles (then stops) on its own.
-  CADisplayLink *_positionLink;
-  CGFloat _lastSampledPosition;
-  NSInteger _stableFrameCount;
-  BOOL _needsOffsetLearn;
+  // Present/dismiss tracking: a display link scoped to the transition
+  // coordinator — started alongside the transition, stopped in its completion.
+  CADisplayLink *_transitionLink;
+  BOOL _isTransitioning;
+
+  // YES while a layout pass owns position emission this frame, so the pan
+  // handler doesn't double-emit.
+  BOOL _isTrackingPositionFromLayout;
+  BOOL _pendingContentSizeChange;
+  BOOL _pendingDetentsChange;
   BOOL _isDragging;
   BOOL _isWillDismissEmitted;
 
@@ -71,6 +78,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   CGFloat _interactiveStartPosition;
   UIView *_interactiveContainerView;
   NSUInteger _interactiveGeneration;
+  CADisplayLink *_interactivePositionLink;
 
   __weak TrueSheetViewController *_parentSheetController;
 
@@ -103,6 +111,10 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     _isDragging = NO;
     _isPresented = NO;
     _isWillDismissEmitted = NO;
+    _isTransitioning = NO;
+    _isTrackingPositionFromLayout = NO;
+    _pendingContentSizeChange = NO;
+    _pendingDetentsChange = NO;
     _activeDetentIndex = -1;
     _pendingDetentIndex = -1;
 
@@ -116,8 +128,10 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
 - (void)dealloc {
   [self restoreWindowAccessibilityElements];
-  [_positionLink invalidate];
-  _positionLink = nil;
+  [_transitionLink invalidate];
+  _transitionLink = nil;
+  [_interactivePositionLink invalidate];
+  _interactivePositionLink = nil;
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
@@ -340,12 +354,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     });
   }
 
-  // Learn the resolver-vs-actual offset before emitting transition positions so
-  // the interpolated index lands exactly on the target detent. The presented
-  // frame is already final here (UIKit animates the layer, not the frame).
-  [self learnOffsetForDetentIndex:self.currentDetentIndex];
-  _needsOffsetLearn = YES;
-  [self kickPositionTracking];
+  [self setupTransitionTracker];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -361,7 +370,8 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
       [self.delegate viewControllerDidPresentAtIndex:index position:self.currentPosition detent:detent];
       [self.delegate viewControllerDidFocus];
 
-      [self kickPositionTracking];
+      [self->_grabberView updateAccessibilityValueWithIndex:index detentCount:self->_detents.count];
+      [self settleAtDetentIndex:index debug:@"did present"];
     });
 
     [self setupGestureRecognizer];
@@ -535,53 +545,83 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   [self setSheetAccessibilityElementsHidden:YES];
 
   // Dispatch to allow pan gesture to set _isDragging before checking;
-  // the position tick emits when the sheet is transitioning to dismiss
+  // the transition tracker emits when the sheet is transitioning to dismiss
   dispatch_async(dispatch_get_main_queue(), ^{
     if (!self->_isDragging) {
       [self emitWillDismissEvents];
     }
   });
 
-  [self kickPositionTracking];
+  [self setupTransitionTracker];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
   [super viewDidDisappear:animated];
 
   // Backstop: if the sheet is torn down mid-gesture (e.g. owning view deallocated),
-  // the observer can't reach us through its weak delegate, so end here.
+  // the observer can't reach us through its weak delegate, so end here to invalidate
+  // _interactivePositionLink — which otherwise retains this controller indefinitely.
   if (_isInteractiveDismiss) {
     [self endInteractiveDismissState];
   }
 
   [self emitDidDismissEvents];
-  [self stopPositionTracking];
 }
 
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 
-  // Any layout can move the sheet (drag, keyboard, rotation, detent resize) —
-  // wake the position tracker; it emits per-frame and settles on its own.
-  [self kickPositionTracking];
+  // Skip during transitions and nav swipes — their trackers own position then.
+  if (_isTransitioning || _isInteractiveDismiss) {
+    return;
+  }
+
+  _isTrackingPositionFromLayout = YES;
+
+  if (_pendingContentSizeChange || _pendingDetentsChange) {
+    _pendingContentSizeChange = NO;
+    _pendingDetentsChange = NO;
+    [self settleAtDetentIndex:self.currentDetentIndex debug:@"layout"];
+  } else {
+    // Drag moves the frame directly and lays out on every touch move, so this
+    // emits at the touch rate. Non-realtime while a child controller sits on
+    // top — its own tracking owns realtime then.
+    UIViewController *presented = self.presentedViewController;
+    BOOL hasPresentedController = presented != nil && !presented.isBeingPresented && !presented.isBeingDismissed;
+    [self emitChangePositionDelegateWithPosition:self.currentPosition realtime:!hasPresentedController debug:@"layout"];
+  }
 }
 
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
 
-  // Skip while backgrounded behind a stacked child — the push-back scaling
-  // changes the frame and would needlessly resize content. _lastReportedSize
-  // stays stale so the restore pass re-reports any real change.
-  if (self.isStackedBehindChild) {
-    return;
+  _isTrackingPositionFromLayout = NO;
+
+  // Skip size reports while backgrounded behind a stacked child — the push-back
+  // scaling changes the frame and would needlessly resize content.
+  // _lastReportedSize stays stale so the restore pass re-reports any real change.
+  if (!self.isStackedBehindChild) {
+    // Report any size change (detent resize, keyboard, rotation) so Yoga
+    // relayouts the container synchronously with the sheet.
+    CGSize size = self.view.frame.size;
+    if (!CGSizeEqualToSize(_lastReportedSize, size)) {
+      _lastReportedSize = size;
+      [self.delegate viewControllerDidChangeSize:size];
+    }
   }
 
-  // Report any size change (detent resize, keyboard, rotation) so Yoga
-  // relayouts the container synchronously with the sheet.
-  CGSize size = self.view.frame.size;
-  if (!CGSizeEqualToSize(_lastReportedSize, size)) {
-    _lastReportedSize = size;
-    [self.delegate viewControllerDidChangeSize:size];
+  if (_pendingDetentIndex >= 0) {
+    NSInteger pendingIndex = _pendingDetentIndex;
+    _pendingDetentIndex = -1;
+
+    // The presentedView frame isn't final until UIKit finishes the resize
+    // animation — no completion hook exists for it, hence the delay.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      CGFloat detent = [self detentValueForIndex:pendingIndex];
+      [self.delegate viewControllerDidChangeDetent:pendingIndex position:self.currentPosition detent:detent];
+      [self->_grabberView updateAccessibilityValueWithIndex:pendingIndex detentCount:self->_detents.count];
+      [self settleAtDetentIndex:pendingIndex debug:@"pending detent change"];
+    });
   }
 }
 
@@ -642,17 +682,27 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   switch (gesture.state) {
     case UIGestureRecognizerStateBegan:
       _isDragging = YES;
-      [self kickPositionTracking];
       break;
     case UIGestureRecognizerStateChanged:
-      [self kickPositionTracking];
+      if (!_isTrackingPositionFromLayout) {
+        [self emitChangePositionDelegateWithPosition:self.currentPosition realtime:YES debug:@"drag change"];
+      }
       break;
     case UIGestureRecognizerStateEnded:
-    case UIGestureRecognizerStateCancelled:
+    case UIGestureRecognizerStateCancelled: {
+      if (!_isTransitioning) {
+        // Dispatch so UIKit picks the target detent first; the settle emit is
+        // non-realtime and JS animates alongside UIKit's snap spring.
+        dispatch_async(dispatch_get_main_queue(), ^{
+          NSInteger endIndex = self.currentDetentIndex;
+          [self->_grabberView updateAccessibilityValueWithIndex:endIndex detentCount:self->_detents.count];
+          [self settleAtDetentIndex:endIndex debug:@"drag end"];
+        });
+      }
+
       _isDragging = NO;
-      _needsOffsetLearn = YES;
-      [self kickPositionTracking];
       break;
+    }
     default:
       break;
   }
@@ -661,110 +711,110 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 #pragma mark - Position Tracking
 
 /**
- * Wakes the position tracker. Called from anything that can move the sheet
- * (layout, drag, transitions, interactive dismiss, detent changes). The tick
- * emits realtime positions while the sheet moves and settles + stops itself
- * once it comes to rest, so kicks are cheap and idempotent.
+ * Tracks the sheet's live position through a present/dismiss transition. The
+ * link's lifetime is scoped to the transition coordinator: started alongside
+ * the transition, stopped in its completion — which fires for finished and
+ * cancelled (interactive) transitions alike.
  */
-- (void)kickPositionTracking {
-  _stableFrameCount = 0;
-  if (!_positionLink) {
-    _lastSampledPosition = self.livePosition;
-    _positionLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(handlePositionTick)];
-    [_positionLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+- (void)setupTransitionTracker {
+  id<UIViewControllerTransitionCoordinator> coordinator = self.transitionCoordinator;
+
+  // A cancelled dismiss re-enters viewWillAppear with the same coordinator —
+  // the tracker from viewWillDisappear still owns it.
+  if (!coordinator || _isTransitioning) {
+    return;
   }
 
-  // Whatever moves this sheet can also move the sheets behind it (deck effect,
-  // detent re-resolution) without their own layout firing — wake the stack.
-  [_parentSheetController kickPositionTracking];
+  _isTransitioning = YES;
+
+  // Learn the resolver-vs-actual offset before emitting transition positions so
+  // the interpolated index lands exactly on the target detent. The presented
+  // frame is already final here (UIKit animates the layer, not the frame).
+  if (!self.isBeingDismissed) {
+    [self learnOffsetForDetentIndex:self.currentDetentIndex];
+  }
+
+  __weak __typeof(self) weakSelf = self;
+  [coordinator
+    animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+      __strong __typeof(weakSelf) strongSelf = weakSelf;
+      if (!strongSelf)
+        return;
+
+      [strongSelf->_transitionLink invalidate];
+      strongSelf->_transitionLink = [CADisplayLink displayLinkWithTarget:strongSelf
+                                                                selector:@selector(handleTransitionTick)];
+      // Track at the display's native refresh rate — the default caps at 60Hz
+      // on ProMotion, dropping every other frame of a 120Hz animation.
+      strongSelf->_transitionLink.preferredFrameRateRange = CAFrameRateRangeMake(60, 120, 120);
+      [strongSelf->_transitionLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+    }
+    completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
+      __strong __typeof(weakSelf) strongSelf = weakSelf;
+      if (!strongSelf)
+        return;
+
+      [strongSelf->_transitionLink invalidate];
+      strongSelf->_transitionLink = nil;
+      strongSelf->_isTransitioning = NO;
+
+      // Emit the settled position after a cancelled dismiss or detent-snap
+      // transition. Delayed because the presentedView frame isn't final until
+      // UIKit completes its layout pass after the transition animation.
+      if (strongSelf->_isPresented && !strongSelf.isBeingDismissed) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+          CGFloat position = strongSelf.currentPosition;
+          [strongSelf emitChangePositionDelegateWithPosition:position realtime:NO debug:@"transition end"];
+        });
+      }
+    }];
 }
 
-- (void)stopPositionTracking {
-  [_positionLink invalidate];
-  _positionLink = nil;
+- (void)handleTransitionTick {
+  // Interactive dismiss phase (finger down) — the pan handler emits.
+  if (!_isDragging) {
+    CGFloat position = self.livePosition;
+
+    if (self.isBeingDismissed) {
+      // Emit only once the dismiss is committed: on release UIKit moves the
+      // model frame off-screen, while a cancelled drag rewinds it back to the
+      // detent (isBeingDismissed stays YES during the rewind).
+      if (self.currentPosition >= self.screenHeight) {
+        [self emitWillDismissEvents];
+      }
+
+      // Hide blur at the end of dismiss to prevent UIVisualEffectView
+      // from causing a flicker/flash at the bottom edge of the sheet.
+      if (self.screenHeight - position < 1) {
+        _blurView.alpha = 0;
+      }
+    }
+
+    [self emitChangePositionDelegateWithPosition:position realtime:YES debug:@"transition"];
+  }
+
+  // The deck effect moves the parent behind this transition without its own
+  // layout firing — mirror its live position.
+  [_parentSheetController emitDeckPosition];
 }
 
-- (void)handlePositionTick {
-  UIView *presentedView = self.presentedView;
-  if (!presentedView) {
-    // Nothing to track (e.g. torn down mid-animation) — stop so the link
-    // doesn't keep this controller alive.
-    if (++_stableFrameCount >= 90) {
-      [self stopPositionTracking];
-    }
-    return;
-  }
-
-  CGFloat position = self.livePosition;
-  BOOL moved = fabs(position - _lastSampledPosition) > 0.01;
-  _lastSampledPosition = position;
-
-  if (self.isBeingDismissed) {
-    // Emit only once the dismiss is committed: on release UIKit moves the
-    // model frame off-screen, while a cancelled drag rewinds it back to the
-    // detent (isBeingDismissed stays YES during the rewind).
-    if (!_isDragging && self.currentPosition >= self.screenHeight) {
-      [self emitWillDismissEvents];
-    }
-
-    // Hide blur at the end of dismiss to prevent UIVisualEffectView
-    // from causing a flicker/flash at the bottom edge of the sheet.
-    if (self.screenHeight - position < 1) {
-      _blurView.alpha = 0;
-    }
-  }
-
-  if (moved) {
-    _stableFrameCount = 0;
-
-    // Emit even when a child sheet sits on top — the parent moves behind it
-    // (deck effect, detent re-resolution) and consumers track that live.
-    [self emitChangePositionDelegateWithPosition:position realtime:YES debug:@"tick"];
-    return;
-  }
-
-  // Never settle mid-gesture or mid-transition — learning an offset there
-  // would store a bogus value.
-  if (_isDragging || _isInteractiveDismiss || self.isBeingPresented || self.isBeingDismissed ||
-      self.transitionCoordinator != nil) {
-    _stableFrameCount = 0;
-    return;
-  }
-
-  // Settle once the sheet has been still with no in-flight animations; the
-  // frame cap guards against leftover animations pinning the link forever.
-  _stableFrameCount++;
-  if (_stableFrameCount >= (self.isPresentedViewAnimating ? 90 : 3)) {
-    [self settlePosition];
-  }
+- (void)emitDeckPosition {
+  [self emitChangePositionDelegateWithPosition:self.livePosition realtime:YES debug:@"deck"];
 }
 
 /**
- * The sheet came to rest: learn the resolver-vs-actual offset when a detent
- * change requested it, flush any pending detent-change event, emit the final
- * position, and stop the tracker.
+ * The sheet is at rest at a detent: learn the resolver-vs-actual offset and
+ * emit the settled position. Only valid when the presentedView frame is final
+ * — never mid-drag or mid-animation, where learning would store a bogus offset.
  */
-- (void)settlePosition {
-  NSInteger index = self.currentDetentIndex;
-
+- (void)settleAtDetentIndex:(NSInteger)index debug:(NSString *)debug {
   // Don't learn while a child sits on top — the deck transform skews the
-  // measured frame. Keep the flag so the next unobstructed settle learns.
-  if (_needsOffsetLearn && self.presentedViewController == nil) {
-    _needsOffsetLearn = NO;
+  // measured frame; the next unobstructed settle learns.
+  if (self.presentedViewController == nil) {
     [self learnOffsetForDetentIndex:index];
   }
 
-  if (_pendingDetentIndex >= 0) {
-    NSInteger pendingIndex = _pendingDetentIndex;
-    _pendingDetentIndex = -1;
-
-    CGFloat detent = [self detentValueForIndex:pendingIndex];
-    [self.delegate viewControllerDidChangeDetent:pendingIndex position:self.currentPosition detent:detent];
-  }
-
-  [_grabberView updateAccessibilityValueWithIndex:index detentCount:_detents.count];
-  [self emitChangePositionDelegateWithPosition:self.currentPosition realtime:NO debug:@"settle"];
-  [self stopPositionTracking];
+  [self emitChangePositionDelegateWithPosition:self.currentPosition realtime:NO debug:debug];
 }
 
 #pragma mark - Interactive Navigation Dismiss
@@ -783,9 +833,17 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   _interactiveStartPosition = self.currentPosition;
   _interactiveContainerView = self.sheet.containerView;
 
-  // The container translation doesn't trigger our layout, so wake the tracker
-  // explicitly; livePosition picks up the container transform.
-  [self kickPositionTracking];
+  // Emit position from the container's presentation layer for the whole gesture, so
+  // both the direct-set drag and the settle animation report a live, smooth position.
+  _interactivePositionLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(emitInteractivePosition)];
+  _interactivePositionLink.preferredFrameRateRange = CAFrameRateRangeMake(60, 120, 120);
+  [_interactivePositionLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+}
+
+- (void)emitInteractivePosition {
+  CALayer *presentation = _interactiveContainerView.layer.presentationLayer;
+  CGFloat offset = presentation ? presentation.affineTransform.ty : 0;
+  [self emitChangePositionDelegateWithPosition:_interactiveStartPosition + offset realtime:YES debug:@"nav swipe"];
 }
 
 // Translate the presentation container, not the sheet's presentedView (whose transform
@@ -860,6 +918,8 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   _isInteractiveDismiss = NO;
   _interactiveContainerView = nil;
   _interactiveStartPosition = 0;
+  [_interactivePositionLink invalidate];
+  _interactivePositionLink = nil;
 }
 
 - (void)emitChangePositionDelegateWithPosition:(CGFloat)position realtime:(BOOL)realtime debug:(NSString *)debug {
@@ -929,19 +989,17 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     _autoDetentHeight = autoHeight;
     _peekDetentHeight = peekHeight;
 
-    _needsOffsetLearn = YES;
     [self.sheet animateChanges:^{
+      self->_pendingContentSizeChange = YES;
       [self.sheet invalidateDetents];
     }];
-    [self kickPositionTracking];
   }
   // iOS 15: detents are fixed medium/large — size changes can't affect them.
 }
 
 - (void)setupSheetDetentsForDetentsChange {
-  _needsOffsetLearn = YES;
+  _pendingDetentsChange = YES;
   [self setupSheetDetents];
-  [self kickPositionTracking];
 }
 
 - (void)setupSheetDetents {
@@ -1137,9 +1195,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
   _pendingDetentIndex = index;
   _activeDetentIndex = index;
-  _needsOffsetLearn = YES;
   [self applyActiveDetent];
-  [self kickPositionTracking];
 }
 
 - (void)setupBackground {
@@ -1336,9 +1392,6 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
 - (void)sheetPresentationControllerDidChangeSelectedDetentIdentifier:
   (UISheetPresentationController *)sheetPresentationController {
-  _needsOffsetLearn = YES;
-  [self kickPositionTracking];
-
   dispatch_async(dispatch_get_main_queue(), ^{
     NSInteger index = self.currentDetentIndex;
     if (index >= 0) {

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -65,9 +65,6 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   CADisplayLink *_transitionLink;
   BOOL _isTransitioning;
 
-  // YES while a layout pass owns position emission this frame, so the pan
-  // handler doesn't double-emit.
-  BOOL _isTrackingPositionFromLayout;
   BOOL _pendingContentSizeChange;
   BOOL _pendingDetentsChange;
   BOOL _isDragging;
@@ -111,7 +108,6 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     _isPresented = NO;
     _isWillDismissEmitted = NO;
     _isTransitioning = NO;
-    _isTrackingPositionFromLayout = NO;
     _pendingContentSizeChange = NO;
     _pendingDetentsChange = NO;
     _activeDetentIndex = -1;
@@ -575,18 +571,15 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     return;
   }
 
-  _isTrackingPositionFromLayout = YES;
-
   if (_pendingContentSizeChange || _pendingDetentsChange) {
     _pendingContentSizeChange = NO;
     _pendingDetentsChange = NO;
     [self settleAtDetentIndex:self.currentDetentIndex debug:@"layout"];
-  } else {
-    // Drag moves the frame directly and lays out on every touch move, so this
-    // emits at the touch rate. A child on top moves this sheet two ways: an
-    // animated collapse/restore step (presenting/dismissing) — emit the target
-    // non-realtime so JS animates to it — or direct per-frame re-layouts while
-    // the child drags, which stay realtime.
+  } else if (!_isDragging) {
+    // Drags emit from the pan handler. A child on top moves this sheet two
+    // ways: an animated collapse/restore step (presenting/dismissing) — emit
+    // the target non-realtime so JS animates to it — or direct per-frame
+    // re-layouts while the child drags, which stay realtime.
     BOOL realtime = self.presentedViewController == nil || !self.isPresentedViewAnimating;
     [self emitChangePositionDelegateWithPosition:self.currentPosition realtime:realtime debug:@"layout"];
   }
@@ -594,8 +587,6 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
-
-  _isTrackingPositionFromLayout = NO;
 
   // Skip size reports while backgrounded behind a stacked child — the push-back
   // scaling changes the frame and would needlessly resize content.
@@ -684,9 +675,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
       _isDragging = YES;
       break;
     case UIGestureRecognizerStateChanged:
-      if (!_isTrackingPositionFromLayout) {
-        [self emitChangePositionDelegateWithPosition:self.currentPosition realtime:YES debug:@"drag change"];
-      }
+      [self emitChangePositionDelegateWithPosition:self.currentPosition realtime:YES debug:@"drag change"];
       break;
     case UIGestureRecognizerStateEnded:
     case UIGestureRecognizerStateCancelled: {

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -42,7 +42,6 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 - (UIViewController *)accessibilityPresentingViewController;
 - (void)setupTransitionTracker;
 - (void)settleAtDetentIndex:(NSInteger)index debug:(NSString *)debug;
-- (void)emitDeckPosition;
 - (void)restoreWindowAccessibilityElements;
 - (void)setSheetAccessibilityElementsHidden:(BOOL)hidden;
 - (void)setAccessibilityContentElement:(UIView *)contentView;
@@ -584,11 +583,13 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     [self settleAtDetentIndex:self.currentDetentIndex debug:@"layout"];
   } else {
     // Drag moves the frame directly and lays out on every touch move, so this
-    // emits at the touch rate. Non-realtime while a child controller sits on
-    // top — its own tracking owns realtime then.
-    UIViewController *presented = self.presentedViewController;
-    BOOL hasPresentedController = presented != nil && !presented.isBeingPresented && !presented.isBeingDismissed;
-    [self emitChangePositionDelegateWithPosition:self.currentPosition realtime:!hasPresentedController debug:@"layout"];
+    // emits at the touch rate. Behind a child, the deck effect relayouts this
+    // sheet as it moves — sample the live on-screen position there since the
+    // push-back transform skews the model frame.
+    BOOL stacked = self.presentedViewController != nil;
+    [self emitChangePositionDelegateWithPosition:(stacked ? self.livePosition : self.currentPosition)
+                                        realtime:YES
+                                           debug:@"layout"];
   }
 }
 
@@ -792,14 +793,6 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
     [self emitChangePositionDelegateWithPosition:position realtime:YES debug:@"transition"];
   }
-
-  // The deck effect moves the parent behind this transition without its own
-  // layout firing — mirror its live position.
-  [_parentSheetController emitDeckPosition];
-}
-
-- (void)emitDeckPosition {
-  [self emitChangePositionDelegateWithPosition:self.livePosition realtime:YES debug:@"deck"];
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the self-settling kick/settle display link (#744) with explicit per-path trackers — the start/stop heuristics (still-frame counting, animation scans, frame caps) proved fragile. Each path now has a deterministic lifetime:

- **Drag** — emitted from the pan handler at the touch rate; layout skips while dragging so there's a single owner per state.
- **Present/dismiss** — a display link scoped to the transition coordinator: started alongside the transition, invalidated in its completion (fires for finished and cancelled interactive transitions alike). Samples `livePosition` (window-space presentation delta), which replaces v3's fake transition view and its snap-jump detection.
- **Nav edge-swipe dismiss** — dedicated link owned by the gesture, invalidated in `endInteractiveDismissState`.
- **Settles** — explicit points again (did-present, drag end, pending content/detents change, pending detent flush, transition end), where offset learning happens; keeps the don't-learn-while-stacked guard.

Behind a stacked child, the deck collapse/restore step is emitted as a non-realtime target (`isPresentedViewAnimating` distinguishes it) so JS animates to it, while direct re-layouts from a dragging child stay realtime.

Both links request the display's native refresh rate — the default caps at 60Hz on ProMotion.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Present/dismiss tracking (animated and non-animated)
- Drag + release snap between detents; drag-to-dismiss with cancel (willDismiss only on commit)
- Programmatic `resize()`
- Nav edge-swipe interactive dismiss (undimmed sheet)
- Keyboard show/hide
- Content-size change with auto detent
- Stacked child sheets: parent position while child presents/dismisses/drags

## Screenshots / Videos

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)