### PR TITLE
fix(android): forward requestDisallowInterceptTouchEvent in footer view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🐛 Bug fixes
 
-- **Android**: The first tap on a `Pressable` is no longer swallowed after a `TextInput` in the same sheet is touched — the sheet's root view now forwards `requestDisallowInterceptTouchEvent` up the tree (mirroring `ReactSurfaceView`) so the touch dispatcher sees the gesture end and the stale responder is released. ([#765](https://github.com/lodev09/react-native-true-sheet/pull/765) by [@lodev09](https://github.com/lodev09))
+- **Android**: The first tap on a `Pressable` is no longer swallowed after a `TextInput` in the same sheet (or footer) is touched — the sheet's root views now forward `requestDisallowInterceptTouchEvent` up the tree (mirroring `ReactSurfaceView`) so the touch dispatcher sees the gesture end and the stale responder is released. ([#765](https://github.com/lodev09/react-native-true-sheet/pull/765), [#766](https://github.com/lodev09/react-native-true-sheet/pull/766) by [@lodev09](https://github.com/lodev09))
 - Keyboard-driven sheet growth no longer corrupts `animatedIndex` — iOS skips detent offset learning while the keyboard has the sheet grown and re-settles once it's away; Android clamps expected detent tops to the available height. Settle emits now learn at the final frame and bypass the dedupe, so presenting and settling land exactly on the detent index. ([#762](https://github.com/lodev09/react-native-true-sheet/pull/762) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.9

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetFooterView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetFooterView.kt
@@ -68,6 +68,12 @@ class TrueSheetFooterView(private val reactContext: ThemedReactContext) :
     return super.onInterceptTouchEvent(event)
   }
 
+  override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+    // Mirrors ReactSurfaceView: keep receiving onInterceptTouchEvent so
+    // jsTouchDispatcher sees the gesture end, but forward the request up the tree.
+    parent?.requestDisallowInterceptTouchEvent(disallowIntercept)
+  }
+
   override fun onTouchEvent(event: MotionEvent): Boolean {
     if (pointerEvents == PointerEvents.NONE || pointerEvents == PointerEvents.BOX_NONE) {
       return false


### PR DESCRIPTION
## Summary

Follow-up to #765 (issue #764).

`TrueSheetFooterView` is the remaining `RootView` implementation with `ViewGroup`'s default `requestDisallowInterceptTouchEvent` (`ReactViewGroup` doesn't override it). An `EditText` in the footer would set the footer's own disallow flag on touch, blinding its `jsTouchDispatcher` to the gesture's UP — leaving a stale JS responder that swallows the next tap on a sibling `Pressable` in the footer. Same class of bug as the controller fix in #765.

Fix mirrors `ReactSurfaceView` (and the controller): don't set the view's own disallow flag, forward the request up the tree — so `TrueSheetCoordinatorLayout` still receives it and its drag arbitration is unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Same repro shape as #764 scoped to the footer: a sheet `footer` containing a `TextInput` and a sibling `Pressable` counting `onPressIn`/`onPress` — tap the input, dismiss the keyboard with the BACK key, tap the button once. With the fix the first tap fires; footer buttons and sheet drag/dismiss behave normally.

## Screenshots / Videos

N/A

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)