### PR TITLE
fix: keep animatedIndex accurate through keyboard growth and settles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🐛 Bug fixes
 
-- **iOS**: Keyboard-driven sheet growth no longer corrupts `animatedIndex` — detent offset learning is skipped while the keyboard has the sheet grown, with a re-settle once it's away. Settle emits now learn at the final frame and bypass the dedupe, so presenting and settling land exactly on the detent index. ([#762](https://github.com/lodev09/react-native-true-sheet/pull/762) by [@lodev09](https://github.com/lodev09))
+- Keyboard-driven sheet growth no longer corrupts `animatedIndex` — iOS skips detent offset learning while the keyboard has the sheet grown and re-settles once it's away; Android clamps expected detent tops to the available height. Settle emits now learn at the final frame and bypass the dedupe, so presenting and settling land exactly on the detent index. ([#762](https://github.com/lodev09/react-native-true-sheet/pull/762) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- **iOS**: Keyboard-driven sheet growth no longer corrupts `animatedIndex` — detent offset learning is skipped while the keyboard has the sheet grown, with a re-settle once it's away. Settle emits now learn at the final frame and bypass the dedupe, so presenting and settling land exactly on the detent index. ([#762](https://github.com/lodev09/react-native-true-sheet/pull/762) by [@lodev09](https://github.com/lodev09))
+
 ## 3.11.9
 
 ### 🐛 Bug fixes

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -310,7 +310,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   val bottomInset: Int
     get() = if (edgeToEdgeEnabled) ScreenUtils.getInsets(reactContext).bottom else 0
 
-  val topInset: Int
+  override val topInset: Int
     get() = if (edgeToEdgeEnabled) ScreenUtils.getInsets(reactContext).top else 0
 
   override val contentBottomInset: Int
@@ -1145,8 +1145,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     // keyboard-expanded position and a non-keyboard detent position. If so, dismiss
     // keyboard and commit to that detent.
     val maxAvailableHeight = realScreenHeight - topInset
-    val keyboardHeight = minOf(detentCalculator.getDetentHeight(detents.last()), maxAvailableHeight)
-    val keyboardTop = realScreenHeight - keyboardHeight
+    val keyboardTop = detentCalculator.getSheetTopForDetentIndex(detents.size - 1)
 
     for (i in detents.indices) {
       val nonKeyboardHeight = minOf(detentCalculator.getDetentHeight(detents[i], includeKeyboard = false), maxAvailableHeight)

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
@@ -20,6 +20,7 @@ interface TrueSheetDetentCalculatorDelegate {
   val contentBottomInset: Int
   val maxContentHeight: Int?
   val keyboardInset: Int
+  val topInset: Int
 }
 
 /**
@@ -39,6 +40,7 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
   private val contentBottomInset: Int get() = delegate?.contentBottomInset ?: 0
   private val maxContentHeight: Int? get() = delegate?.maxContentHeight
   private val keyboardInset: Int get() = delegate?.keyboardInset ?: 0
+  private val topInset: Int get() = delegate?.topInset ?: 0
 
   /**
    * Height for peek (-2.0) detents: header + footer + peek content height.
@@ -79,7 +81,12 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
       RNLog.w(reactContext, "TrueSheet: Detent index ($index) is out of bounds (0..${detents.size - 1})")
       return realScreenHeight
     }
-    return realScreenHeight - getDetentHeight(detents[index])
+    // Clamp to the space the sheet can actually occupy — matching
+    // setupSheetDetents. A keyboard-inflated detent height can exceed it,
+    // placing the expected top above the screen while the real sheet stops
+    // at the top inset.
+    val maxAvailableHeight = realScreenHeight - topInset
+    return realScreenHeight - minOf(getDetentHeight(detents[index]), maxAvailableHeight)
   }
 
   /**
@@ -186,6 +193,10 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
     for (i in 0 until count - 1) {
       val pos = getSheetTopForDetentIndex(i)
       val nextPos = getSheetTopForDetentIndex(i + 1)
+
+      // Skip degenerate segments — keyboard growth can clamp adjacent detents
+      // to the same top; falling through reports the topmost detent
+      if (pos == nextPos) continue
 
       if (positionPx in nextPos..pos) {
         val range = pos - nextPos

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -77,6 +77,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL dismissible;
 @property (nonatomic, assign) BOOL isPresented;
 @property (nonatomic, assign) NSInteger activeDetentIndex;
+
+/**
+ * YES while the keyboard has the sheet grown beyond its detent height.
+ * Offset learning is skipped in this state — the measured frame would bake
+ * ~keyboardHeight into the learned offset.
+ */
+@property (nonatomic, assign) BOOL keyboardSheetGrown;
 @property (nonatomic, readonly) BOOL isTopmostPresentedController;
 @property (nonatomic, weak, nullable) UIView *accessibilityContentView;
 

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -460,6 +460,10 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     [self endInteractiveDismissState];
   }
 
+  // Dismissing with the keyboard up skips the hide notification — don't let
+  // the stale flag block learning on the next present.
+  _keyboardSheetGrown = NO;
+
   [self emitDidDismissEvents];
 }
 
@@ -478,6 +482,21 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     } else {
       UIViewController *presented = self.presentedViewController;
       BOOL hasPresentedController = presented != nil && !presented.isBeingPresented && !presented.isBeingDismissed;
+
+      // A layout pass at rest can nudge the frame by a sub-pixel amount
+      // (pixel-grid snapping after present), leaving the interpolated index
+      // slightly off the whole number. Re-learn when the frame is effectively
+      // at the current detent so the drift is absorbed instead of emitted.
+      // The tight threshold keeps real movement from being absorbed.
+      if (presented == nil && !_isDragging) {
+        NSInteger index = self.currentDetentIndex;
+        CGFloat expectedHeight = [_detentCalculator resolvedHeightForIndex:index];
+        CGFloat actualHeight = self.screenHeight - self.currentPosition;
+        if (expectedHeight > 0 && fabs(actualHeight - expectedHeight) < 2) {
+          [self learnOffsetForDetentIndex:index];
+        }
+      }
+
       [self emitChangePositionDelegateWithPosition:self.currentPosition
                                           realtime:!hasPresentedController
                                              debug:@"layout"];
@@ -636,13 +655,13 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
       strongSelf->_isTransitioning = NO;
       strongSelf->_isTransitionSnapping = NO;
 
-      // Emit settled position after detent snap.
+      // Settle after a present or detent-snap transition.
       // Uses dispatch_after because presentedView frame isn't final until UIKit
-      // completes its layout pass after the transition animation.
+      // completes its layout pass after the transition animation — learning
+      // here absorbs any sub-pixel drift since the earlier learns.
       if (strongSelf->_isPresented) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-          CGFloat position = strongSelf.currentPosition;
-          [strongSelf emitChangePositionDelegateWithPosition:position realtime:NO debug:@"transition end"];
+          [strongSelf settleAtDetentIndex:strongSelf.currentDetentIndex debug:@"transition end"];
         });
       }
     }];
