### PR TITLE
feat: add TrueSheetNavBar — native navigation bar via the header prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - New `headerOptions` prop with a `position` option — set to `'absolute'` to float the header over the content (pinned to the top edge) and exclude it from the `auto` detent height. ([#747](https://github.com/lodev09/react-native-true-sheet/pull/747) by [@lodev09](https://github.com/lodev09))
 - A relative footer now owns the bottom safe-area inset at the `auto` detent — the inset is no longer added to the auto height, so the footer sits flush at the sheet's bottom edge. ([#749](https://github.com/lodev09/react-native-true-sheet/pull/749) by [@lodev09](https://github.com/lodev09))
 - The footer now absorbs the bottom safe-area inset as padding when `insetAdjustment` is `automatic`, regardless of `footerOptions.position` — content stays above the home indicator while the footer's background fills the inset, so no manual safe-area padding is needed. The inset is skipped while the keyboard is open. ([#750](https://github.com/lodev09/react-native-true-sheet/pull/750) by [@lodev09](https://github.com/lodev09))
+- New `TrueSheetNavBar` component — pass it to the `header` prop for a native navigation bar with title, large title (iOS), left/right/title bar items hosting React children, appearance options, and a native search field (`UISearchController` on iOS, collapsible `SearchView` on Android, styled bar on Web) with `onSearchChange`/`Submit`/`Focus`/`Blur`/`Cancel` events. Its height counts toward the `auto` and `peek` detents. ([#757](https://github.com/lodev09/react-native-true-sheet/pull/757) by [@lodev09](https://github.com/lodev09))
 
 ### 🐛 Bug fixes
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
@@ -28,7 +28,8 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
   TrueSheetContentViewDelegate,
   TrueSheetHeaderViewDelegate,
   TrueSheetFooterViewDelegate,
-  TrueSheetPeekViewDelegate {
+  TrueSheetPeekViewDelegate,
+  TrueSheetNavBarViewDelegate {
 
   var delegate: TrueSheetContainerViewDelegate? = null
 
@@ -36,10 +37,19 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
   var headerView: TrueSheetHeaderView? = null
   var footerView: TrueSheetFooterView? = null
   var peekView: TrueSheetPeekView? = null
+  var navBarView: TrueSheetNavBarView? = null
 
   var contentHeight: Int = 0
   var headerHeight: Int = 0
   var footerHeight: Int = 0
+
+  /**
+   * Height of the native nav bar toolbar pinned above this container.
+   * Feeds the header channel for detents, but the container itself is offset
+   * below the toolbar since the bar isn't part of the RN layout.
+   */
+  val navBarHeight: Int
+    get() = if (navBarView != null) headerHeight else 0
 
   /**
    * Distance from the top of the content view to the bottom of the peek view.
@@ -128,6 +138,14 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
         headerView = child
       }
 
+      is TrueSheetNavBarView -> {
+        child.delegate = this
+        navBarView = child
+        // No-op if this container isn't in the controller yet —
+        // TrueSheetView attaches it when the container mounts
+        child.attachToolbar()
+      }
+
       is TrueSheetFooterView -> {
         child.delegate = this
         child.setBottomInset(footerBottomInset)
@@ -148,6 +166,13 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
         view.delegate = null
         headerView = null
         headerViewDidChangeSize(0, 0)
+      }
+
+      is TrueSheetNavBarView -> {
+        view.delegate = null
+        view.detachToolbar()
+        navBarView = null
+        navBarViewDidChangeHeight(0, 0)
       }
 
       is TrueSheetFooterView -> {
@@ -215,6 +240,13 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
 
   override fun headerViewDidChangeSize(width: Int, height: Int) {
     headerHeight = height
+    delegate?.containerViewHeaderDidChangeSize(width, height)
+  }
+
+  override fun navBarViewDidChangeHeight(width: Int, height: Int) {
+    headerHeight = height
+    // The toolbar isn't part of the RN layout — shift the container below it
+    translationY = height.toFloat()
     delegate?.containerViewHeaderDidChangeSize(width, height)
   }
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetNavBarItemView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetNavBarItemView.kt
@@ -1,0 +1,63 @@
+package com.lodev09.truesheet
+
+import android.annotation.SuppressLint
+import android.view.View
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.views.view.ReactViewGroup
+
+/**
+ * Bar item view re-parented into the nav bar's toolbar.
+ * RN/Yoga computes its size, but the toolbar owns its position — onMeasure
+ * reports the size captured from React's mount pass so the toolbar's own
+ * measure pass doesn't collapse it.
+ */
+@SuppressLint("ViewConstructor")
+class TrueSheetNavBarItemView(context: ThemedReactContext) : ReactViewGroup(context) {
+
+  enum class SlotType {
+    LEFT,
+    RIGHT,
+    TITLE;
+
+    companion object {
+      fun fromString(value: String?): SlotType =
+        when (value) {
+          "right" -> RIGHT
+          "title" -> TITLE
+          else -> LEFT
+        }
+    }
+  }
+
+  var navBar: TrueSheetNavBarView? = null
+
+  var slotType: SlotType = SlotType.LEFT
+    set(value) {
+      if (field == value) return
+      field = value
+      navBar?.itemSlotDidChange(this)
+    }
+
+  private var reactWidth = 0
+  private var reactHeight = 0
+
+  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+    if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.EXACTLY &&
+      MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.EXACTLY
+    ) {
+      // Exact specs come from React's mount pass — capture the Yoga-computed
+      // size and have the toolbar re-layout with it
+      reactWidth = MeasureSpec.getSize(widthMeasureSpec)
+      reactHeight = MeasureSpec.getSize(heightMeasureSpec)
+      (parent as? View)?.let {
+        forceLayout()
+        it.requestLayout()
+      }
+    }
+    setMeasuredDimension(reactWidth, reactHeight)
+  }
+
+  companion object {
+    const val TAG_NAME = "TrueSheet"
+  }
+}

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetNavBarItemViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetNavBarItemViewManager.kt
@@ -1,0 +1,36 @@
+package com.lodev09.truesheet
+
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewGroupManager
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.TrueSheetNavBarItemViewManagerDelegate
+import com.facebook.react.viewmanagers.TrueSheetNavBarItemViewManagerInterface
+
+/**
+ * ViewManager for TrueSheetNavBarItemView
+ * Bar item slot re-parented into the nav bar's toolbar
+ */
+@ReactModule(name = TrueSheetNavBarItemViewManager.REACT_CLASS)
+class TrueSheetNavBarItemViewManager :
+  ViewGroupManager<TrueSheetNavBarItemView>(),
+  TrueSheetNavBarItemViewManagerInterface<TrueSheetNavBarItemView> {
+
+  private val delegate: ViewManagerDelegate<TrueSheetNavBarItemView> = TrueSheetNavBarItemViewManagerDelegate(this)
+
+  override fun getName(): String = REACT_CLASS
+
+  override fun createViewInstance(reactContext: ThemedReactContext): TrueSheetNavBarItemView = TrueSheetNavBarItemView(reactContext)
+
+  override fun getDelegate(): ViewManagerDelegate<TrueSheetNavBarItemView> = delegate
+
+  @ReactProp(name = "slotType")
+  override fun setSlotType(view: TrueSheetNavBarItemView, value: String?) {
+    view.slotType = TrueSheetNavBarItemView.SlotType.fromString(value)
+  }
+
+  companion object {
+    const val REACT_CLASS = "TrueSheetNavBarItemView"
+  }
+}

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetNavBarView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetNavBarView.kt
@@ -1,0 +1,360 @@
+package com.lodev09.truesheet
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.res.Configuration
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.widget.SearchView
+import androidx.appcompat.widget.Toolbar
+import com.facebook.react.uimanager.PixelUtil.dpToPx
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.Event
+import com.facebook.react.uimanager.events.EventDispatcher
+import com.facebook.react.views.view.ReactViewGroup
+import com.google.android.material.appbar.MaterialToolbar
+import com.lodev09.truesheet.events.*
+
+/**
+ * Delegate interface for nav bar height changes
+ */
+interface TrueSheetNavBarViewDelegate {
+  fun navBarViewDidChangeHeight(width: Int, height: Int)
+}
+
+/**
+ * Invisible config view for the sheet's native navigation bar.
+ * Owns a MaterialToolbar that is attached natively to the sheet's controller,
+ * pinned above the RN-managed container. Bar item children are re-parented
+ * into the toolbar — child accessors are proxied so React still sees them.
+ */
+@SuppressLint("ViewConstructor")
+class TrueSheetNavBarView(private val reactContext: ThemedReactContext) : ReactViewGroup(reactContext) {
+
+  var delegate: TrueSheetNavBarViewDelegate? = null
+  var eventDispatcher: EventDispatcher? = null
+
+  // ==================== Props ====================
+
+  var title: String? = null
+  var largeTitle: Boolean = false
+  var tintColor: Int? = null
+  var titleColor: Int? = null
+  var barColor: Int? = null
+  var separatorHidden: Boolean = false
+  var searchable: Boolean = false
+  var searchPlaceholder: String? = null
+
+  // ==================== Toolbar ====================
+
+  private val toolbarView: ToolbarView = ToolbarView(reactContext)
+
+  val toolbar: MaterialToolbar
+    get() = toolbarView
+
+  private var lastBarHeight = 0
+  private var isRelayoutPending = false
+
+  // Mirrors React's child indices — the actual native parent is the toolbar
+  private val itemViews = mutableListOf<View>()
+
+  private var searchMenuItem: MenuItem? = null
+  private var searchView: SearchView? = null
+
+  init {
+    toolbar.minimumHeight = resolveActionBarSize()
+    toolbar.setBackgroundColor(Color.TRANSPARENT)
+  }
+
+  // ==================== React Child Management ====================
+
+  override fun addView(child: View?, index: Int) {
+    child ?: return
+
+    itemViews.add(index, child)
+    toolbar.addView(child, createItemLayoutParams(child))
+
+    if (child is TrueSheetNavBarItemView) {
+      child.navBar = this
+    }
+    updateTitle()
+  }
+
+  override fun getChildCount(): Int = itemViews.size
+
+  override fun getChildAt(index: Int): View? = itemViews.getOrNull(index)
+
+  override fun removeViewAt(index: Int) {
+    val child = itemViews.removeAt(index)
+    toolbar.removeView(child)
+
+    if (child is TrueSheetNavBarItemView) {
+      child.navBar = null
+    }
+    updateTitle()
+  }
+
+  // ==================== Layout ====================
+
+  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    // The config view spans the container's width (height stays 0)
+    layoutToolbar()
+  }
+
+  /**
+   * Manually measures and lays out the toolbar — its parent is a React-managed
+   * view group that never runs a native layout pass on it.
+   */
+  fun layoutToolbar() {
+    val barWidth = if (width > 0) width else (toolbar.parent as? View)?.width ?: 0
+    if (barWidth <= 0) return
+
+    toolbar.measure(
+      MeasureSpec.makeMeasureSpec(barWidth, MeasureSpec.EXACTLY),
+      MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+    )
+    val newBarHeight = toolbar.measuredHeight
+    toolbar.layout(0, 0, barWidth, newBarHeight)
+
+    if (newBarHeight != lastBarHeight) {
+      lastBarHeight = newBarHeight
+      delegate?.navBarViewDidChangeHeight(barWidth, newBarHeight)
+    }
+  }
+
+  private fun requestBarLayout() {
+    toolbar.requestLayout()
+  }
+
+  // ==================== Toolbar Attachment ====================
+
+  /**
+   * Attaches the toolbar to the sheet's controller so it stays pinned at the
+   * sheet's top edge, above (and outside) the RN-managed container.
+   */
+  fun attachToolbar() {
+    val controller = (parent as? TrueSheetContainerView)?.parent as? TrueSheetViewController ?: return
+    if (toolbar.parent === controller) return
+
+    (toolbar.parent as? ViewGroup)?.removeView(toolbar)
+    controller.addView(toolbar)
+    layoutToolbar()
+  }
+
+  fun detachToolbar() {
+    (toolbar.parent as? ViewGroup)?.removeView(toolbar)
+  }
+
+  // ==================== Configuration ====================
+
+  /**
+   * Called by the ViewManager after all properties are set.
+   */
+  fun finalizeUpdates() {
+    toolbar.setBackgroundColor(barColor ?: Color.TRANSPARENT)
+    toolbarView.separatorVisible = !separatorHidden
+
+    // No large title collapse behavior on Android — bump the title text appearance instead
+    val titleAppearance = if (largeTitle) {
+      androidx.appcompat.R.style.TextAppearance_AppCompat_Headline
+    } else {
+      androidx.appcompat.R.style.TextAppearance_AppCompat_Widget_ActionBar_Title
+    }
+    toolbar.setTitleTextAppearance(context, titleAppearance)
+    toolbar.setTitleTextColor(titleColor ?: tintColor ?: defaultTitleColor())
+
+    tintColor?.let {
+      toolbar.setNavigationIconTint(it)
+      toolbar.collapseIcon?.setTint(it)
+    }
+
+    updateTitle()
+    setupSearch()
+    requestBarLayout()
+  }
+
+  fun itemSlotDidChange(item: TrueSheetNavBarItemView) {
+    (item.layoutParams as? Toolbar.LayoutParams)?.let {
+      it.gravity = gravityForSlotType(item.slotType)
+      item.layoutParams = it
+    }
+    updateTitle()
+    requestBarLayout()
+  }
+
+  private fun createItemLayoutParams(child: View): Toolbar.LayoutParams {
+    val slotType = (child as? TrueSheetNavBarItemView)?.slotType ?: TrueSheetNavBarItemView.SlotType.LEFT
+    return Toolbar.LayoutParams(
+      Toolbar.LayoutParams.WRAP_CONTENT,
+      Toolbar.LayoutParams.WRAP_CONTENT,
+      gravityForSlotType(slotType)
+    )
+  }
+
+  private fun gravityForSlotType(slotType: TrueSheetNavBarItemView.SlotType): Int {
+    val horizontalGravity = when (slotType) {
+      TrueSheetNavBarItemView.SlotType.RIGHT -> Gravity.END
+      TrueSheetNavBarItemView.SlotType.TITLE -> Gravity.CENTER_HORIZONTAL
+      else -> Gravity.START
+    }
+    return horizontalGravity or Gravity.CENTER_VERTICAL
+  }
+
+  /**
+   * A title item acts as the title custom view — it replaces the title text.
+   */
+  private fun updateTitle() {
+    val hasTitleItem = itemViews.any { (it as? TrueSheetNavBarItemView)?.slotType == TrueSheetNavBarItemView.SlotType.TITLE }
+    toolbar.title = if (hasTitleItem) null else title
+  }
+
+  // ==================== Search ====================
+
+  private fun setupSearch() {
+    if (!searchable) {
+      if (searchMenuItem != null) {
+        toolbar.menu.removeItem(SEARCH_MENU_ITEM_ID)
+        searchMenuItem = null
+        searchView = null
+      }
+      return
+    }
+
+    if (searchMenuItem == null) {
+      val search = SearchView(toolbar.context).apply {
+        setOnQueryTextFocusChangeListener { _, hasFocus ->
+          dispatchEvent(
+            if (hasFocus) {
+              SearchFocusEvent(surfaceId, id)
+            } else {
+              SearchBlurEvent(surfaceId, id)
+            }
+          )
+        }
+        setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+          override fun onQueryTextChange(newText: String): Boolean {
+            dispatchEvent(SearchChangeEvent(surfaceId, id, newText))
+            return true
+          }
+
+          override fun onQueryTextSubmit(query: String): Boolean {
+            dispatchEvent(SearchSubmitEvent(surfaceId, id, query))
+            return true
+          }
+        })
+      }
+      searchView = search
+
+      searchMenuItem = toolbar.menu.add(Menu.NONE, SEARCH_MENU_ITEM_ID, Menu.NONE, SEARCH_MENU_TITLE).apply {
+        setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS or MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW)
+        setIcon(androidx.appcompat.R.drawable.abc_ic_search_api_material)
+        actionView = search
+        setOnActionExpandListener(object : MenuItem.OnActionExpandListener {
+          override fun onMenuItemActionExpand(item: MenuItem): Boolean = true
+
+          override fun onMenuItemActionCollapse(item: MenuItem): Boolean {
+            search.setQuery("", false)
+            dispatchEvent(SearchCancelEvent(surfaceId, id))
+            return true
+          }
+        })
+      }
+    }
+
+    searchView?.queryHint = searchPlaceholder
+    tintColor?.let { searchMenuItem?.icon?.setTint(it) }
+  }
+
+  // ==================== Event Dispatching ====================
+
+  private val surfaceId: Int
+    get() = UIManagerHelper.getSurfaceId(this)
+
+  private fun dispatchEvent(event: Event<*>) {
+    eventDispatcher?.dispatchEvent(event)
+  }
+
+  // ==================== Helpers ====================
+
+  private fun defaultTitleColor(): Int {
+    val typedArray = context.obtainStyledAttributes(intArrayOf(android.R.attr.textColorPrimary))
+    val color = typedArray.getColor(0, Color.BLACK)
+    typedArray.recycle()
+    return color
+  }
+
+  private fun resolveActionBarSize(): Int {
+    val typedValue = TypedValue()
+    val resolved = context.theme.resolveAttribute(androidx.appcompat.R.attr.actionBarSize, typedValue, true) ||
+      context.theme.resolveAttribute(android.R.attr.actionBarSize, typedValue, true)
+
+    return if (resolved) {
+      TypedValue.complexToDimensionPixelSize(typedValue.data, resources.displayMetrics)
+    } else {
+      DEFAULT_BAR_HEIGHT.dpToPx().toInt()
+    }
+  }
+
+  private fun isDarkMode(): Boolean =
+    (
+      reactContext.resources.configuration.uiMode and
+        Configuration.UI_MODE_NIGHT_MASK
+      ) == Configuration.UI_MODE_NIGHT_YES
+
+  // ==================== ToolbarView ====================
+
+  private inner class ToolbarView(context: Context) : MaterialToolbar(context) {
+    var separatorVisible = false
+      set(value) {
+        if (field == value) return
+        field = value
+        invalidate()
+      }
+
+    private val separatorPaint = Paint().apply {
+      color = if (isDarkMode()) SEPARATOR_COLOR_DARK else SEPARATOR_COLOR_LIGHT
+    }
+
+    override fun requestLayout() {
+      super.requestLayout()
+
+      // React-managed ancestors never run a native layout pass on the toolbar —
+      // schedule a manual one
+      if (isRelayoutPending) return
+      isRelayoutPending = true
+      post {
+        isRelayoutPending = false
+        layoutToolbar()
+      }
+    }
+
+    override fun dispatchDraw(canvas: Canvas) {
+      super.dispatchDraw(canvas)
+      if (separatorVisible) {
+        val separatorHeight = maxOf(1f, SEPARATOR_HEIGHT.dpToPx())
+        canvas.drawRect(0f, height - separatorHeight, width.toFloat(), height.toFloat(), separatorPaint)
+      }
+    }
+  }
+
+  companion object {
+    const val TAG_NAME = "TrueSheet"
+
+    private const val DEFAULT_BAR_HEIGHT = 56 // dp
+    private const val SEPARATOR_HEIGHT = 0.5f // dp
+    private const val SEARCH_MENU_ITEM_ID = 1
+    private const val SEARCH_MENU_TITLE = "Search"
+
+    private const val SEPARATOR_COLOR_LIGHT = 0x1F000000
+    private const val SEPARATOR_COLOR_DARK = 0x33FFFFFF
+  }
+}

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetNavBarViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetNavBarViewManager.kt
@@ -1,0 +1,101 @@
+package com.lodev09.truesheet
+
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.ViewGroupManager
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.TrueSheetNavBarViewManagerDelegate
+import com.facebook.react.viewmanagers.TrueSheetNavBarViewManagerInterface
+import com.lodev09.truesheet.events.*
+
+/**
+ * ViewManager for TrueSheetNavBarView
+ * Config view for the sheet's native navigation bar
+ */
+@ReactModule(name = TrueSheetNavBarViewManager.REACT_CLASS)
+class TrueSheetNavBarViewManager :
+  ViewGroupManager<TrueSheetNavBarView>(),
+  TrueSheetNavBarViewManagerInterface<TrueSheetNavBarView> {
+
+  private val delegate: ViewManagerDelegate<TrueSheetNavBarView> = TrueSheetNavBarViewManagerDelegate(this)
+
+  override fun getName(): String = REACT_CLASS
+
+  override fun createViewInstance(reactContext: ThemedReactContext): TrueSheetNavBarView = TrueSheetNavBarView(reactContext)
+
+  override fun getDelegate(): ViewManagerDelegate<TrueSheetNavBarView> = delegate
+
+  override fun onDropViewInstance(view: TrueSheetNavBarView) {
+    super.onDropViewInstance(view)
+    view.detachToolbar()
+  }
+
+  override fun onAfterUpdateTransaction(view: TrueSheetNavBarView) {
+    super.onAfterUpdateTransaction(view)
+    view.finalizeUpdates()
+  }
+
+  override fun addEventEmitters(reactContext: ThemedReactContext, view: TrueSheetNavBarView) {
+    val dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.id)
+    view.eventDispatcher = dispatcher
+  }
+
+  override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> =
+    mutableMapOf(
+      SearchChangeEvent.EVENT_NAME to hashMapOf("registrationName" to SearchChangeEvent.REGISTRATION_NAME),
+      SearchSubmitEvent.EVENT_NAME to hashMapOf("registrationName" to SearchSubmitEvent.REGISTRATION_NAME),
+      SearchFocusEvent.EVENT_NAME to hashMapOf("registrationName" to SearchFocusEvent.REGISTRATION_NAME),
+      SearchBlurEvent.EVENT_NAME to hashMapOf("registrationName" to SearchBlurEvent.REGISTRATION_NAME),
+      SearchCancelEvent.EVENT_NAME to hashMapOf("registrationName" to SearchCancelEvent.REGISTRATION_NAME)
+    )
+
+  // ==================== Props ====================
+
+  @ReactProp(name = "title")
+  override fun setTitle(view: TrueSheetNavBarView, value: String?) {
+    view.title = value
+  }
+
+  @ReactProp(name = "largeTitle", defaultBoolean = false)
+  override fun setLargeTitle(view: TrueSheetNavBarView, value: Boolean) {
+    view.largeTitle = value
+  }
+
+  @ReactProp(name = "tintColor", customType = "Color")
+  override fun setTintColor(view: TrueSheetNavBarView, value: Int?) {
+    view.tintColor = value
+  }
+
+  @ReactProp(name = "titleColor", customType = "Color")
+  override fun setTitleColor(view: TrueSheetNavBarView, value: Int?) {
+    view.titleColor = value
+  }
+
+  @ReactProp(name = "barColor", customType = "Color")
+  override fun setBarColor(view: TrueSheetNavBarView, value: Int?) {
+    view.barColor = value
+  }
+
+  @ReactProp(name = "separatorHidden", defaultBoolean = false)
+  override fun setSeparatorHidden(view: TrueSheetNavBarView, value: Boolean) {
+    view.separatorHidden = value
+  }
+
+  @ReactProp(name = "searchable", defaultBoolean = false)
+  override fun setSearchable(view: TrueSheetNavBarView, value: Boolean) {
+    view.searchable = value
+  }
+
+  @ReactProp(name = "searchOptions")
+  override fun setSearchOptions(view: TrueSheetNavBarView, options: ReadableMap?) {
+    // cancelText, hideWhenScrolling, and searchPlacement are iOS-specific - no-op on Android
+    view.searchPlaceholder = if (options != null && options.hasKey("placeholder")) options.getString("placeholder") else null
+  }
+
+  companion object {
+    const val REACT_CLASS = "TrueSheetNavBarView"
+  }
+}

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetPackage.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetPackage.kt
@@ -39,6 +39,8 @@ class TrueSheetPackage : BaseReactPackage() {
       TrueSheetContainerViewManager(),
       TrueSheetContentViewManager(),
       TrueSheetHeaderViewManager(),
+      TrueSheetNavBarViewManager(),
+      TrueSheetNavBarItemViewManager(),
       TrueSheetFooterViewManager(),
       TrueSheetPeekViewManager()
     )

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -120,6 +120,11 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
 
     if (child is TrueSheetContainerView) {
       child.delegate = this
+
+      // A nav bar mounts before its container reaches the controller —
+      // attach its toolbar now that the hierarchy is complete
+      child.navBarView?.attachToolbar()
+
       val surfaceId = UIManagerHelper.getSurfaceId(this)
       eventDispatcher?.dispatchEvent(MountEvent(surfaceId, id))
     }
