### PR TITLE
fix(android): first tap on Pressable swallowed after touching TextInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug fixes
 
+- **Android**: The first tap on a `Pressable` is no longer swallowed after a `TextInput` in the same sheet is touched — the sheet's root view now forwards `requestDisallowInterceptTouchEvent` up the tree (mirroring `ReactSurfaceView`) so the touch dispatcher sees the gesture end and the stale responder is released. ([#765](https://github.com/lodev09/react-native-true-sheet/pull/765) by [@lodev09](https://github.com/lodev09))
 - Keyboard-driven sheet growth no longer corrupts `animatedIndex` — iOS skips detent offset learning while the keyboard has the sheet grown and re-settles once it's away; Android clamps expected detent tops to the available height. Settle emits now learn at the final frame and bypass the dedupe, so presenting and settling land exactly on the detent index. ([#762](https://github.com/lodev09/react-native-true-sheet/pull/762) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.9

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -1347,6 +1347,12 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     return super.onInterceptTouchEvent(event)
   }
 
+  override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+    // Mirrors ReactSurfaceView: keep receiving onInterceptTouchEvent so
+    // jsTouchDispatcher sees the gesture end, but forward the request up the tree.
+    parent?.requestDisallowInterceptTouchEvent(disallowIntercept)
+  }
+
   override fun onTouchEvent(event: MotionEvent): Boolean {
     eventDispatcher?.let {
       jsTouchDispatcher.handleTouchEvent(event, it, reactContext)


### PR DESCRIPTION
## Summary

Fixes #764.

`TrueSheetViewController` implements RN's `RootView` and feeds its own `JSTouchDispatcher` from `onInterceptTouchEvent`, but inherited `ViewGroup`'s default `requestDisallowInterceptTouchEvent`. When a `TextInput` inside the sheet called `requestDisallowInterceptTouchEvent(true)` on touch, the controller stopped receiving `onInterceptTouchEvent`, so `jsTouchDispatcher` never saw the gesture's UP — JS kept the `TextInput` as the stale responder and swallowed the next tap on any sibling `Pressable`.

Fix mirrors `ReactSurfaceView.requestDisallowInterceptTouchEvent`: don't set the controller's own disallow flag, forward the request up the tree. `TrueSheetCoordinatorLayout` drag handling still gets the signal.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Reproduced in the example app on Android with a sheet containing a `TextInput` and a sibling `Pressable` counting `onPressIn`/`onPress`:

1. Open the sheet, tap the `TextInput` (no typing).
2. Dismiss the keyboard with the BACK key (a "dismiss keyboard" `Pressable` would absorb the swallowed tap and hide the bug).
3. Tap Submit once.

Before: counters stay `0 · 0`; a second identical tap fires. After: first tap fires `1 · 1`. Control (tap Submit without touching the field) fires on first tap in both builds. Sheet drag, dismiss, and inner scroll verified working with the fix.

## Screenshots / Videos

N/A

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)