### PR TITLE
fix: stop touches inside sheet from leaking to outside touchables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Android**: The first tap on a `Pressable` is no longer swallowed after a `TextInput` in the same sheet (or footer) is touched — the sheet's root views now forward `requestDisallowInterceptTouchEvent` up the tree (mirroring `ReactSurfaceView`) so the touch dispatcher sees the gesture end and the stale responder is released. ([#765](https://github.com/lodev09/react-native-true-sheet/pull/765), [#766](https://github.com/lodev09/react-native-true-sheet/pull/766) by [@lodev09](https://github.com/lodev09))
 - Keyboard-driven sheet growth no longer corrupts `animatedIndex` — iOS skips detent offset learning while the keyboard has the sheet grown and re-settles once it's away; Android clamps expected detent tops to the available height. Settle emits now learn at the final frame and bypass the dedupe, so presenting and settling land exactly on the detent index. ([#762](https://github.com/lodev09/react-native-true-sheet/pull/762) by [@lodev09](https://github.com/lodev09))
+- Touches on the sheet no longer leak to touchables outside it — tapping the sheet surface used to fire the `onPress` of a parent `Pressable` since unclaimed touches bubble up the React tree. The sheet container now claims them and stops touch propagation at the sheet boundary. ([#767](https://github.com/lodev09/react-native-true-sheet/pull/767) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.9
 

--- a/example/shared/src/components/sheets/ScrollViewSheet.tsx
+++ b/example/shared/src/components/sheets/ScrollViewSheet.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useState } from 'react';
+import { forwardRef, useCallback, useRef, useState } from 'react';
 import {
   StyleSheet,
   ScrollView,
@@ -8,6 +8,7 @@ import {
   Image,
   ActivityIndicator,
   Platform,
+  Pressable,
 } from 'react-native';
 import { TrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
 
@@ -30,9 +31,10 @@ interface ScrollViewSheetProps extends TrueSheetProps {}
 
 const HeavyItem = ({ index }: { index: number }) => {
   const [imageLoaded, setImageLoaded] = useState(false);
+  const sheet = useRef<TrueSheet>(null);
 
   return (
-    <View style={styles.item}>
+    <Pressable style={styles.item} onPress={() => console.log(`HeavyItem #${index + 1} pressed!`)}>
       <View style={styles.imageContainer}>
         {!imageLoaded && <ActivityIndicator style={styles.loader} size="small" />}
         <Image
@@ -41,13 +43,18 @@ const HeavyItem = ({ index }: { index: number }) => {
           onLoad={() => setImageLoaded(true)}
         />
       </View>
-      <View style={styles.itemContent}>
+      <Pressable style={styles.itemContent} onPress={() => sheet.current?.present()}>
         <Text style={styles.itemTitle}>Item #{index + 1}</Text>
         <Text style={styles.itemDescription}>
           Complex component with images and text to test heavy rendering and lazy loading.
         </Text>
-      </View>
-    </View>
+      </Pressable>
+      <TrueSheet ref={sheet} detents={[0.5]} backgroundColor={Platform.select({ android: DARK })}>
+        <View style={styles.placeholder}>
+          <Text style={styles.placeholderText}>Sheet content</Text>
+        </View>
+      </TrueSheet>
+    </Pressable>
   );
 };
 

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -42,6 +42,7 @@ import {
   findNodeHandle,
   processColor,
   type NativeEventSubscription,
+  type GestureResponderEvent,
 } from 'react-native';
 
 const LINKING_ERROR =
@@ -56,6 +57,13 @@ if (!TrueSheetModule) {
 }
 
 type NativeRef = ComponentRef<typeof TrueSheetViewNativeComponent>;
+
+// Claim touches that no descendant claimed so the responder negotiation
+// doesn't bubble up to touchables outside the sheet
+const absorbUnclaimedTouches = () => true;
+
+// Stop raw touch events from bubbling past the sheet to outside ancestors
+const stopTouchPropagation = (event: GestureResponderEvent) => event.stopPropagation();
 
 interface TrueSheetState {
   shouldRenderNativeView: boolean;
@@ -538,6 +546,11 @@ export class TrueSheet
         {this.state.shouldRenderNativeView && (
           <TrueSheetContainerViewNativeComponent
             style={scrollable ? styles.scrollableContainer : undefined}
+            onStartShouldSetResponder={absorbUnclaimedTouches}
+            onTouchStart={stopTouchPropagation}
+            onTouchMove={stopTouchPropagation}
+            onTouchEnd={stopTouchPropagation}
+            onTouchCancel={stopTouchPropagation}
           >
             {header && (
               <TrueSheetHeaderViewNativeComponent style={[styles.header, headerStyle]}>


### PR DESCRIPTION
## Summary

Fixes #763. When a `TrueSheet` is rendered inside a `Pressable` (or any touchable), tapping the presented sheet surface fired the parent's `onPress`.

Native views are reparented into the sheet, but RN touch events bubble through the React tree — so touches that nothing inside the sheet claimed kept bubbling up to touchables outside it. The container now:

- Claims unclaimed touches via `onStartShouldSetResponder`, so the responder negotiation never reaches ancestors outside the sheet. Deeper touchables inside the sheet still win (bubble runs deepest-first), and native gestures (sheet drag, scroll) are unaffected since the responder grant doesn't block native handlers.
- Stops raw `onTouch*` events from propagating past the sheet boundary.

Also adds a repro to the example's `ScrollViewSheet`: each item is a `Pressable` with a nested sheet.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

1. Open the ScrollView sheet in the example app
2. Tap an item's text to present the nested sheet
3. Tap the nested sheet surface — the parent item's `onPress` should NOT log
4. Verify buttons, scrolling, refresh control, and sheet dragging inside the sheet still work

## Screenshots / Videos

N/A

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)