@@ -141,6 +146,10 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
           dismiss(true) {}
         }
       }
+
+      // The nav bar toolbar lives in the controller, outside the container's
+      // subtree — detach it so the controller only holds React children
+      child.navBarView?.detachToolbar()
     }
     viewController.removeView(child)
   }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -272,6 +272,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   // Cached values used during dismiss when container is unmounted
   private var cachedContentHeight: Int = 0
   private var cachedHeaderHeight: Int = 0
+  private var cachedNavBarHeight: Int = 0
   private var cachedFooterHeight: Int = 0
   private var cachedPeekContentHeight: Int = 0
 
@@ -280,6 +281,11 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   override val headerHeight: Int
     get() = containerView?.headerHeight ?: cachedHeaderHeight
+
+  // Native nav bar toolbar height — counts toward detents (via headerHeight)
+  // but sits outside the RN-managed container, which is offset below it
+  private val navBarHeight: Int
+    get() = containerView?.navBarHeight ?: cachedNavBarHeight
 
   override var absoluteHeader: Boolean = false
 
@@ -392,6 +398,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     wasHiddenByScreen = false
     cachedContentHeight = 0
     cachedHeaderHeight = 0
+    cachedNavBarHeight = 0
     isPresentAnimating = false
     lastEmittedPositionPx = -1
     detentIndexBeforeKeyboard = -1
@@ -840,6 +847,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     containerView?.let {
       cachedContentHeight = it.contentHeight
       cachedHeaderHeight = it.headerHeight
+      cachedNavBarHeight = it.navBarHeight
       cachedFooterHeight = it.footerHeight
       cachedPeekContentHeight = it.peekContentHeight
     }
@@ -1009,7 +1017,9 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     val sheetHeight = sheet.height
     val sheetTop = sheet.top
 
-    var footerY = (sheetHeight - sheetTop - footerHeight - keyboardShift).toFloat()
+    // Footer coordinates are relative to the container, which is offset below
+    // the nav bar toolbar when one is present
+    var footerY = (sheetHeight - sheetTop - footerHeight - keyboardShift - navBarHeight).toFloat()
 
     // Adjust during dismiss animation when slideOffset is negative. Skipped
     // while the keyboard is open — the detents collapse to the expanded
@@ -1021,7 +1031,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     }
 
     // Clamp to prevent footer going above safe area
-    val maxAllowedY = (sheetHeight - topInset - footerHeight).toFloat()
+    val maxAllowedY = (sheetHeight - topInset - footerHeight - navBarHeight).toFloat()
     footerView.y = minOf(footerY, maxAllowedY)
   }
 
@@ -1284,7 +1294,11 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     val targetIndex = (if (pendingDetentIndex >= 0) pendingDetentIndex else currentDetentIndex)
       .coerceIn(0, detents.size - 1)
     val maxAvailableHeight = realScreenHeight - topInset
-    val newHeight = minOf(detentCalculator.getDetentHeight(detents[targetIndex]), maxAvailableHeight)
+
+    // The nav bar toolbar sits above the container — the container only gets
+    // the remaining height below it
+    val newHeight = (minOf(detentCalculator.getDetentHeight(detents[targetIndex]), maxAvailableHeight) - navBarHeight)
+      .coerceAtLeast(0)
     val newWidth = getStateWidth()
 
     if (deferShrink && newWidth == lastStateWidth && newHeight < lastStateHeight) return
@@ -1302,7 +1316,8 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
     val maxAvailableHeight = realScreenHeight - topInset
     val minHeight = minOf(detentCalculator.getDetentHeight(detents.first()), maxAvailableHeight)
-    val newHeight = detentCalculator.getVisibleSheetHeight(sheetTop).coerceIn(minHeight, maxAvailableHeight)
+    val newHeight = (detentCalculator.getVisibleSheetHeight(sheetTop).coerceIn(minHeight, maxAvailableHeight) - navBarHeight)
+      .coerceAtLeast(0)
 
     setStateDimensions(getStateWidth(), newHeight)
   }