@@ -798,7 +817,10 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     .index = [self interpolatedIndexForPosition:position],
   };
 
-  if (!TrueSheetPositionStateEquals(_lastEmittedPositionState, state)) {
+  // Settle (non-realtime) emits are authoritative and bypass the dedupe — a
+  // learn right before them can correct the interpolated index by less than
+  // the tolerance, and the corrected value must still reach JS.
+  if (!realtime || !TrueSheetPositionStateEquals(_lastEmittedPositionState, state)) {
     _lastEmittedPositionState = state;
 
     [self.delegate viewControllerDidChangePosition:state.index
@@ -809,7 +831,22 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 }
 
 - (void)learnOffsetForDetentIndex:(NSInteger)index {
+  if (_keyboardSheetGrown) {
+    return;
+  }
   [_detentCalculator learnOffsetForDetentIndex:index];
+}
+
+- (void)setKeyboardSheetGrown:(BOOL)keyboardSheetGrown {
+  BOOL wasGrown = _keyboardSheetGrown;
+  _keyboardSheetGrown = keyboardSheetGrown;
+
+  // Settles are skipped or measure a mid-animation frame while the keyboard
+  // has the sheet grown (e.g. a drag-end during the shrink-back) — re-settle
+  // at the resting detent once the keyboard is fully away.
+  if (wasGrown && !keyboardSheetGrown && self.isPresented && !_isDragging) {
+    [self settleAtDetentIndex:self.currentDetentIndex debug:@"keyboard settled"];
+  }
 }
 
 /**

--- a/ios/core/TrueSheetDetentCalculator.h
+++ b/ios/core/TrueSheetDetentCalculator.h
@@ -56,6 +56,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)learnOffsetForDetentIndex:(NSInteger)index;
 
 /**
+ Returns the expected sheet height for a detent index: the UIKit-resolved
+ height plus the learned offset.
+ */
+- (CGFloat)resolvedHeightForIndex:(NSInteger)index;
+
+/**
  Finds the segment between detents for a given position.
  Returns YES if position is between two detents, NO if at edges.
  outIndex: The lower detent index of the segment (-1 if above first detent)

--- a/ios/core/TrueSheetKeyboardObserver.mm
+++ b/ios/core/TrueSheetKeyboardObserver.mm
@@ -83,6 +83,21 @@
 
   _currentHeight = keyboardHeight;
 
+  if (keyboardHeight > 0) {
+    _viewController.keyboardSheetGrown = YES;
+  } else {
+    // The sheet stays grown until UIKit finishes the shrink-back animation —
+    // clear after it completes, unless the keyboard came back in the meantime.
+    __weak __typeof(self) weakSelf = self;
+    dispatch_after(
+      dispatch_time(DISPATCH_TIME_NOW, (int64_t)((duration + 0.1) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (strongSelf && strongSelf->_currentHeight == 0) {
+          strongSelf->_viewController.keyboardSheetGrown = NO;
+        }
+      });
+  }
+
   for (id<TrueSheetKeyboardObserverDelegate> delegate in _delegates) {
     if (keyboardHeight > 0) {
       [delegate keyboardWillShow:keyboardHeight duration:duration curve:curve];


### PR DESCRIPTION
## Summary

Patch-release port of the fixes from #761 for the 3.11.x line — fixes #758 (bug 1):

**iOS**
- Offset learning is now skipped while the keyboard has the sheet grown — a content/footer resize settle in that state stored a keyboard-inflated offset, capping `animatedIndex` around 0.4 on subsequent drags. The keyboard observer sets a `keyboardSheetGrown` flag on show and clears it after the hide animation completes (guarding the shrink-back window).
- Clearing the flag triggers a re-settle at the resting detent — settles skipped or measured mid-shrink-back (e.g. drag-end while the keyboard hides) left offsets stale.
- The transition-end settle now learns at the final frame, and the layout path absorbs sub-pixel pixel-grid drift (within 2px of the current detent), so present lands exactly on the detent index.
- Non-realtime (settle) emits bypass the position dedupe — corrections smaller than the 0.01 tolerance never reached JS.

**Android**
- Expected detent tops are now clamped to the available height (screen minus top inset), matching the behavior config. A keyboard-inflated top detent put the expected top above the screen while the real sheet stopped at the top inset, capping `animatedIndex` at ~0.81 instead of 1.0.
- Zero-height interpolation segments are skipped so a fully keyboard-expanded sheet reports the topmost detent.

Note on #758 bug 2 (`resize()` no-op after a user drag): not reproducible — the drag-sync in `viewControllerDidChangeDetent` already keeps `activeDetentIndex` current on this line; the reported mechanism only audited `TrueSheetViewController.mm` and missed the sync in `TrueSheetView.mm`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Verified on v4 (#761) with a dedicated repro sheet (footer `TextInput` + runtime footer resize + `animatedIndex` readout); this port is line-for-line equivalent — anchors on `main` are byte-identical except the iOS layout branch, which gains an explicit `!_isDragging` guard. Repro steps from #758:

1. Focus a footer input (keyboard up, sheet grown)
2. Trigger a footer/content resize while the keyboard is up
3. Dismiss the keyboard, collapse, then drag to the top detent
4. `animatedIndex` peaks at 1.0 (previously ~0.4 on iOS)
5. Android: keyboard expands the sheet → `animatedIndex` reads 1.0 (previously ~0.81)

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)