--- a/android/src/main/java/com/lodev09/truesheet/events/TrueSheetSearchEvents.kt
+++ b/android/src/main/java/com/lodev09/truesheet/events/TrueSheetSearchEvents.kt
@@ -1,0 +1,88 @@
+package com.lodev09.truesheet.events
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+/**
+ * Fired when the nav bar search text changes
+ * Payload: { text: string }
+ */
+class SearchChangeEvent(surfaceId: Int, viewId: Int, private val text: String) : Event<SearchChangeEvent>(surfaceId, viewId) {
+
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap =
+    Arguments.createMap().apply {
+      putString("text", text)
+    }
+
+  companion object {
+    const val EVENT_NAME = "topSearchChange"
+    const val REGISTRATION_NAME = "onSearchChange"
+  }
+}
+
+/**
+ * Fired when the nav bar search is submitted
+ * Payload: { text: string }
+ */
+class SearchSubmitEvent(surfaceId: Int, viewId: Int, private val text: String) : Event<SearchSubmitEvent>(surfaceId, viewId) {
+
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap =
+    Arguments.createMap().apply {
+      putString("text", text)
+    }
+
+  companion object {
+    const val EVENT_NAME = "topSearchSubmit"
+    const val REGISTRATION_NAME = "onSearchSubmit"
+  }
+}
+
+/**
+ * Fired when the nav bar search field gains focus
+ */
+class SearchFocusEvent(surfaceId: Int, viewId: Int) : Event<SearchFocusEvent>(surfaceId, viewId) {
+
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap = Arguments.createMap()
+
+  companion object {
+    const val EVENT_NAME = "topSearchFocus"
+    const val REGISTRATION_NAME = "onSearchFocus"
+  }
+}
+
+/**
+ * Fired when the nav bar search field loses focus
+ */
+class SearchBlurEvent(surfaceId: Int, viewId: Int) : Event<SearchBlurEvent>(surfaceId, viewId) {
+
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap = Arguments.createMap()
+
+  companion object {
+    const val EVENT_NAME = "topSearchBlur"
+    const val REGISTRATION_NAME = "onSearchBlur"
+  }
+}
+
+/**
+ * Fired when the nav bar search is cancelled (search view collapsed)
+ */
+class SearchCancelEvent(surfaceId: Int, viewId: Int) : Event<SearchCancelEvent>(surfaceId, viewId) {
+
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap = Arguments.createMap()
+
+  companion object {
+    const val EVENT_NAME = "topSearchCancel"
+    const val REGISTRATION_NAME = "onSearchCancel"
+  }
+}

--- a/example/shared/src/components/sheets/NavBarSheet.tsx
+++ b/example/shared/src/components/sheets/NavBarSheet.tsx
@@ -1,0 +1,81 @@
+import { forwardRef, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { TrueSheet, TrueSheetNavBar, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
+
+import { BORDER_RADIUS, GAP, LIGHT_GRAY, SPACING, times } from '../../utils';
+
+interface NavBarSheetProps extends TrueSheetProps {}
+
+const ITEMS = times(30, (i) => `Item #${i + 1}`);
+
+export const NavBarSheet = forwardRef<TrueSheet, NavBarSheetProps>((props, ref) => {
+  const [query, setQuery] = useState('');
+
+  const items = ITEMS.filter((item) => item.toLowerCase().includes(query.toLowerCase()));
+
+  const dismiss = () => {
+    if (typeof ref === 'object' && ref?.current) {
+      ref.current.dismiss();
+    }
+  };
+
+  return (
+    <TrueSheet
+      ref={ref}
+      name="navbar"
+      detents={[0.6, 1]}
+      style={styles.sheet}
+      header={
+        <TrueSheetNavBar
+          title="Nav Bar"
+          largeTitle
+          search={{ placeholder: 'Search items' }}
+          onSearchChange={(event) => setQuery(event.nativeEvent.text)}
+          onSearchCancel={() => setQuery('')}
+        >
+          <TrueSheetNavBar.Right>
+            <Pressable onPress={dismiss} hitSlop={8}>
+              <Text style={styles.doneText}>Done</Text>
+            </Pressable>
+          </TrueSheetNavBar.Right>
+        </TrueSheetNavBar>
+      }
+      onDidPresent={() => console.log('NavBar sheet presented!')}
+      onDidDismiss={() => console.log('NavBar sheet dismissed!')}
+      {...props}
+    >
+      <ScrollView contentContainerStyle={styles.content} keyboardDismissMode="on-drag">
+        {items.map((item) => (
+          <View key={item} style={styles.item}>
+            <Text style={styles.itemText}>{item}</Text>
+          </View>
+        ))}
+      </ScrollView>
+    </TrueSheet>
+  );
+});
+
+NavBarSheet.displayName = 'NavBarSheet';
+
+const styles = StyleSheet.create({
+  sheet: {
+    flex: 1,
+  },
+  content: {
+    padding: SPACING,
+    gap: GAP,
+  },
+  doneText: {
+    fontSize: 17,
+    fontWeight: '600',
+    color: '#0A84FF',
+  },
+  item: {
+    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+    borderRadius: BORDER_RADIUS,
+    padding: SPACING,
+  },
+  itemText: {
+    color: LIGHT_GRAY,
+  },
+});

--- a/example/shared/src/components/sheets/index.ts
+++ b/example/shared/src/components/sheets/index.ts
@@ -5,3 +5,4 @@ export * from './FlatListSheet';
 export * from './GestureSheet';
 export * from './BlankSheet';
 export * from './NavigationSheet';
+export * from './NavBarSheet';

--- a/example/shared/src/screens/MapScreen.tsx
+++ b/example/shared/src/screens/MapScreen.tsx
@@ -43,6 +43,7 @@ import {
   BasicSheet,
   FlatListSheet,
   GestureSheet,
+  NavBarSheet,
   PromptSheet,
   ScrollViewSheet,
 } from '../components/sheets';
@@ -108,6 +109,7 @@ const MapScreenInner = ({
   const scrollViewSheet = useRef<TrueSheet>(null);
   const flatListSheet = useRef<TrueSheet>(null);
   const gestureSheet = useRef<TrueSheet>(null);
+  const navBarSheet = useRef<TrueSheet>(null);
 
   const [anchorLeft, setAnchorLeft] = useState(false);
   const [scrollViewLoading, setScrollViewLoading] = useState(false);
@@ -249,8 +251,11 @@ const MapScreenInner = ({
           onPress={() => presentBasicSheet(0)}
           onLongPress={rapidPresentDismiss}
         />
-        <Button text="Open Modal" onPress={onNavigateToModal} />
-        <Button text="Sheet Navigator" onPress={onNavigateToSheetStack} />
+        <Button text="Nav Bar" onPress={() => navBarSheet.current?.present()} />
+        <ButtonGroup>
+          <Button text="Open Modal" onPress={onNavigateToModal} />
+          <Button text="Sheet Navigator" onPress={onNavigateToSheetStack} />
+        </ButtonGroup>
         {isTablet && (
           <ButtonGroup>
             <Button text="Anchor Left" onPress={() => setAnchorLeft(true)} />
@@ -297,6 +302,7 @@ const MapScreenInner = ({
         <ScrollViewSheet ref={scrollViewSheet} />
         <FlatListSheet ref={flatListSheet} />
         <GestureSheet ref={gestureSheet} />
+        <NavBarSheet ref={navBarSheet} />
       </ReanimatedTrueSheet>
     </View>
   );

--- a/example/shared/src/screens/MapScreen.tsx
+++ b/example/shared/src/screens/MapScreen.tsx
@@ -12,10 +12,12 @@ import {
 } from 'react-native';
 import {
   TrueSheet,
+  TrueSheetNavBar,
   type DetentChangeEvent,
   type DidPresentEvent,
   type DragBeginEvent,
   type DragEndEvent,
+  type SearchChangeEvent,
   type WillPresentEvent,
 } from '@lodev09/react-native-true-sheet';
 import {
@@ -34,7 +36,7 @@ import Animated, {
 import { TrueSheetProvider } from '@lodev09/react-native-true-sheet';
 import { ReanimatedTrueSheetProvider } from '@lodev09/react-native-true-sheet/reanimated';
 
-import { Button, ButtonGroup, DemoContent, Header, Spacer } from '../components';
+import { Button, ButtonGroup, DemoContent, Spacer } from '../components';
 import { BLUE, DARK, GAP, GRAY, HEADER_HEIGHT, SPACING } from '../utils';
 
 import {
@@ -228,7 +230,14 @@ const MapScreenInner = ({
         // }}
         onWillDismiss={() => log('willDismiss')}
         onDidDismiss={() => log('didDismiss')}
-        header={<Header />}
+        header={
+          <TrueSheetNavBar
+            search={{ placeholder: 'Search maps', hideWhenScrolling: false }}
+            onSearchChange={(e: SearchChangeEvent) => log(`search: ${e.nativeEvent.text}`)}
+            onSearchFocus={() => sheetRef.current?.resize(2)}
+            onSearchCancel={() => sheetRef.current?.resize(0)}
+          />
+        }
       >
         <View style={styles.heading}>
           <Text style={styles.title}>True Sheet</Text>

--- a/example/shared/src/screens/StandardScreen.tsx
+++ b/example/shared/src/screens/StandardScreen.tsx
@@ -7,6 +7,7 @@ import {
   BlankSheet,
   FlatListSheet,
   GestureSheet,
+  NavBarSheet,
   NavigationSheet,
   PromptSheet,
   ScrollViewSheet,
@@ -32,6 +33,7 @@ export const StandardScreen = ({
   const gestureSheet = useRef<TrueSheet>(null);
   const blankSheet = useRef<TrueSheet>(null);
   const navigationSheet = useRef<TrueSheet>(null);
+  const navBarSheet = useRef<TrueSheet>(null);
 
   const presentBasicSheet = async (index = 0) => {
     await basicSheet.current?.present(index);
@@ -57,6 +59,7 @@ export const StandardScreen = ({
         <Button text="TrueSheet FlatList" onPress={() => flatListSheet.current?.present()} />
         <Button text="TrueSheet Gestures" onPress={() => gestureSheet.current?.present()} />
         <Button text="Blank Sheet" onPress={() => blankSheet.current?.present()} />
+        <Button text="TrueSheet NavBar" onPress={() => navBarSheet.current?.present()} />
 
         <BasicSheet ref={basicSheet} onNavigateToTest={onNavigateToTest} />
         <PromptSheet ref={promptSheet} />
@@ -65,6 +68,7 @@ export const StandardScreen = ({
         <GestureSheet ref={gestureSheet} />
         <BlankSheet ref={blankSheet} />
         <NavigationSheet ref={navigationSheet} />
+        <NavBarSheet ref={navBarSheet} />
       </View>
     </TrueSheetProvider>
   );

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @class TrueSheetPeekView;
+@class TrueSheetNavBarView;
 
 @protocol TrueSheetContainerViewDelegate <NSObject>
 
@@ -35,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)containerViewHeaderDidChangeSize:(CGSize)newSize;
 - (void)containerViewFooterDidChangeSize:(CGSize)newSize;
 - (void)containerViewPeekDidChangeSize:(CGSize)newSize;
+- (void)containerViewNavBarDidChange;
 
 @end
 
@@ -66,6 +68,11 @@ NS_ASSUME_NONNULL_BEGIN
  * owns the sheet's bottom edge, so its background fills the inset
  */
 @property (nonatomic, assign) CGFloat footerBottomInset;
+
+/**
+ * The mounted nav bar config component, if any
+ */
+@property (nonatomic, weak, readonly, nullable) TrueSheetNavBarView *navBarView;
 
 /**
  * Returns the current content height

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -13,6 +13,7 @@
 #import "TrueSheetContentView.h"
 #import "TrueSheetFooterView.h"
 #import "TrueSheetHeaderView.h"
+#import "TrueSheetNavBarView.h"
 #import "TrueSheetPeekView.h"
 #import "TrueSheetViewController.h"
 #import "core/TrueSheetKeyboardObserver.h"
@@ -54,6 +55,7 @@ using namespace facebook::react;
   TrueSheetHeaderView *_headerView;
   TrueSheetFooterView *_footerView;
   TrueSheetPeekView *__weak _peekView;
+  TrueSheetNavBarView *__weak _navBarView;
   TrueSheetKeyboardObserver *_keyboardObserver;
 }
 
@@ -229,6 +231,17 @@ using namespace facebook::react;
     [_footerView setBottomInset:_footerBottomInset];
     [self footerViewDidChangeSize:_footerView.frame.size];
   }
+
+  if ([childComponentView isKindOfClass:[TrueSheetNavBarView class]]) {
+    if (_navBarView != nil) {
+      RCTLogWarn(@"TrueSheet: Container can only have one nav bar component.");
+      return;
+    }
+    _navBarView = (TrueSheetNavBarView *)childComponentView;
+    if ([self.delegate respondsToSelector:@selector(containerViewNavBarDidChange)]) {
+      [self.delegate containerViewNavBarDidChange];
+    }
+  }
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
@@ -248,6 +261,14 @@ using namespace facebook::react;
     _footerView = nil;
     _contentView.footerView = nil;
     [self footerViewDidChangeSize:CGSizeZero];
+  }
+
+  if ([childComponentView isKindOfClass:[TrueSheetNavBarView class]] && _navBarView == childComponentView) {
+    [_navBarView detach];
+    _navBarView = nil;
+    if ([self.delegate respondsToSelector:@selector(containerViewNavBarDidChange)]) {
+      [self.delegate containerViewNavBarDidChange];
+    }
   }
 
   [super unmountChildComponentView:childComponentView index:index];

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -233,9 +233,10 @@ using namespace facebook::react;
   }
 
   if ([childComponentView isKindOfClass:[TrueSheetNavBarView class]]) {
-    if (_navBarView != nil) {
-      RCTLogWarn(@"TrueSheet: Container can only have one nav bar component.");
-      return;
+    if (_navBarView != nil && _navBarView != childComponentView) {
+      // A remount (e.g. reload) can insert the replacement before the old
+      // config unmounts — hand over instead of dropping the new one
+      [_navBarView detach];
     }
     _navBarView = (TrueSheetNavBarView *)childComponentView;
     if ([self.delegate respondsToSelector:@selector(containerViewNavBarDidChange)]) {

--- a/ios/TrueSheetNavBarItemView.h
+++ b/ios/TrueSheetNavBarItemView.h
@@ -1,0 +1,39 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import <React/RCTViewComponentView.h>
+#import <UIKit/UIKit.h>
+#import <react/renderer/components/TrueSheetSpec/Props.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class TrueSheetNavBarItemView;
+
+@protocol TrueSheetNavBarItemViewDelegate <NSObject>
+@optional
+- (void)navBarItemViewDidChangeSize:(TrueSheetNavBarItemView *)itemView;
+@end
+
+/**
+ * Hosts React children for a nav bar slot. Re-parented into the navigation
+ * bar as a bar button custom view or title view — UIKit owns its position,
+ * while Yoga drives its size (reported via intrinsicContentSize).
+ */
+@interface TrueSheetNavBarItemView : RCTViewComponentView
+
+@property (nonatomic, weak, nullable) id<TrueSheetNavBarItemViewDelegate> delegate;
+@property (nonatomic, readonly) facebook::react::TrueSheetNavBarItemViewSlotType slotType;
+@property (nonatomic, readonly) CGSize contentSize;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // RCT_NEW_ARCH_ENABLED

--- a/ios/TrueSheetNavBarItemView.h
+++ b/ios/TrueSheetNavBarItemView.h
@@ -32,6 +32,20 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) facebook::react::TrueSheetNavBarItemViewSlotType slotType;
 @property (nonatomic, readonly) CGSize contentSize;
 
+/**
+ * Whether Auto Layout owns this view's frame — iOS 26 lays bar button custom
+ * views out with constraints inside the glass backdrop; frame-based custom
+ * views collapse. Title views stay frame-based.
+ */
+@property (nonatomic, readonly) BOOL needsAutoLayout;
+
+/**
+ * Lazily-created bar button item hosting this view. On iOS 26 the custom view
+ * is a wrapper that centers this view with Auto Layout, sized to it via
+ * intrinsicContentSize.
+ */
+- (UIBarButtonItem *)barButtonItem;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/TrueSheetNavBarItemView.mm
+++ b/ios/TrueSheetNavBarItemView.mm
@@ -19,6 +19,9 @@ using namespace facebook::react;
 
 @implementation TrueSheetNavBarItemView {
   CGSize _lastSize;
+  // Strong reference creates a retain cycle through the custom view —
+  // cleared in prepareForRecycle
+  UIBarButtonItem *_barButtonItem;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider {
@@ -45,11 +48,17 @@ using namespace facebook::react;
 
 - (void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
            oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics {
-  // UIKit owns this view's position inside the bar — apply Yoga's size only,
-  // otherwise the frame origin (relative to the config view) would offset it.
-  auto adjustedMetrics = layoutMetrics;
-  adjustedMetrics.frame.origin = {0, 0};
-  [super updateLayoutMetrics:adjustedMetrics oldLayoutMetrics:oldLayoutMetrics];
+  if (self.needsAutoLayout) {
+    // Auto Layout owns the frame — record Yoga's metrics and surface the size
+    // via intrinsicContentSize instead of applying it directly
+    _layoutMetrics = layoutMetrics;
+  } else {
+    // UIKit owns this view's position inside the bar — apply Yoga's size only,
+    // otherwise the frame origin (relative to the config view) would offset it.
+    auto adjustedMetrics = layoutMetrics;
+    adjustedMetrics.frame.origin = {0, 0};
+    [super updateLayoutMetrics:adjustedMetrics oldLayoutMetrics:oldLayoutMetrics];
+  }
 
   CGSize newSize = CGSizeMake(layoutMetrics.frame.size.width, layoutMetrics.frame.size.height);
   if (!CGSizeEqualToSize(newSize, _lastSize)) {
@@ -60,6 +69,52 @@ using namespace facebook::react;
       [self.delegate navBarItemViewDidChangeSize:self];
     }
   }
+}
+
+- (BOOL)needsAutoLayout {
+  if (@available(iOS 26.0, *)) {
+    return _slotType == TrueSheetNavBarItemViewSlotType::Left || _slotType == TrueSheetNavBarItemViewSlotType::Right;
+  }
+  return NO;
+}
+
+- (UIBarButtonItem *)barButtonItem {
+  if (_barButtonItem) {
+    return _barButtonItem;
+  }
+
+  if (self.needsAutoLayout) {
+    // iOS 26 stretches bar button custom views to a minimum width — a wrapper
+    // centers this view inside itself so children stay centered
+    UIView *wrapperView = [[UIView alloc] init];
+    wrapperView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+    [wrapperView addSubview:self];
+
+    [self.centerXAnchor constraintEqualToAnchor:wrapperView.centerXAnchor].active = YES;
+    [self.centerYAnchor constraintEqualToAnchor:wrapperView.centerYAnchor].active = YES;
+
+    // High priority (not required) — when UIKit stretches the wrapper past
+    // this view's size, the wrapper constraint breaks instead of UIKit's
+    NSLayoutConstraint *widthEqual = [wrapperView.widthAnchor constraintEqualToAnchor:self.widthAnchor];
+    widthEqual.priority = UILayoutPriorityDefaultHigh;
+    widthEqual.active = YES;
+
+    NSLayoutConstraint *heightEqual = [wrapperView.heightAnchor constraintEqualToAnchor:self.heightAnchor];
+    heightEqual.priority = UILayoutPriorityDefaultHigh;
+    heightEqual.active = YES;
+
+    [self setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+    [self setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
+    [self setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+    [self setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisVertical];
+
+    _barButtonItem = [[UIBarButtonItem alloc] initWithCustomView:wrapperView];
+  } else {
+    _barButtonItem = [[UIBarButtonItem alloc] initWithCustomView:self];
+  }
+
+  return _barButtonItem;
 }
 
 - (CGSize)contentSize {
@@ -76,6 +131,9 @@ using namespace facebook::react;
 
 - (void)prepareForRecycle {
   [super prepareForRecycle];
+  [self removeFromSuperview];
+  self.translatesAutoresizingMaskIntoConstraints = YES;
+  _barButtonItem = nil;
   _lastSize = CGSizeZero;
   _slotType = TrueSheetNavBarItemViewSlotType::Left;
   self.delegate = nil;

--- a/ios/TrueSheetNavBarItemView.mm
+++ b/ios/TrueSheetNavBarItemView.mm
@@ -1,0 +1,90 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import "TrueSheetNavBarItemView.h"
+
+#import <react/renderer/components/TrueSheetSpec/ComponentDescriptors.h>
+#import <react/renderer/components/TrueSheetSpec/EventEmitters.h>
+#import <react/renderer/components/TrueSheetSpec/Props.h>
+#import <react/renderer/components/TrueSheetSpec/RCTComponentViewHelpers.h>
+
+using namespace facebook::react;
+
+@implementation TrueSheetNavBarItemView {
+  CGSize _lastSize;
+}
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetNavBarItemViewComponentDescriptor>();
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const TrueSheetNavBarItemViewProps>();
+    _props = defaultProps;
+
+    _lastSize = CGSizeZero;
+    _slotType = TrueSheetNavBarItemViewSlotType::Left;
+  }
+  return self;
+}
+
+- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps {
+  [super updateProps:props oldProps:oldProps];
+
+  const auto &newProps = *std::static_pointer_cast<TrueSheetNavBarItemViewProps const>(props);
+  _slotType = newProps.slotType;
+}
+
+- (void)updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics {
+  // UIKit owns this view's position inside the bar — apply Yoga's size only,
+  // otherwise the frame origin (relative to the config view) would offset it.
+  auto adjustedMetrics = layoutMetrics;
+  adjustedMetrics.frame.origin = {0, 0};
+  [super updateLayoutMetrics:adjustedMetrics oldLayoutMetrics:oldLayoutMetrics];
+
+  CGSize newSize = CGSizeMake(layoutMetrics.frame.size.width, layoutMetrics.frame.size.height);
+  if (!CGSizeEqualToSize(newSize, _lastSize)) {
+    _lastSize = newSize;
+    [self invalidateIntrinsicContentSize];
+
+    if ([self.delegate respondsToSelector:@selector(navBarItemViewDidChangeSize:)]) {
+      [self.delegate navBarItemViewDidChangeSize:self];
+    }
+  }
+}
+
+- (CGSize)contentSize {
+  return _lastSize;
+}
+
+- (CGSize)intrinsicContentSize {
+  return _lastSize;
+}
+
+- (CGSize)sizeThatFits:(CGSize)size {
+  return _lastSize;
+}
+
+- (void)prepareForRecycle {
+  [super prepareForRecycle];
+  _lastSize = CGSizeZero;
+  _slotType = TrueSheetNavBarItemViewSlotType::Left;
+  self.delegate = nil;
+}
+
+@end
+
+Class<RCTComponentViewProtocol> TrueSheetNavBarItemViewCls(void) {
+  return TrueSheetNavBarItemView.class;
+}
+
+#endif  // RCT_NEW_ARCH_ENABLED

--- a/ios/TrueSheetNavBarView.h
+++ b/ios/TrueSheetNavBarView.h
@@ -28,7 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
                contentViewController:(UIViewController *)contentViewController;
 
 /**
- * Clears the navigationItem and re-parents item children back into this view.
+ * Clears the navigationItem and releases the navigation host references.
+ * Item children stay owned by their bar button items for re-attachment.
  */
 - (void)detach;
 

--- a/ios/TrueSheetNavBarView.h
+++ b/ios/TrueSheetNavBarView.h
@@ -1,0 +1,39 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import <React/RCTViewComponentView.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Config component for the sheet's native navigation bar. Invisible in the
+ * React hierarchy — its props and item children are applied to the embedded
+ * navigation controller's bar and the content controller's navigationItem.
+ */
+@interface TrueSheetNavBarView : RCTViewComponentView
+
+/**
+ * Applies the bar config to the embedded navigation host.
+ * Item children become bar button custom views / the title view.
+ */
+- (void)attachToNavigationController:(UINavigationController *)navigationController
+               contentViewController:(UIViewController *)contentViewController;
+
+/**
+ * Clears the navigationItem and re-parents item children back into this view.
+ */
+- (void)detach;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // RCT_NEW_ARCH_ENABLED

--- a/ios/TrueSheetNavBarView.mm
+++ b/ios/TrueSheetNavBarView.mm
@@ -1,0 +1,344 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import "TrueSheetNavBarView.h"
+#import "TrueSheetNavBarItemView.h"
+
+#import <react/renderer/components/TrueSheetSpec/ComponentDescriptors.h>
+#import <react/renderer/components/TrueSheetSpec/EventEmitters.h>
+#import <react/renderer/components/TrueSheetSpec/Props.h>
+#import <react/renderer/components/TrueSheetSpec/RCTComponentViewHelpers.h>
+
+#import <React/RCTConversions.h>
+#import <React/RCTLog.h>
+#import <React/RCTSurfaceTouchHandler.h>
+
+using namespace facebook::react;
+
+@interface TrueSheetNavBarView () <TrueSheetNavBarItemViewDelegate, UISearchBarDelegate>
+@end
+
+@implementation TrueSheetNavBarView {
+  __weak UINavigationController *_navigationController;
+  __weak UIViewController *_contentViewController;
+
+  NSMutableArray<TrueSheetNavBarItemView *> *_items;
+  // Item views live outside the React-managed subtree once re-parented into
+  // the bar, so each hosts its own touch handler.
+  NSMapTable<TrueSheetNavBarItemView *, RCTSurfaceTouchHandler *> *_touchHandlers;
+
+  UISearchController *_searchController;
+}
+
+#pragma mark - Initialization
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetNavBarViewComponentDescriptor>();
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const TrueSheetNavBarViewProps>();
+    _props = defaultProps;
+
+    _items = [NSMutableArray array];
+    _touchHandlers = [NSMapTable weakToStrongObjectsMapTable];
+  }
+  return self;
+}
+
+- (const TrueSheetNavBarViewProps &)navBarProps {
+  return *std::static_pointer_cast<TrueSheetNavBarViewProps const>(_props);
+}
+
+#pragma mark - Attach / Detach
+
+- (void)attachToNavigationController:(UINavigationController *)navigationController
+               contentViewController:(UIViewController *)contentViewController {
+  _navigationController = navigationController;
+  _contentViewController = contentViewController;
+
+  [self applyConfig];
+  [self applyBarItems];
+}
+
+- (void)detach {
+  UIViewController *contentViewController = _contentViewController;
+  if (contentViewController) {
+    contentViewController.navigationItem.leftBarButtonItems = nil;
+    contentViewController.navigationItem.rightBarButtonItems = nil;
+    contentViewController.navigationItem.titleView = nil;
+    contentViewController.navigationItem.searchController = nil;
+  }
+
+  for (TrueSheetNavBarItemView *item in _items) {
+    [self addSubview:item];
+  }
+
+  _navigationController = nil;
+  _contentViewController = nil;
+}
+
+#pragma mark - Child Component Mounting
+
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
+  if (![childComponentView isKindOfClass:[TrueSheetNavBarItemView class]]) {
+    RCTLogWarn(@"TrueSheet: NavBar children must be NavBar.Left, NavBar.Right, or NavBar.Title.");
+    return;
+  }
+
+  TrueSheetNavBarItemView *item = (TrueSheetNavBarItemView *)childComponentView;
+  item.delegate = self;
+  [_items insertObject:item atIndex:MIN((NSUInteger)index, _items.count)];
+
+  RCTSurfaceTouchHandler *touchHandler = [[RCTSurfaceTouchHandler alloc] init];
+  [touchHandler attachToView:item];
+  [_touchHandlers setObject:touchHandler forKey:item];
+
+  // Holds the item until the bar re-parents it on attach
+  [self addSubview:item];
+
+  [self applyBarItems];
+}
+
+- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
+  if (![childComponentView isKindOfClass:[TrueSheetNavBarItemView class]])
+    return;
+
+  TrueSheetNavBarItemView *item = (TrueSheetNavBarItemView *)childComponentView;
+
+  RCTSurfaceTouchHandler *touchHandler = [_touchHandlers objectForKey:item];
+  [touchHandler detachFromView:item];
+  [_touchHandlers removeObjectForKey:item];
+
+  item.delegate = nil;
+  [_items removeObject:item];
+  [item removeFromSuperview];
+
+  [self applyBarItems];
+}
+
+#pragma mark - Props
+
+- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps {
+  [super updateProps:props oldProps:oldProps];
+  [self applyConfig];
+}
+
+- (void)applyConfig {
+  UINavigationController *navigationController = _navigationController;
+  UIViewController *contentViewController = _contentViewController;
+  if (!navigationController || !contentViewController)
+    return;
+
+  const auto &props = [self navBarProps];
+  UINavigationBar *navBar = navigationController.navigationBar;
+  UINavigationItem *navItem = contentViewController.navigationItem;
+
+  navItem.title = RCTNSStringFromStringNilIfEmpty(props.title);
+
+  navBar.prefersLargeTitles = props.largeTitle;
+  navItem.largeTitleDisplayMode =
+    props.largeTitle ? UINavigationItemLargeTitleDisplayModeAlways : UINavigationItemLargeTitleDisplayModeNever;
+
+  UIColor *tintColor = RCTUIColorFromSharedColor(props.tintColor);
+  navBar.tintColor = tintColor;
+
+  UIColor *titleColor = RCTUIColorFromSharedColor(props.titleColor);
+  NSDictionary *titleAttributes = titleColor ? @{NSForegroundColorAttributeName : titleColor} : @{};
+
+  // Standard appearance — shown once content scrolls behind the bar
+  UINavigationBarAppearance *standardAppearance = [[UINavigationBarAppearance alloc] init];
+  UIColor *barColor = RCTUIColorFromSharedColor(props.barColor);
+  if (barColor) {
+    [standardAppearance configureWithOpaqueBackground];
+    standardAppearance.backgroundColor = barColor;
+  } else {
+    [standardAppearance configureWithDefaultBackground];
+  }
+  if (props.separatorHidden) {
+    standardAppearance.shadowColor = nil;
+  }
+  standardAppearance.titleTextAttributes = titleAttributes;
+  standardAppearance.largeTitleTextAttributes = titleAttributes;
+
+  // Scroll-edge appearance — transparent at rest so the sheet background shows
+  UINavigationBarAppearance *scrollEdgeAppearance = [[UINavigationBarAppearance alloc] init];
+  [scrollEdgeAppearance configureWithTransparentBackground];
+  scrollEdgeAppearance.titleTextAttributes = titleAttributes;
+  scrollEdgeAppearance.largeTitleTextAttributes = titleAttributes;
+
+  navBar.standardAppearance = standardAppearance;
+  navBar.compactAppearance = standardAppearance;
+  navBar.scrollEdgeAppearance = scrollEdgeAppearance;
+  if (@available(iOS 15.0, *)) {
+    navBar.compactScrollEdgeAppearance = scrollEdgeAppearance;
+  }
+
+  [self applySearch];
+}
+
+- (void)applySearch {
+  UIViewController *contentViewController = _contentViewController;
+  if (!contentViewController)
+    return;
+
+  const auto &props = [self navBarProps];
+  UINavigationItem *navItem = contentViewController.navigationItem;
+
+  if (!props.searchable) {
+    navItem.searchController = nil;
+    _searchController = nil;
+    return;
+  }
+
+  if (!_searchController) {
+    _searchController = [[UISearchController alloc] initWithSearchResultsController:nil];
+    _searchController.obscuresBackgroundDuringPresentation = NO;
+    _searchController.searchBar.delegate = self;
+  }
+
+  UISearchBar *searchBar = _searchController.searchBar;
+  searchBar.placeholder = RCTNSStringFromStringNilIfEmpty(props.searchOptions.placeholder);
+
+  NSString *cancelText = RCTNSStringFromStringNilIfEmpty(props.searchOptions.cancelText);
+  if (cancelText) {
+    [searchBar setValue:cancelText forKey:@"cancelButtonText"];
+  }
+
+  navItem.searchController = _searchController;
+  navItem.hidesSearchBarWhenScrolling = props.searchOptions.hideWhenScrolling;
+
+  if (@available(iOS 16.0, *)) {
+    switch (props.searchOptions.searchPlacement) {
+      case TrueSheetNavBarViewSearchPlacement::Inline:
+        navItem.preferredSearchBarPlacement = UINavigationItemSearchBarPlacementInline;
+        break;
+      case TrueSheetNavBarViewSearchPlacement::Stacked:
+        navItem.preferredSearchBarPlacement = UINavigationItemSearchBarPlacementStacked;
+        break;
+      case TrueSheetNavBarViewSearchPlacement::Automatic:
+        navItem.preferredSearchBarPlacement = UINavigationItemSearchBarPlacementAutomatic;
+        break;
+    }
+  }
+}
+
+#pragma mark - Bar Items
+
+- (void)applyBarItems {
+  UIViewController *contentViewController = _contentViewController;
+  if (!contentViewController)
+    return;
+
+  NSMutableArray<UIBarButtonItem *> *leftItems = [NSMutableArray array];
+  NSMutableArray<UIBarButtonItem *> *rightItems = [NSMutableArray array];
+  TrueSheetNavBarItemView *titleItem = nil;
+
+  for (TrueSheetNavBarItemView *item in _items) {
+    switch (item.slotType) {
+      case TrueSheetNavBarItemViewSlotType::Left:
+        [leftItems addObject:[[UIBarButtonItem alloc] initWithCustomView:item]];
+        break;
+      case TrueSheetNavBarItemViewSlotType::Right:
+        [rightItems addObject:[[UIBarButtonItem alloc] initWithCustomView:item]];
+        break;
+      case TrueSheetNavBarItemViewSlotType::Title:
+        titleItem = item;
+        break;
+    }
+  }
+
+  UINavigationItem *navItem = contentViewController.navigationItem;
+  navItem.leftBarButtonItems = leftItems;
+  // UIKit orders right items trailing-to-leading — reverse so children read
+  // left-to-right on screen in JSX order
+  navItem.rightBarButtonItems = [[rightItems reverseObjectEnumerator] allObjects];
+  navItem.titleView = titleItem;
+}
+
+#pragma mark - TrueSheetNavBarItemViewDelegate
+
+- (void)navBarItemViewDidChangeSize:(TrueSheetNavBarItemView *)itemView {
+  UINavigationController *navigationController = _navigationController;
+  if (!navigationController)
+    return;
+
+  itemView.frame = (CGRect){itemView.frame.origin, itemView.contentSize};
+  [navigationController.navigationBar setNeedsLayout];
+}
+
+#pragma mark - UISearchBarDelegate
+
+- (const TrueSheetNavBarViewEventEmitter *)navBarEventEmitter {
+  if (!_eventEmitter)
+    return nullptr;
+  return static_cast<const TrueSheetNavBarViewEventEmitter *>(_eventEmitter.get());
+}
+
+- (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText {
+  if (auto emitter = [self navBarEventEmitter]) {
+    TrueSheetNavBarViewEventEmitter::OnSearchChange event;
+    event.text = std::string([searchText UTF8String] ?: "");
+    emitter->onSearchChange(event);
+  }
+}
+
+- (void)searchBarSearchButtonClicked:(UISearchBar *)searchBar {
+  if (auto emitter = [self navBarEventEmitter]) {
+    TrueSheetNavBarViewEventEmitter::OnSearchSubmit event;
+    event.text = std::string([searchBar.text UTF8String] ?: "");
+    emitter->onSearchSubmit(event);
+  }
+}
+
+- (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar {
+  if (auto emitter = [self navBarEventEmitter]) {
+    emitter->onSearchFocus({});
+  }
+}
+
+- (void)searchBarTextDidEndEditing:(UISearchBar *)searchBar {
+  if (auto emitter = [self navBarEventEmitter]) {
+    emitter->onSearchBlur({});
+  }
+}
+
+- (void)searchBarCancelButtonClicked:(UISearchBar *)searchBar {
+  if (auto emitter = [self navBarEventEmitter]) {
+    emitter->onSearchCancel({});
+  }
+}
+
+#pragma mark - Recycling
+
+- (void)prepareForRecycle {
+  [super prepareForRecycle];
+
+  [self detach];
+
+  for (TrueSheetNavBarItemView *item in _items) {
+    RCTSurfaceTouchHandler *touchHandler = [_touchHandlers objectForKey:item];
+    [touchHandler detachFromView:item];
+    item.delegate = nil;
+  }
+  [_touchHandlers removeAllObjects];
+  [_items removeAllObjects];
+
+  _searchController = nil;
+}
+
+@end
+
+Class<RCTComponentViewProtocol> TrueSheetNavBarViewCls(void) {
+  return TrueSheetNavBarView.class;
+}
+
+#endif  // RCT_NEW_ARCH_ENABLED

--- a/ios/TrueSheetNavBarView.mm
+++ b/ios/TrueSheetNavBarView.mm
@@ -10,6 +10,7 @@
 
 #import "TrueSheetNavBarView.h"
 #import "TrueSheetNavBarItemView.h"
+#import "utils/PlatformUtil.h"
 
 #import <react/renderer/components/TrueSheetSpec/ComponentDescriptors.h>
 #import <react/renderer/components/TrueSheetSpec/EventEmitters.h>
@@ -33,8 +34,12 @@ using namespace facebook::react;
   // Item views live outside the React-managed subtree once re-parented into
   // the bar, so each hosts its own touch handler.
   NSMapTable<TrueSheetNavBarItemView *, RCTSurfaceTouchHandler *> *_touchHandlers;
+  TrueSheetNavBarItemView *__weak _titleItemView;
 
   UISearchController *_searchController;
+  // Standalone search bar hosted in the navigation row when the row is
+  // otherwise empty — a stacked search controller would leave a blank row above
+  UISearchBar *_titleSearchBar;
 }
 
 #pragma mark - Initialization
@@ -67,6 +72,9 @@ using namespace facebook::react;
 
   [self applyConfig];
   [self applyBarItems];
+  // Attaching while already visible (e.g. remount on reload) — the bar won't
+  // pick the config up until it lays out
+  [self layoutNavigationBar];
 }
 
 - (void)detach {
@@ -76,10 +84,6 @@ using namespace facebook::react;
     contentViewController.navigationItem.rightBarButtonItems = nil;
     contentViewController.navigationItem.titleView = nil;
     contentViewController.navigationItem.searchController = nil;
-  }
-
-  for (TrueSheetNavBarItemView *item in _items) {
-    [self addSubview:item];
   }
 
   _navigationController = nil;
@@ -130,6 +134,7 @@ using namespace facebook::react;
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps {
   [super updateProps:props oldProps:oldProps];
   [self applyConfig];
+  [self layoutNavigationBar];
 }
 
 - (void)applyConfig {
@@ -196,24 +201,43 @@ using namespace facebook::react;
   if (!props.searchable) {
     navItem.searchController = nil;
     _searchController = nil;
+    _titleSearchBar = nil;
+    navItem.titleView = _titleItemView;
     return;
   }
+
+  BOOL stacked = props.searchOptions.searchPlacement == TrueSheetNavBarViewSearchPlacement::Stacked;
+  if (stacked && ![self hasNavigationRowContent]) {
+    // Nothing else in the navigation row — host the search bar in it directly
+    // instead of stacking it below an empty row
+    navItem.searchController = nil;
+    _searchController = nil;
+
+    if (!_titleSearchBar) {
+      _titleSearchBar = [[UISearchBar alloc] init];
+      _titleSearchBar.searchBarStyle = UISearchBarStyleMinimal;
+      _titleSearchBar.delegate = self;
+    }
+    [self configureSearchBar:_titleSearchBar];
+    navItem.titleView = _titleSearchBar;
+    return;
+  }
+
+  if (navItem.titleView == _titleSearchBar) {
+    navItem.titleView = _titleItemView;
+  }
+  _titleSearchBar = nil;
 
   if (!_searchController) {
     _searchController = [[UISearchController alloc] initWithSearchResultsController:nil];
     _searchController.obscuresBackgroundDuringPresentation = NO;
     _searchController.searchBar.delegate = self;
   }
+  [self configureSearchBar:_searchController.searchBar];
 
-  UISearchBar *searchBar = _searchController.searchBar;
-  searchBar.placeholder = RCTNSStringFromStringNilIfEmpty(props.searchOptions.placeholder);
-
-  NSString *cancelText = RCTNSStringFromStringNilIfEmpty(props.searchOptions.cancelText);
-  if (cancelText) {
-    [searchBar setValue:cancelText forKey:@"cancelButtonText"];
+  if (navItem.searchController != _searchController) {
+    navItem.searchController = _searchController;
   }
-
-  navItem.searchController = _searchController;
   navItem.hidesSearchBarWhenScrolling = props.searchOptions.hideWhenScrolling;
 
   if (@available(iOS 16.0, *)) {
@@ -229,6 +253,32 @@ using namespace facebook::react;
         break;
     }
   }
+
+#if RNTS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+  if (@available(iOS 26.0, *)) {
+    // A stacked search bar can silently vanish when the navigation item is
+    // reconfigured repeatedly while toolbar integration is allowed
+    // (see react-native-screens #3168)
+    navItem.searchBarPlacementAllowsToolbarIntegration = !stacked;
+  }
+#endif
+}
+
+- (void)configureSearchBar:(UISearchBar *)searchBar {
+  const auto &props = [self navBarProps];
+  searchBar.placeholder = RCTNSStringFromStringNilIfEmpty(props.searchOptions.placeholder);
+
+  NSString *cancelText = RCTNSStringFromStringNilIfEmpty(props.searchOptions.cancelText);
+  if (cancelText) {
+    [searchBar setValue:cancelText forKey:@"cancelButtonText"];
+  }
+}
+
+// Whether the navigation row shows anything besides the bar background —
+// title text or any bar item
+- (BOOL)hasNavigationRowContent {
+  const auto &props = [self navBarProps];
+  return !props.title.empty() || _items.count > 0;
 }
 
 #pragma mark - Bar Items
@@ -245,10 +295,10 @@ using namespace facebook::react;
   for (TrueSheetNavBarItemView *item in _items) {
     switch (item.slotType) {
       case TrueSheetNavBarItemViewSlotType::Left:
-        [leftItems addObject:[[UIBarButtonItem alloc] initWithCustomView:item]];
+        [leftItems addObject:item.barButtonItem];
         break;
       case TrueSheetNavBarItemViewSlotType::Right:
-        [rightItems addObject:[[UIBarButtonItem alloc] initWithCustomView:item]];
+        [rightItems addObject:item.barButtonItem];
         break;
       case TrueSheetNavBarItemViewSlotType::Title:
         titleItem = item;
@@ -262,17 +312,35 @@ using namespace facebook::react;
   // left-to-right on screen in JSX order
   navItem.rightBarButtonItems = [[rightItems reverseObjectEnumerator] allObjects];
   navItem.titleView = titleItem;
+  _titleItemView = titleItem;
+
+  // Items count toward the navigation row — re-evaluate the search placement
+  [self applySearch];
+  [self layoutNavigationBar];
 }
 
 #pragma mark - TrueSheetNavBarItemViewDelegate
 
 - (void)navBarItemViewDidChangeSize:(TrueSheetNavBarItemView *)itemView {
+  if (!itemView.needsAutoLayout) {
+    itemView.frame = (CGRect){itemView.frame.origin, itemView.contentSize};
+  }
+  [self layoutNavigationBar];
+}
+
+// Forces the bar to lay out — config changes made while the bar is already
+// visible don't take effect until it does
+- (void)layoutNavigationBar {
   UINavigationController *navigationController = _navigationController;
   if (!navigationController)
     return;
 
-  itemView.frame = (CGRect){itemView.frame.origin, itemView.contentSize};
-  [navigationController.navigationBar setNeedsLayout];
+  UINavigationBar *navBar = navigationController.navigationBar;
+  if (navBar.window == nil)
+    return;
+
+  [navBar setNeedsLayout];
+  [navBar layoutIfNeeded];
 }
 
 #pragma mark - UISearchBarDelegate
@@ -300,18 +368,33 @@ using namespace facebook::react;
 }
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar {
+  // A standalone bar manages its own cancel button — UISearchController
+  // handles this for the stacked bar
+  if (searchBar == _titleSearchBar) {
+    [searchBar setShowsCancelButton:YES animated:YES];
+  }
+
   if (auto emitter = [self navBarEventEmitter]) {
     emitter->onSearchFocus({});
   }
 }
 
 - (void)searchBarTextDidEndEditing:(UISearchBar *)searchBar {
+  if (searchBar == _titleSearchBar) {
+    [searchBar setShowsCancelButton:NO animated:YES];
+  }
+
   if (auto emitter = [self navBarEventEmitter]) {
     emitter->onSearchBlur({});
   }
 }
 
 - (void)searchBarCancelButtonClicked:(UISearchBar *)searchBar {
+  if (searchBar == _titleSearchBar) {
+    searchBar.text = @"";
+    [searchBar resignFirstResponder];
+  }
+
   if (auto emitter = [self navBarEventEmitter]) {
     emitter->onSearchCancel({});
   }
@@ -332,7 +415,9 @@ using namespace facebook::react;
   [_touchHandlers removeAllObjects];
   [_items removeAllObjects];
 
+  _titleItemView = nil;
   _searchController = nil;
+  _titleSearchBar = nil;
 }
 
 @end

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -646,6 +646,13 @@ using namespace facebook::react;
   [self setupSheetDetentsForSizeChange];
 }
 
+// The bar's measured height changed as the navigation host laid out
+// (search bar attach, large title, margins) — the auto/peek detents track it
+- (void)viewControllerNavBarDidChangeHeight {
+  _controller.headerHeight = @([self measuredHeaderHeight]);
+  [self setupSheetDetentsForSizeChange];
+}
+
 #pragma mark - TrueSheetViewControllerDelegate
 
 - (void)viewControllerWillPresentAtIndex:(NSInteger)index position:(CGFloat)position detent:(CGFloat)detent {
@@ -656,13 +663,6 @@ using namespace facebook::react;
 - (void)viewControllerDidPresentAtIndex:(NSInteger)index position:(CGFloat)position detent:(CGFloat)detent {
   [_containerView setupKeyboardObserverWithViewController:_controller];
   [TrueSheetLifecycleEvents emitDidPresent:_eventEmitter index:index position:position detent:detent];
-
-  // The bar has real metrics only after presentation (large title, search bar)
-  // — refresh the header height so auto/peek detents account for it.
-  if (_containerView.navBarView) {
-    _controller.headerHeight = @([self measuredHeaderHeight]);
-    [self setupSheetDetentsForSizeChange];
-  }
 
   if (_pendingPropsUpdate) {
     _pendingPropsUpdate = NO;

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -13,6 +13,7 @@
 #import "TrueSheetContentView.h"
 #import "TrueSheetFooterView.h"
 #import "TrueSheetModule.h"
+#import "TrueSheetNavBarView.h"
 #import "TrueSheetViewController.h"
 #import "core/RNScreensEventObserver.h"
 #import "events/TrueSheetDragEvents.h"
@@ -284,7 +285,7 @@ using namespace facebook::react;
   _state = std::static_pointer_cast<TrueSheetViewShadowNode::ConcreteState const>(state);
 
   if (_controller && !_controller.isStackedBehindChild) {
-    CGSize size = _controller.view.frame.size;
+    CGSize size = [_controller contentAreaSize];
     if (size.width < 1 || size.height < 1) {
       // Pre-present the controller has no layout yet. Seed with screen
       // dimensions so content (e.g. a FlatList viewport) can lay out and
@@ -383,8 +384,7 @@ using namespace facebook::react;
   _containerView.delegate = self;
 
   [_touchHandler attachToView:_containerView];
-  [_controller.view addSubview:_containerView];
-  [_controller.view bringSubviewToFront:_containerView];
+  [_controller attachContainerView:_containerView navBarView:_containerView.navBarView];
   _containerView.accessibilityViewIsModal = YES;
   _controller.accessibilityContentView = _containerView;
   [_controller setupAccessibilityContainer];
@@ -394,7 +394,7 @@ using namespace facebook::react;
     _controller.contentHeight = @(contentHeight);
   }
 
-  CGFloat headerHeight = [_containerView headerHeight];
+  CGFloat headerHeight = [self measuredHeaderHeight];
   if (headerHeight > 0) {
     _controller.headerHeight = @(headerHeight);
   }
@@ -475,7 +475,7 @@ using namespace facebook::react;
   // detent retarget that snaps the presentation stack.
   if (_containerView) {
     _controller.contentHeight = @([_containerView contentHeight]);
-    _controller.headerHeight = @([_containerView headerHeight]);
+    _controller.headerHeight = @([self measuredHeaderHeight]);
     _controller.footerHeight = @([_containerView footerHeight]);
     _controller.peekContentHeight = @([_containerView peekContentHeight]);
   }
@@ -635,6 +635,17 @@ using namespace facebook::react;
   [self setupScrollable];
 }
 
+// Nav bar config mounted or unmounted — re-host the container and refresh
+// the header height feeding the auto/peek detents.
+- (void)containerViewNavBarDidChange {
+  if (_containerView) {
+    [_controller attachContainerView:_containerView navBarView:_containerView.navBarView];
+  }
+
+  _controller.headerHeight = @([self measuredHeaderHeight]);
+  [self setupSheetDetentsForSizeChange];
+}
+
 #pragma mark - TrueSheetViewControllerDelegate
 
 - (void)viewControllerWillPresentAtIndex:(NSInteger)index position:(CGFloat)position detent:(CGFloat)detent {
@@ -645,6 +656,13 @@ using namespace facebook::react;
 - (void)viewControllerDidPresentAtIndex:(NSInteger)index position:(CGFloat)position detent:(CGFloat)detent {
   [_containerView setupKeyboardObserverWithViewController:_controller];
   [TrueSheetLifecycleEvents emitDidPresent:_eventEmitter index:index position:position detent:detent];
+
+  // The bar has real metrics only after presentation (large title, search bar)
+  // — refresh the header height so auto/peek detents account for it.
+  if (_containerView.navBarView) {
+    _controller.headerHeight = @([self measuredHeaderHeight]);
+    [self setupSheetDetentsForSizeChange];
+  }
 
   if (_pendingPropsUpdate) {
     _pendingPropsUpdate = NO;
@@ -773,6 +791,14 @@ using namespace facebook::react;
 
 #pragma mark - Private Helpers
 
+// The nav bar replaces the header slot — its height feeds the same detent math
+- (CGFloat)measuredHeaderHeight {
+  if (_containerView.navBarView) {
+    return [_controller navBarHeight];
+  }
+  return [_containerView headerHeight];
+}
+
 - (void)setupScrollable {
   if (!_containerView)
     return;
@@ -782,6 +808,7 @@ using namespace facebook::react;
   _containerView.hasAutoDetent = _hasAutoDetent;
   _containerView.footerBottomInset = _controller.footerBottomInset;
   [_containerView setupScrollable];
+  [_controller setupNavContentScrollTracking];
 }
 
 - (void)applySheetPropsUpdate {

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
                                  detent:(CGFloat)detent
                                realtime:(BOOL)realtime;
 - (void)viewControllerDidChangeSize:(CGSize)size;
+- (void)viewControllerNavBarDidChangeHeight;
 - (void)viewControllerWillFocus;
 - (void)viewControllerDidFocus;
 - (void)viewControllerWillBlur;

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -20,6 +20,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class TrueSheetNavBarView;
+
 @protocol TrueSheetViewControllerDelegate <NSObject>
 
 - (void)viewControllerWillPresentAtIndex:(NSInteger)index position:(CGFloat)position detent:(CGFloat)detent;
@@ -90,6 +92,34 @@ NS_ASSUME_NONNULL_BEGIN
  * owns the sheet's bottom edge, so its background fills the inset.
  */
 @property (nonatomic, readonly) CGFloat footerBottomInset;
+
+/**
+ * The embedded navigation controller backing the sheet's nav bar, if any.
+ */
+@property (nonatomic, readonly, nullable) UINavigationController *navHostController;
+
+/**
+ * Hosts the container view — inside the embedded navigation controller's
+ * content area when a nav bar config is present, directly otherwise.
+ */
+- (void)attachContainerView:(UIView *)containerView navBarView:(nullable TrueSheetNavBarView *)navBarView;
+
+/**
+ * The navigation bar's current height. 0 when no nav bar is embedded.
+ */
+- (CGFloat)navBarHeight;
+
+/**
+ * The area available to the container — the content area below the nav bar
+ * when one is embedded, the sheet's full bounds otherwise.
+ */
+- (CGSize)contentAreaSize;
+
+/**
+ * Associates the content's scroll view with the embedded navigation host to
+ * drive scroll-edge appearance and large title collapse.
+ */
+- (void)setupNavContentScrollTracking;
 
 - (void)setupAccessibilityContainer;
 - (void)applyActiveDetent;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -90,6 +90,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
   UINavigationController *_navHostController;
   TrueSheetNavContentViewController *_navContentController;
+  CGFloat _lastNavBarHeight;
 }
 
 #pragma mark - Initialization
@@ -975,13 +976,33 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     return 0;
   }
 
-  UINavigationBar *navBar = _navHostController.navigationBar;
-  CGFloat height = navBar.frame.size.height;
-  if (height < 1) {
-    // Not laid out yet (pre-present) — the standard bar metric
-    height = [navBar sizeThatFits:CGSizeZero].height;
+  // The content controller lays out below the bar (edgesForExtendedLayout
+  // none) — its top edge is the full space the bar consumes, including the
+  // title row, a stacked search bar, and any bar margins. The bar's own frame
+  // misses those.
+  if (_navContentController.isViewLoaded && _navHostController.isViewLoaded) {
+    CGFloat contentTop = [_navContentController.view convertRect:_navContentController.view.bounds
+                                                          toView:_navHostController.view]
+                           .origin.y;
+    if (contentTop >= 1) {
+      return contentTop;
+    }
   }
-  return height;
+
+  // Not laid out yet (pre-present) — the standard bar metric
+  return [_navHostController.navigationBar sizeThatFits:CGSizeZero].height;
+}
+
+// The bar settles its real height only as the navigation host lays out
+// (search bar attach, large title, margins) — push changes to the detents
+- (void)notifyNavBarHeightIfChanged {
+  CGFloat height = [self navBarHeight];
+  if (fabs(height - _lastNavBarHeight) < 0.5) {
+    return;
+  }
+
+  _lastNavBarHeight = height;
+  [self.delegate viewControllerNavBarDidChangeHeight];
 }
 
 - (void)attachContainerView:(UIView *)containerView navBarView:(TrueSheetNavBarView *)navBarView {
@@ -1013,6 +1034,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   __weak __typeof(self) weakSelf = self;
   _navContentController.onLayoutSubviews = ^(CGSize size) {
     [weakSelf reportContentAreaSizeIfChanged];
+    [weakSelf notifyNavBarHeightIfChanged];
   };
 
   _navHostController = [[UINavigationController alloc] initWithRootViewController:_navContentController];
@@ -1037,6 +1059,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   [_navHostController removeFromParentViewController];
   _navHostController = nil;
   _navContentController = nil;
+  _lastNavBarHeight = 0;
 }
 
 - (void)setupNavContentScrollTracking {

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -9,9 +9,11 @@
 #import "TrueSheetViewController.h"
 #import "TrueSheetContainerView.h"
 #import "TrueSheetContentView.h"
+#import "TrueSheetNavBarView.h"
 #import "core/TrueSheetBlurView.h"
 #import "core/TrueSheetDetentCalculator.h"
 #import "core/TrueSheetGrabberView.h"
+#import "core/TrueSheetNavContentViewController.h"
 #import "utils/BlurUtil.h"
 #import "utils/GestureUtil.h"
 #import "utils/PlatformUtil.h"
@@ -85,6 +87,9 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   TrueSheetBlurView *_blurView;
   TrueSheetGrabberView *_grabberView;
   TrueSheetDetentCalculator *_detentCalculator;
+
+  UINavigationController *_navHostController;
+  TrueSheetNavContentViewController *_navContentController;
 }
 
 #pragma mark - Initialization
@@ -588,18 +593,10 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
 
-  // Skip size reports while backgrounded behind a stacked child — the push-back
-  // scaling changes the frame and would needlessly resize content.
-  // _lastReportedSize stays stale so the restore pass re-reports any real change.
-  if (!self.isStackedBehindChild) {
-    // Report any size change (detent resize, keyboard, rotation) so Yoga
-    // relayouts the container synchronously with the sheet.
-    CGSize size = self.view.frame.size;
-    if (!CGSizeEqualToSize(_lastReportedSize, size)) {
-      _lastReportedSize = size;
-      [self.delegate viewControllerDidChangeSize:size];
-    }
-  }
+  // Report any size change (detent resize, keyboard, rotation) so Yoga
+  // relayouts the container synchronously with the sheet. With a nav host,
+  // the content controller's own layout pass reports the fresher value.
+  [self reportContentAreaSizeIfChanged];
 
   if (_pendingDetentIndex >= 0) {
     NSInteger pendingIndex = _pendingDetentIndex;
@@ -947,6 +944,113 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
 - (CGFloat)detentValueForIndex:(NSInteger)index {
   return [_detentCalculator detentValueForIndex:index];
+}
+
+#pragma mark - Navigation Host
+
+// Skips size reports while backgrounded behind a stacked child — the push-back
+// scaling changes the frame and would needlessly resize content.
+// _lastReportedSize stays stale so the restore pass re-reports any real change.
+- (void)reportContentAreaSizeIfChanged {
+  if (self.isStackedBehindChild) {
+    return;
+  }
+
+  CGSize size = self.contentAreaSize;
+  if (!CGSizeEqualToSize(_lastReportedSize, size)) {
+    _lastReportedSize = size;
+    [self.delegate viewControllerDidChangeSize:size];
+  }
+}
+
+- (CGSize)contentAreaSize {
+  if (_navHostController && _navContentController.isViewLoaded) {
+    return _navContentController.view.frame.size;
+  }
+  return self.view.frame.size;
+}
+
+- (CGFloat)navBarHeight {
+  if (!_navHostController) {
+    return 0;
+  }
+
+  UINavigationBar *navBar = _navHostController.navigationBar;
+  CGFloat height = navBar.frame.size.height;
+  if (height < 1) {
+    // Not laid out yet (pre-present) — the standard bar metric
+    height = [navBar sizeThatFits:CGSizeZero].height;
+  }
+  return height;
+}
+
+- (void)attachContainerView:(UIView *)containerView navBarView:(TrueSheetNavBarView *)navBarView {
+  if (navBarView) {
+    [self embedNavigationHost];
+    [navBarView attachToNavigationController:_navHostController contentViewController:_navContentController];
+    [_navContentController.view addSubview:containerView];
+    [self setupNavContentScrollTracking];
+  } else {
+    [self removeNavigationHost];
+    [self.view addSubview:containerView];
+    [self.view bringSubviewToFront:containerView];
+  }
+
+  // Force a fresh report — the content area changed shape with the host
+  _lastReportedSize = CGSizeZero;
+  [self reportContentAreaSizeIfChanged];
+}
+
+- (void)embedNavigationHost {
+  if (_navHostController) {
+    return;
+  }
+
+  _navContentController = [[TrueSheetNavContentViewController alloc] init];
+  // Keeps the search controller's presentation inside the sheet
+  _navContentController.definesPresentationContext = YES;
+
+  __weak __typeof(self) weakSelf = self;
+  _navContentController.onLayoutSubviews = ^(CGSize size) {
+    [weakSelf reportContentAreaSizeIfChanged];
+  };
+
+  _navHostController = [[UINavigationController alloc] initWithRootViewController:_navContentController];
+  _navHostController.view.backgroundColor = [UIColor clearColor];
+
+  [self addChildViewController:_navHostController];
+  _navHostController.view.frame = self.view.bounds;
+  _navHostController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  [self.view addSubview:_navHostController.view];
+  [_navHostController didMoveToParentViewController:self];
+
+  [self.view bringSubviewToFront:_grabberView];
+}
+
+- (void)removeNavigationHost {
+  if (!_navHostController) {
+    return;
+  }
+
+  [_navHostController willMoveToParentViewController:nil];
+  [_navHostController.view removeFromSuperview];
+  [_navHostController removeFromParentViewController];
+  _navHostController = nil;
+  _navContentController = nil;
+}
+
+- (void)setupNavContentScrollTracking {
+  if (!_navHostController) {
+    return;
+  }
+
+  if (@available(iOS 15.0, *)) {
+    TrueSheetContentView *contentView = [self findContentView:self.view];
+    RCTScrollViewComponentView *scrollViewComponent = contentView ? [contentView findScrollView] : nil;
+    // Drives scroll-edge appearance and large title collapse — the content
+    // sits below the bar, so UIKit can't discover the scroll view on its own
+    [_navContentController setContentScrollView:scrollViewComponent.scrollView forEdge:NSDirectionalRectEdgeTop];
+  }
 }
 
 #pragma mark - Sheet Configuration

--- a/ios/core/TrueSheetNavContentViewController.h
+++ b/ios/core/TrueSheetNavContentViewController.h
@@ -1,0 +1,24 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Root of the embedded navigation controller. Hosts the sheet's container
+ * view below the navigation bar and reports its content-area size so Yoga
+ * tracks it (detent resizes, large title collapse, search bar reveal).
+ */
+@interface TrueSheetNavContentViewController : UIViewController
+
+@property (nonatomic, copy, nullable) void (^onLayoutSubviews)(CGSize size);
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/core/TrueSheetNavContentViewController.mm
+++ b/ios/core/TrueSheetNavContentViewController.mm
@@ -1,0 +1,35 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#import "TrueSheetNavContentViewController.h"
+
+@implementation TrueSheetNavContentViewController
+
+- (instancetype)init {
+  if (self = [super initWithNibName:nil bundle:nil]) {
+    // Lay the view out below the bar — content never underlaps, so Yoga sizing
+    // stays correct without inset gymnastics
+    self.edgesForExtendedLayout = UIRectEdgeNone;
+  }
+  return self;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  self.view.backgroundColor = [UIColor clearColor];
+}
+
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+
+  if (self.onLayoutSubviews) {
+    self.onLayoutSubviews(self.view.bounds.size);
+  }
+}
+
+@end

--- a/ios/tvos/TrueSheetStubs.mm
+++ b/ios/tvos/TrueSheetStubs.mm
@@ -94,6 +94,28 @@ using namespace facebook::react;
 
 @end
 
+@interface TrueSheetNavBarView : RCTViewComponentView
+@end
+
+@implementation TrueSheetNavBarView
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetNavBarViewComponentDescriptor>();
+}
+
+@end
+
+@interface TrueSheetNavBarItemView : RCTViewComponentView
+@end
+
+@implementation TrueSheetNavBarItemView
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetNavBarItemViewComponentDescriptor>();
+}
+
+@end
+
 #pragma mark - Module
 
 @interface TrueSheetModule : NSObject <RCTBridgeModule, NativeTrueSheetModuleSpec>

--- a/package.json
+++ b/package.json
@@ -268,6 +268,12 @@
         },
         "TrueSheetPeekView": {
           "className": "TrueSheetPeekView"
+        },
+        "TrueSheetNavBarView": {
+          "className": "TrueSheetNavBarView"
+        },
+        "TrueSheetNavBarItemView": {
+          "className": "TrueSheetNavBarItemView"
         }
       }
     }

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -34,6 +34,7 @@ import TrueSheetHeaderViewNativeComponent from './fabric/TrueSheetHeaderViewNati
 import TrueSheetFooterViewNativeComponent from './fabric/TrueSheetFooterViewNativeComponent';
 
 import TrueSheetModule from './specs/NativeTrueSheetModule';
+import { TrueSheetNavBar } from './TrueSheetNavBar';
 
 import {
   Platform,
@@ -483,6 +484,8 @@ export class TrueSheet
       return Math.min(1, detent);
     });
 
+    const headerElement = header ? (isValidElement(header) ? header : createElement(header)) : null;
+
     // Cache grabberOptions to avoid creating a new object every render
     if (grabberOptions !== this.cachedGrabberOptions) {
       this.cachedGrabberOptions = grabberOptions;
@@ -540,17 +543,22 @@ export class TrueSheet
       >
         {this.state.shouldRenderNativeView && (
           <TrueSheetContainerViewNativeComponent style={styles.container}>
-            {header && (
-              <TrueSheetHeaderViewNativeComponent
-                style={[
-                  styles.header,
-                  headerOptions?.position === 'absolute' && styles.absoluteHeader,
-                  headerStyle,
-                ]}
-              >
-                {isValidElement(header) ? header : createElement(header)}
-              </TrueSheetHeaderViewNativeComponent>
-            )}
+            {headerElement &&
+              // A nav bar renders as a config component — the native side
+              // re-parents it into the navigation bar, not the header slot
+              (headerElement.type === TrueSheetNavBar ? (
+                headerElement
+              ) : (
+                <TrueSheetHeaderViewNativeComponent
+                  style={[
+                    styles.header,
+                    headerOptions?.position === 'absolute' && styles.absoluteHeader,
+                    headerStyle,
+                  ]}
+                >
+                  {headerElement}
+                </TrueSheetHeaderViewNativeComponent>
+              ))}
             <TrueSheetContentViewNativeComponent style={style}>
               {children}
             </TrueSheetContentViewNativeComponent>

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -649,12 +649,13 @@ export interface TrueSheetNavBarSearchOptions {
   /**
    * Placement of the search field within the bar.
    *
-   * - `'automatic'`: The system decides based on context.
-   * - `'inline'`: Trailing edge of the bar, alongside the title.
    * - `'stacked'`: Below the title, spanning the bar's width.
+   * - `'inline'`: Trailing edge of the bar, alongside the title.
+   * - `'automatic'`: The system decides — on iOS 26+ this may anchor the
+   *   search field to the bottom edge of the sheet (integrated placement).
    *
    * @platform ios 16+
-   * @default 'automatic'
+   * @default 'stacked'
    */
   placement?: 'automatic' | 'inline' | 'stacked';
 }

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentType, ReactElement } from 'react';
+import type { ComponentType, ReactElement, ReactNode } from 'react';
 import type {
   ColorValue,
   NativeSyntheticEvent,
@@ -44,6 +44,19 @@ export type DidFocusEvent = NativeSyntheticEvent<null>;
 export type DidBlurEvent = NativeSyntheticEvent<null>;
 export type WillFocusEvent = NativeSyntheticEvent<null>;
 export type WillBlurEvent = NativeSyntheticEvent<null>;
+
+export interface SearchTextEventPayload {
+  /**
+   * The current search text.
+   */
+  text: string;
+}
+
+export type SearchChangeEvent = NativeSyntheticEvent<SearchTextEventPayload>;
+export type SearchSubmitEvent = NativeSyntheticEvent<SearchTextEventPayload>;
+export type SearchFocusEvent = NativeSyntheticEvent<null>;
+export type SearchBlurEvent = NativeSyntheticEvent<null>;
+export type SearchCancelEvent = NativeSyntheticEvent<null>;
 
 /**
  * Options for customizing the grabber (drag handle) appearance.
@@ -608,6 +621,123 @@ export interface TrueSheetProps extends ViewProps {
    * @platform android
    */
   onBackPress?: () => boolean | void;
+}
+
+/**
+ * Options for the nav bar's native search field.
+ */
+export interface TrueSheetNavBarSearchOptions {
+  /**
+   * Placeholder text for the search field.
+   */
+  placeholder?: string;
+
+  /**
+   * The cancel button label.
+   *
+   * @platform ios
+   */
+  cancelText?: string;
+
+  /**
+   * Whether the search field hides when the content scrolls.
+   *
+   * @default true
+   */
+  hideWhenScrolling?: boolean;
+
+  /**
+   * Placement of the search field within the bar.
+   *
+   * - `'automatic'`: The system decides based on context.
+   * - `'inline'`: Trailing edge of the bar, alongside the title.
+   * - `'stacked'`: Below the title, spanning the bar's width.
+   *
+   * @platform ios 16+
+   * @default 'automatic'
+   */
+  placement?: 'automatic' | 'inline' | 'stacked';
+}
+
+/**
+ * Props for the `TrueSheetNavBar` component.
+ * Pass it to the sheet's `header` prop to render a native navigation bar.
+ */
+export interface TrueSheetNavBarProps {
+  /**
+   * The bar title.
+   * Overridden by a `TrueSheetNavBar.Title` child when provided.
+   */
+  title?: string;
+
+  /**
+   * Displays the title using the large title style.
+   * Collapses to the standard title as the content scrolls.
+   *
+   * @platform ios
+   * @default false
+   */
+  largeTitle?: boolean;
+
+  /**
+   * Tint color applied to bar items (buttons).
+   */
+  tintColor?: ColorValue;
+
+  /**
+   * The title text color.
+   */
+  titleColor?: ColorValue;
+
+  /**
+   * The bar background color, visible when content scrolls behind the bar.
+   * Uses the native adaptive material when not provided.
+   */
+  backgroundColor?: ColorValue;
+
+  /**
+   * Hides the hairline separator shown when content scrolls behind the bar.
+   *
+   * @default false
+   */
+  separatorHidden?: boolean;
+
+  /**
+   * Enables the native search field.
+   * Pass `true` or an options object.
+   */
+  search?: boolean | TrueSheetNavBarSearchOptions;
+
+  /**
+   * Called when the search text changes.
+   */
+  onSearchChange?: (event: SearchChangeEvent) => void;
+
+  /**
+   * Called when the search is submitted (return key).
+   */
+  onSearchSubmit?: (event: SearchSubmitEvent) => void;
+
+  /**
+   * Called when the search field gains focus.
+   */
+  onSearchFocus?: (event: SearchFocusEvent) => void;
+
+  /**
+   * Called when the search field loses focus.
+   */
+  onSearchBlur?: (event: SearchBlurEvent) => void;
+
+  /**
+   * Called when the search is cancelled.
+   */
+  onSearchCancel?: (event: SearchCancelEvent) => void;
+
+  /**
+   * Bar item slots — `TrueSheetNavBar.Left`, `TrueSheetNavBar.Right`,
+   * and `TrueSheetNavBar.Title`.
+   */
+  children?: ReactNode;
 }
 
 /**

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -706,6 +706,9 @@ export interface TrueSheetNavBarProps {
   /**
    * Enables the native search field.
    * Pass `true` or an options object.
+   *
+   * On iOS, when the bar has no title and no items, a `stacked` search field
+   * renders inline in the bar row instead of below an empty row.
    */
   search?: boolean | TrueSheetNavBarSearchOptions;
 

--- a/src/TrueSheetNavBar.tsx
+++ b/src/TrueSheetNavBar.tsx
@@ -1,0 +1,106 @@
+import { StyleSheet, type ViewProps } from 'react-native';
+
+import type { TrueSheetNavBarProps } from './TrueSheet.types';
+import TrueSheetNavBarViewNativeComponent from './fabric/TrueSheetNavBarViewNativeComponent';
+import TrueSheetNavBarItemViewNativeComponent from './fabric/TrueSheetNavBarItemViewNativeComponent';
+
+const NavBarLeft = ({ style, ...rest }: ViewProps) => (
+  <TrueSheetNavBarItemViewNativeComponent slotType="left" style={[styles.item, style]} {...rest} />
+);
+
+const NavBarRight = ({ style, ...rest }: ViewProps) => (
+  <TrueSheetNavBarItemViewNativeComponent slotType="right" style={[styles.item, style]} {...rest} />
+);
+
+const NavBarTitle = ({ style, ...rest }: ViewProps) => (
+  <TrueSheetNavBarItemViewNativeComponent slotType="title" style={[styles.item, style]} {...rest} />
+);
+
+const NavBar = (props: TrueSheetNavBarProps) => {
+  const {
+    title,
+    largeTitle,
+    tintColor,
+    titleColor,
+    backgroundColor,
+    separatorHidden,
+    search,
+    onSearchChange,
+    onSearchSubmit,
+    onSearchFocus,
+    onSearchBlur,
+    onSearchCancel,
+    children,
+  } = props;
+
+  const searchOptions = typeof search === 'object' ? search : undefined;
+
+  return (
+    <TrueSheetNavBarViewNativeComponent
+      style={styles.navBar}
+      pointerEvents="box-none"
+      title={title}
+      largeTitle={largeTitle}
+      tintColor={tintColor}
+      titleColor={titleColor}
+      barColor={backgroundColor}
+      separatorHidden={separatorHidden}
+      searchable={!!search}
+      searchOptions={{
+        placeholder: searchOptions?.placeholder,
+        cancelText: searchOptions?.cancelText,
+        hideWhenScrolling: searchOptions?.hideWhenScrolling,
+        searchPlacement: searchOptions?.placement,
+      }}
+      onSearchChange={onSearchChange}
+      onSearchSubmit={onSearchSubmit}
+      onSearchFocus={onSearchFocus}
+      onSearchBlur={onSearchBlur}
+      onSearchCancel={onSearchCancel}
+    >
+      {children}
+    </TrueSheetNavBarViewNativeComponent>
+  );
+};
+
+/**
+ * Native navigation bar for the sheet. Pass it to the sheet's `header` prop.
+ * Backed by `UINavigationController` on iOS — supports large titles,
+ * scroll-edge appearance, bar items, and a native search field.
+ *
+ * ```tsx
+ * <TrueSheet
+ *   header={
+ *     <TrueSheetNavBar title="Details" largeTitle search>
+ *       <TrueSheetNavBar.Left><BackButton /></TrueSheetNavBar.Left>
+ *       <TrueSheetNavBar.Right><DoneButton /></TrueSheetNavBar.Right>
+ *     </TrueSheetNavBar>
+ *   }
+ * >
+ * ```
+ */
+export const TrueSheetNavBar = Object.assign(NavBar, {
+  Left: NavBarLeft,
+  Right: NavBarRight,
+  Title: NavBarTitle,
+});
+
+const styles = StyleSheet.create({
+  // Invisible config view — bar items are re-parented into the native bar.
+  // Spans the container width so item slots measure against the bar's width.
+  navBar: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 0,
+    overflow: 'visible',
+    zIndex: 1,
+  },
+  // Sized by its children — the native side drives its placement in the bar
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+  },
+});

--- a/src/TrueSheetNavBar.web.tsx
+++ b/src/TrueSheetNavBar.web.tsx
@@ -1,0 +1,163 @@
+import { Children, isValidElement, type ReactNode } from 'react';
+import { StyleSheet, Text, TextInput, View, type ViewProps } from 'react-native';
+
+import type {
+  SearchBlurEvent,
+  SearchChangeEvent,
+  SearchFocusEvent,
+  SearchSubmitEvent,
+  TrueSheetNavBarProps,
+} from './TrueSheet.types';
+
+const NavBarLeft = ({ children, style, ...rest }: ViewProps) => (
+  <View style={[styles.item, style]} {...rest}>
+    {children}
+  </View>
+);
+
+const NavBarRight = ({ children, style, ...rest }: ViewProps) => (
+  <View style={[styles.item, style]} {...rest}>
+    {children}
+  </View>
+);
+
+const NavBarTitle = ({ children, style, ...rest }: ViewProps) => (
+  <View style={[styles.item, style]} {...rest}>
+    {children}
+  </View>
+);
+
+const NavBar = (props: TrueSheetNavBarProps) => {
+  const {
+    title,
+    largeTitle,
+    titleColor,
+    backgroundColor,
+    separatorHidden,
+    search,
+    onSearchChange,
+    onSearchSubmit,
+    onSearchFocus,
+    onSearchBlur,
+    children,
+  } = props;
+
+  const searchOptions = typeof search === 'object' ? search : undefined;
+
+  let left: ReactNode = null;
+  let right: ReactNode = null;
+  let titleSlot: ReactNode = null;
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    if (child.type === NavBarLeft) left = child;
+    if (child.type === NavBarRight) right = child;
+    if (child.type === NavBarTitle) titleSlot = child;
+  });
+
+  return (
+    <View
+      style={[
+        styles.bar,
+        !separatorHidden && styles.separator,
+        backgroundColor != null && { backgroundColor },
+      ]}
+    >
+      <View style={styles.row}>
+        <View style={styles.side}>{left}</View>
+        <View style={styles.center}>
+          {titleSlot ??
+            (!largeTitle && title != null && (
+              <Text
+                numberOfLines={1}
+                style={[styles.title, titleColor != null && { color: titleColor }]}
+              >
+                {title}
+              </Text>
+            ))}
+        </View>
+        <View style={[styles.side, styles.sideRight]}>{right}</View>
+      </View>
+      {largeTitle && !titleSlot && title != null && (
+        <Text
+          numberOfLines={1}
+          style={[styles.largeTitle, titleColor != null && { color: titleColor }]}
+        >
+          {title}
+        </Text>
+      )}
+      {!!search && (
+        <TextInput
+          style={styles.search}
+          placeholder={searchOptions?.placeholder ?? 'Search'}
+          onChangeText={(text) => onSearchChange?.({ nativeEvent: { text } } as SearchChangeEvent)}
+          onSubmitEditing={(event) =>
+            onSearchSubmit?.({
+              nativeEvent: { text: event.nativeEvent.text },
+            } as SearchSubmitEvent)
+          }
+          onFocus={() => onSearchFocus?.({ nativeEvent: null } as SearchFocusEvent)}
+          onBlur={() => onSearchBlur?.({ nativeEvent: null } as SearchBlurEvent)}
+        />
+      )}
+    </View>
+  );
+};
+
+/**
+ * Web implementation of `TrueSheetNavBar`.
+ * Renders a styled header bar matching the native API.
+ */
+export const TrueSheetNavBar = Object.assign(NavBar, {
+  Left: NavBarLeft,
+  Right: NavBarRight,
+  Title: NavBarTitle,
+});
+
+const styles = StyleSheet.create({
+  bar: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    gap: 8,
+  },
+  separator: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: 'rgba(0, 0, 0, 0.2)',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: 36,
+  },
+  side: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+  },
+  sideRight: {
+    justifyContent: 'flex-end',
+  },
+  center: {
+    flex: 2,
+    alignItems: 'center',
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  largeTitle: {
+    fontSize: 34,
+    fontWeight: '700',
+  },
+  search: {
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 17,
+    backgroundColor: 'rgba(0, 0, 0, 0.06)',
+  },
+});

--- a/src/__tests__/TrueSheet.test.tsx
+++ b/src/__tests__/TrueSheet.test.tsx
@@ -1,6 +1,6 @@
 import { Text } from 'react-native';
 import { render, act } from '@testing-library/react-native';
-import { TrueSheet, TrueSheetPeek } from '../index';
+import { TrueSheet, TrueSheetNavBar, TrueSheetPeek } from '../index';
 import type {
   DidDismissEvent,
   WillFocusEvent,
@@ -52,6 +52,30 @@ describe('TrueSheet', () => {
     );
     expect(getByText('Content')).toBeDefined();
     expect(getByText('Footer Content')).toBeDefined();
+  });
+
+  it('should render TrueSheetNavBar as header', () => {
+    const { getByText } = render(
+      <TrueSheet
+        name="test"
+        initialDetentIndex={0}
+        header={
+          <TrueSheetNavBar title="Title">
+            <TrueSheetNavBar.Left>
+              <Text>Left Item</Text>
+            </TrueSheetNavBar.Left>
+            <TrueSheetNavBar.Right>
+              <Text>Right Item</Text>
+            </TrueSheetNavBar.Right>
+          </TrueSheetNavBar>
+        }
+      >
+        <Text>Content</Text>
+      </TrueSheet>
+    );
+    expect(getByText('Left Item')).toBeDefined();
+    expect(getByText('Right Item')).toBeDefined();
+    expect(getByText('Content')).toBeDefined();
   });
 
   it('should render TrueSheetPeek within content', () => {

--- a/src/fabric/TrueSheetNavBarItemViewNativeComponent.ts
+++ b/src/fabric/TrueSheetNavBarItemViewNativeComponent.ts
@@ -1,0 +1,10 @@
+import type { ViewProps } from 'react-native';
+import type { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
+import { codegenNativeComponent } from 'react-native';
+
+export interface NativeProps extends ViewProps {
+  // Named uniquely — codegen derives the enum name from the field name
+  slotType?: WithDefault<'left' | 'right' | 'title', 'left'>;
+}
+
+export default codegenNativeComponent<NativeProps>('TrueSheetNavBarItemView', {});

--- a/src/fabric/TrueSheetNavBarViewNativeComponent.ts
+++ b/src/fabric/TrueSheetNavBarViewNativeComponent.ts
@@ -7,7 +7,7 @@ type SearchOptionsType = Readonly<{
   cancelText?: string;
   hideWhenScrolling?: WithDefault<boolean, true>;
   // Named uniquely — codegen derives the enum name from the field name
-  searchPlacement?: WithDefault<'automatic' | 'inline' | 'stacked', 'automatic'>;
+  searchPlacement?: WithDefault<'automatic' | 'inline' | 'stacked', 'stacked'>;
 }>;
 
 export interface SearchTextEventPayload {

--- a/src/fabric/TrueSheetNavBarViewNativeComponent.ts
+++ b/src/fabric/TrueSheetNavBarViewNativeComponent.ts
@@ -1,0 +1,34 @@
+import type { ColorValue, ViewProps } from 'react-native';
+import type { DirectEventHandler, WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
+import { codegenNativeComponent } from 'react-native';
+
+type SearchOptionsType = Readonly<{
+  placeholder?: string;
+  cancelText?: string;
+  hideWhenScrolling?: WithDefault<boolean, true>;
+  // Named uniquely — codegen derives the enum name from the field name
+  searchPlacement?: WithDefault<'automatic' | 'inline' | 'stacked', 'automatic'>;
+}>;
+
+export interface SearchTextEventPayload {
+  text: string;
+}
+
+export interface NativeProps extends ViewProps {
+  title?: string;
+  largeTitle?: WithDefault<boolean, false>;
+  tintColor?: ColorValue;
+  titleColor?: ColorValue;
+  barColor?: ColorValue;
+  separatorHidden?: WithDefault<boolean, false>;
+  searchable?: WithDefault<boolean, false>;
+  searchOptions?: SearchOptionsType;
+
+  onSearchChange?: DirectEventHandler<SearchTextEventPayload>;
+  onSearchSubmit?: DirectEventHandler<SearchTextEventPayload>;
+  onSearchFocus?: DirectEventHandler<null>;
+  onSearchBlur?: DirectEventHandler<null>;
+  onSearchCancel?: DirectEventHandler<null>;
+}
+
+export default codegenNativeComponent<NativeProps>('TrueSheetNavBarView', {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './TrueSheet';
 export * from './TrueSheet.types';
 export { TrueSheetPeek } from './TrueSheetPeek';
+export { TrueSheetNavBar } from './TrueSheetNavBar';
 export { TrueSheetProvider, useTrueSheet } from './TrueSheetProvider';

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -67,6 +67,18 @@ export function TrueSheetPeek({ children, ...rest }: ViewProps) {
 }
 
 /**
+ * Mock TrueSheetNavBar component for testing.
+ */
+export const TrueSheetNavBar = Object.assign(
+  ({ children }: { children?: ReactNode }) => React.createElement(View, null, children),
+  {
+    Left: ({ children, ...rest }: ViewProps) => React.createElement(View, rest, children),
+    Right: ({ children, ...rest }: ViewProps) => React.createElement(View, rest, children),
+    Title: ({ children, ...rest }: ViewProps) => React.createElement(View, rest, children),
+  }
+);
+
+/**
  * Mock TrueSheetProvider for testing.
  */
 export function TrueSheetProvider({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary

Adds `TrueSheetNavBar`, a native navigation bar rendered through the existing `header` prop:

```tsx
<TrueSheet
  header={
    <TrueSheetNavBar title="Details" largeTitle search={{ placeholder: 'Search' }}>
      <TrueSheetNavBar.Left><BackButton /></TrueSheetNavBar.Left>
      <TrueSheetNavBar.Right><DoneButton /></TrueSheetNavBar.Right>
    </TrueSheetNavBar>
  }
>
```

- **iOS**: embeds a child `UINavigationController` inside `TrueSheetViewController` (presentation flow untouched) — real `UINavigationBar` with large titles, scroll-edge appearance (`setContentScrollView:forEdge:`), `UISearchController`, and bar items hosting arbitrary React children as Yoga-sized custom views.
- **Android**: `MaterialToolbar` pinned natively above the RN container (container offset + Fabric state height compensated), slot children re-parented with screens-style measurement, collapsible `SearchView`.
- **Web**: styled bar with the same API, search input included.
- Bar height feeds the existing `headerHeight` channel so `auto`/`peek` detents account for it.
- Props: `title`, `largeTitle` (iOS), `tintColor`, `titleColor`, `backgroundColor`, `separatorHidden`, `search` (`placeholder`, `cancelText`, `hideWhenScrolling`, `placement`), plus `onSearchChange/Submit/Focus/Blur/Cancel`.
- Examples: new `NavBarSheet` (large title + search filter + Done item) and the map screen's main sheet now uses native search (focus expands, cancel collapses to peek).

Out of scope (follow-ups): native `UIMenu` bar-item menus, Android large-title collapse, docs site page.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- `yarn typecheck`, `yarn lint`, `objclint`, `ktlint` clean; 45 jest tests pass (new NavBar render test included)
- Android manager/delegate signatures verified against freshly generated codegen output
- Native runtime untested yet — needs a build (codegen) + manual pass on the example app (`NavBarSheet` + map screen)

## Screenshots / Videos

_Pending manual test run._

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)