### PR TITLE
feat: add accessibilityOptions prop for customizing accessibility strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🎉 New features
+
+- New `accessibilityOptions` prop for customizing (e.g. localizing) the accessibility strings announced by screen readers — grabber label/hint, detent state values (with `{index}`/`{count}` placeholders), Android expand/collapse action labels, and the sheet pane/dialog title on Android and Web. ([#770](https://github.com/lodev09/react-native-true-sheet/pull/770) by [@lodev09](https://github.com/lodev09))
+
 ### 🐛 Bug fixes
 
 - **Android**: The first tap on a `Pressable` is no longer swallowed after a `TextInput` in the same sheet (or footer) is touched — the sheet's root views now forward `requestDisallowInterceptTouchEvent` up the tree (mirroring `ReactSurfaceView`) so the touch dispatcher sees the gesture end and the stale responder is released. ([#765](https://github.com/lodev09/react-native-true-sheet/pull/765), [#766](https://github.com/lodev09/react-native-true-sheet/pull/766) by [@lodev09](https://github.com/lodev09))

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -15,6 +15,7 @@ import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.util.RNLog
 import com.facebook.react.views.view.ReactViewGroup
+import com.lodev09.truesheet.core.AccessibilityOptions
 import com.lodev09.truesheet.core.GrabberOptions
 import com.lodev09.truesheet.core.RNScreensEventObserver
 import com.lodev09.truesheet.core.RNScreensEventObserverDelegate
@@ -261,6 +262,10 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
 
   fun setGrabberOptions(options: GrabberOptions?) {
     viewController.grabberOptions = options
+  }
+
+  fun setAccessibilityOptions(options: AccessibilityOptions?) {
+    viewController.accessibilityOptions = options
   }
 
   fun setSheetElevation(elevation: Float) {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.util.RNLog
 import com.facebook.react.views.view.ReactViewGroup
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.lodev09.truesheet.core.AccessibilityOptions
 import com.lodev09.truesheet.core.GrabberOptions
 import com.lodev09.truesheet.core.TrueSheetBottomSheetBehavior
 import com.lodev09.truesheet.core.TrueSheetBottomSheetView
@@ -213,6 +214,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   var dimmedDetentIndex = 0
   override var grabber: Boolean = true
   override var grabberOptions: GrabberOptions? = null
+  override var accessibilityOptions: AccessibilityOptions? = null
   override var sheetBackgroundColor: Int? = null
   var insetAdjustment: TrueSheetInsetAdjustment = TrueSheetInsetAdjustment.AUTOMATIC
 
@@ -714,6 +716,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     sheet.setupBackground()
     sheet.setupElevation()
     sheet.setupGrabber()
+    sheet.setupAccessibility()
 
     if (shouldAnimatePresent) {
       isPresentAnimating = true

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -14,6 +14,7 @@ import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.TrueSheetViewManagerDelegate
 import com.facebook.react.viewmanagers.TrueSheetViewManagerInterface
+import com.lodev09.truesheet.core.AccessibilityOptions
 import com.lodev09.truesheet.core.GrabberOptions
 import com.lodev09.truesheet.events.*
 
@@ -134,6 +135,25 @@ class TrueSheetViewManager :
       adaptive = if (options.hasKey("adaptive")) options.getBoolean("adaptive") else true
     )
     view.setGrabberOptions(grabberOptions)
+  }
+
+  @ReactProp(name = "accessibilityOptions")
+  override fun setAccessibilityOptions(view: TrueSheetView, options: ReadableMap?) {
+    if (options == null) {
+      view.setAccessibilityOptions(null)
+      return
+    }
+
+    val accessibilityOptions = AccessibilityOptions(
+      grabberLabel = if (options.hasKey("grabberLabel")) options.getString("grabberLabel") else null,
+      expandedValue = if (options.hasKey("expandedValue")) options.getString("expandedValue") else null,
+      collapsedValue = if (options.hasKey("collapsedValue")) options.getString("collapsedValue") else null,
+      detentValue = if (options.hasKey("detentValue")) options.getString("detentValue") else null,
+      expandActionLabel = if (options.hasKey("expandActionLabel")) options.getString("expandActionLabel") else null,
+      collapseActionLabel = if (options.hasKey("collapseActionLabel")) options.getString("collapseActionLabel") else null,
+      paneTitle = if (options.hasKey("paneTitle")) options.getString("paneTitle") else null
+    )
+    view.setAccessibilityOptions(accessibilityOptions)
   }
 
   @ReactProp(name = "dismissible", defaultBoolean = true)

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetBottomSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetBottomSheetView.kt
@@ -222,7 +222,7 @@ class TrueSheetBottomSheetView(private val reactContext: ThemedReactContext) : F
   }
 
   fun setupAccessibility() {
-    ViewCompat.setAccessibilityPaneTitle(this, delegate?.accessibilityOptions?.paneTitle)
+    ViewCompat.setAccessibilityPaneTitle(this, delegate?.accessibilityOptions?.paneTitle ?: "Bottom sheet")
   }
 
   // =============================================================================

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetBottomSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetBottomSheetView.kt
@@ -31,6 +31,7 @@ interface TrueSheetBottomSheetViewDelegate {
   val anchorOffset: Int
   val grabber: Boolean
   val grabberOptions: GrabberOptions?
+  val accessibilityOptions: AccessibilityOptions?
   val draggable: Boolean
   fun bottomSheetViewDidTapGrabber()
   fun bottomSheetViewDidAccessibilityIncrement()
@@ -205,7 +206,7 @@ class TrueSheetBottomSheetView(private val reactContext: ThemedReactContext) : F
       return
     }
 
-    val grabberView = TrueSheetGrabberView(reactContext, delegate?.grabberOptions).apply {
+    val grabberView = TrueSheetGrabberView(reactContext, delegate?.grabberOptions, delegate?.accessibilityOptions).apply {
       tag = GRABBER_TAG
       id = View.generateViewId()
       onAccessibilityIncrement = { delegate?.bottomSheetViewDidAccessibilityIncrement() }
@@ -220,6 +221,10 @@ class TrueSheetBottomSheetView(private val reactContext: ThemedReactContext) : F
 
   fun updateGrabberAccessibilityValue(index: Int, detentCount: Int) {
     findViewWithTag<TrueSheetGrabberView>(GRABBER_TAG)?.updateAccessibilityValue(index, detentCount)
+  }
+
+  fun setupAccessibility() {
+    ViewCompat.setAccessibilityPaneTitle(this, delegate?.accessibilityOptions?.paneTitle ?: "Bottom sheet")
   }
 
   // =============================================================================

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetBottomSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetBottomSheetView.kt
@@ -79,8 +79,6 @@ class TrueSheetBottomSheetView(private val reactContext: ThemedReactContext) : F
     // Allow content to extend beyond bounds (for footer positioning)
     clipChildren = false
     clipToPadding = false
-
-    ViewCompat.setAccessibilityPaneTitle(this, "Bottom sheet")
   }
 
   override fun setTranslationY(translationY: Float) {
@@ -224,7 +222,7 @@ class TrueSheetBottomSheetView(private val reactContext: ThemedReactContext) : F
   }
 
   fun setupAccessibility() {
-    ViewCompat.setAccessibilityPaneTitle(this, delegate?.accessibilityOptions?.paneTitle ?: "Bottom sheet")
+    ViewCompat.setAccessibilityPaneTitle(this, delegate?.accessibilityOptions?.paneTitle)
   }
 
   // =============================================================================

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetGrabberView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetGrabberView.kt
@@ -111,7 +111,7 @@ class TrueSheetGrabberView(
     addView(pillView)
 
     isFocusable = true
-    contentDescription = accessibilityOptions?.grabberLabel
+    contentDescription = accessibilityOptions?.grabberLabel ?: "Drag handle"
 
     accessibilityDelegate = object : View.AccessibilityDelegate() {
       override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfo) {
@@ -119,13 +119,13 @@ class TrueSheetGrabberView(
         info.addAction(
           AccessibilityNodeInfo.AccessibilityAction(
             AccessibilityNodeInfo.ACTION_SCROLL_FORWARD,
-            accessibilityOptions?.expandActionLabel
+            accessibilityOptions?.expandActionLabel ?: "Expand"
           )
         )
         info.addAction(
           AccessibilityNodeInfo.AccessibilityAction(
             AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD,
-            accessibilityOptions?.collapseActionLabel
+            accessibilityOptions?.collapseActionLabel ?: "Collapse"
           )
         )
         info.className = "android.widget.SeekBar"
@@ -152,14 +152,14 @@ class TrueSheetGrabberView(
     val description: CharSequence? = when {
       index < 0 || detentCount <= 0 -> null
 
-      index >= detentCount - 1 -> accessibilityOptions?.expandedValue
+      index >= detentCount - 1 -> accessibilityOptions?.expandedValue ?: "Expanded"
 
-      index == 0 -> accessibilityOptions?.collapsedValue
+      index == 0 -> accessibilityOptions?.collapsedValue ?: "Collapsed"
 
       else ->
-        accessibilityOptions?.detentValue
-          ?.replace("{index}", "${index + 1}")
-          ?.replace("{count}", "$detentCount")
+        (accessibilityOptions?.detentValue ?: "Detent {index} of {count}")
+          .replace("{index}", "${index + 1}")
+          .replace("{count}", "$detentCount")
     }
     ViewCompat.setStateDescription(this, description)
   }

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetGrabberView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetGrabberView.kt
@@ -27,11 +27,28 @@ data class GrabberOptions(
 )
 
 /**
+ * Options for customizing (e.g. localizing) accessibility strings.
+ */
+data class AccessibilityOptions(
+  val grabberLabel: String? = null,
+  val expandedValue: String? = null,
+  val collapsedValue: String? = null,
+  val detentValue: String? = null,
+  val expandActionLabel: String? = null,
+  val collapseActionLabel: String? = null,
+  val paneTitle: String? = null
+)
+
+/**
  * Native grabber (drag handle) view for the bottom sheet.
  * Displays a small pill-shaped indicator at the top of the sheet with a tappable hitbox.
  */
 @SuppressLint("ViewConstructor")
-class TrueSheetGrabberView(context: Context, private val options: GrabberOptions? = null) : FrameLayout(context) {
+class TrueSheetGrabberView(
+  context: Context,
+  private val options: GrabberOptions? = null,
+  private val accessibilityOptions: AccessibilityOptions? = null
+) : FrameLayout(context) {
 
   companion object {
     private const val DEFAULT_WIDTH = 32f // dp
@@ -94,7 +111,7 @@ class TrueSheetGrabberView(context: Context, private val options: GrabberOptions
     addView(pillView)
 
     isFocusable = true
-    contentDescription = "Drag handle"
+    contentDescription = accessibilityOptions?.grabberLabel ?: "Drag handle"
 
     accessibilityDelegate = object : View.AccessibilityDelegate() {
       override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfo) {
@@ -102,13 +119,13 @@ class TrueSheetGrabberView(context: Context, private val options: GrabberOptions
         info.addAction(
           AccessibilityNodeInfo.AccessibilityAction(
             AccessibilityNodeInfo.ACTION_SCROLL_FORWARD,
-            "Expand"
+            accessibilityOptions?.expandActionLabel ?: "Expand"
           )
         )
         info.addAction(
           AccessibilityNodeInfo.AccessibilityAction(
             AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD,
-            "Collapse"
+            accessibilityOptions?.collapseActionLabel ?: "Collapse"
           )
         )
         info.className = "android.widget.SeekBar"
@@ -134,9 +151,16 @@ class TrueSheetGrabberView(context: Context, private val options: GrabberOptions
   fun updateAccessibilityValue(index: Int, detentCount: Int) {
     val description: CharSequence? = when {
       index < 0 || detentCount <= 0 -> null
-      index >= detentCount - 1 -> "Expanded"
-      index == 0 -> "Collapsed"
-      else -> "Detent ${index + 1} of $detentCount"
+
+      index >= detentCount - 1 -> accessibilityOptions?.expandedValue ?: "Expanded"
+
+      index == 0 -> accessibilityOptions?.collapsedValue ?: "Collapsed"
+
+      else ->
+        accessibilityOptions?.detentValue
+          ?.replace("{index}", "${index + 1}")
+          ?.replace("{count}", "$detentCount")
+          ?: "Detent ${index + 1} of $detentCount"
     }
     ViewCompat.setStateDescription(this, description)
   }

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetGrabberView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetGrabberView.kt
@@ -111,7 +111,7 @@ class TrueSheetGrabberView(
     addView(pillView)
 
     isFocusable = true
-    contentDescription = accessibilityOptions?.grabberLabel ?: "Drag handle"
+    contentDescription = accessibilityOptions?.grabberLabel
 
     accessibilityDelegate = object : View.AccessibilityDelegate() {
       override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfo) {
@@ -119,13 +119,13 @@ class TrueSheetGrabberView(
         info.addAction(
           AccessibilityNodeInfo.AccessibilityAction(
             AccessibilityNodeInfo.ACTION_SCROLL_FORWARD,
-            accessibilityOptions?.expandActionLabel ?: "Expand"
+            accessibilityOptions?.expandActionLabel
           )
         )
         info.addAction(
           AccessibilityNodeInfo.AccessibilityAction(
             AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD,
-            accessibilityOptions?.collapseActionLabel ?: "Collapse"
+            accessibilityOptions?.collapseActionLabel
           )
         )
         info.className = "android.widget.SeekBar"
@@ -152,15 +152,14 @@ class TrueSheetGrabberView(
     val description: CharSequence? = when {
       index < 0 || detentCount <= 0 -> null
 
-      index >= detentCount - 1 -> accessibilityOptions?.expandedValue ?: "Expanded"
+      index >= detentCount - 1 -> accessibilityOptions?.expandedValue
 
-      index == 0 -> accessibilityOptions?.collapsedValue ?: "Collapsed"
+      index == 0 -> accessibilityOptions?.collapsedValue
 
       else ->
         accessibilityOptions?.detentValue
           ?.replace("{index}", "${index + 1}")
           ?.replace("{count}", "$detentCount")
-          ?: "Detent ${index + 1} of $detentCount"
     }
     ViewCompat.setStateDescription(this, description)
   }

--- a/docs/docs/reference/01-configuration.mdx
+++ b/docs/docs/reference/01-configuration.mdx
@@ -256,6 +256,30 @@ Options for customizing the grabber appearance. Only applies when [`grabber`](#g
 On iOS, when `grabberOptions` is not provided, the native system grabber is used. When any option is provided, a custom grabber view with vibrancy effect is rendered instead.
 :::
 
+## `accessibilityOptions`
+
+Options for customizing (e.g. localizing) the accessibility strings announced by screen readers.
+
+| Type | Default | 🍎 | 🤖 | 🌐 |
+| - | - | - | - | - |
+| [`AccessibilityOptions`](types#accessibilityoptions) | | ✅ | ✅ | ✅ |
+
+```tsx
+<TrueSheet
+  accessibilityOptions={{
+    grabberLabel: 'Poignée de déplacement',
+    expandedValue: 'Développé',
+    collapsedValue: 'Réduit',
+  }}
+>
+  <View />
+</TrueSheet>
+```
+
+:::info
+On iOS, the grabber strings only apply when [`grabberOptions`](#grabberoptions) is provided. Without it, iOS uses the system grabber which is already localized by the system.
+:::
+
 ## `header`
 
 A component that is fixed at the top of the sheet content. Useful for search bars, titles, or other header content. The header height is automatically accounted for in layout calculations. Accepts a functional `Component` or `ReactElement`. See [this guide](../guides/header) for example.

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -160,6 +160,38 @@ Options for customizing the grabber (drag handle) appearance.
 | `color` | `ColorValue` | The color of the grabber. Uses native styling when not provided. | |
 | `adaptive` | `boolean` | Whether the grabber adapts to light/dark mode. Uses vibrancy on iOS and theme-based colors on Android. | `true` |
 
+## `AccessibilityOptions`
+
+Options for customizing (e.g. localizing) the accessibility strings announced by screen readers.
+
+```tsx
+<TrueSheet
+  accessibilityOptions={{
+    grabberLabel: 'Poignée de déplacement',
+    expandedValue: 'Développé',
+    collapsedValue: 'Réduit',
+    detentValue: 'Position {index} sur {count}',
+  }}
+>
+  <View />
+</TrueSheet>
+```
+
+| Property | Type | Description | Default |
+| - | - | - | - |
+| `grabberLabel` | `string` | The accessibility label of the grabber. | iOS: `'Sheet Grabber'`, Android: `'Drag handle'` |
+| `grabberHint` | `string` | The accessibility hint of the grabber. iOS only. | `'Double-tap to expand. Swipe up or down to resize the sheet'` |
+| `expandedValue` | `string` | The value announced when the sheet is at the last detent. | `'Expanded'` |
+| `collapsedValue` | `string` | The value announced when the sheet is at the first detent. | `'Collapsed'` |
+| `detentValue` | `string` | The value announced at intermediate detents. Supports `{index}` and `{count}` placeholders. | `'Detent {index} of {count}'` |
+| `expandActionLabel` | `string` | The label of the expand accessibility action. Android only. | `'Expand'` |
+| `collapseActionLabel` | `string` | The label of the collapse accessibility action. Android only. | `'Collapse'` |
+| `paneTitle` | `string` | The title announced when the sheet appears. Sets the accessibility pane title on Android and the hidden dialog title on Web. | Android: `'Bottom sheet'`, Web: `'Sheet'` |
+
+:::info
+On iOS, the grabber strings only apply when [`grabberOptions`](configuration#grabberoptions) is provided. Without it, iOS uses the system grabber which is already localized by the system.
+:::
+
 ## `InsetAdjustment`
 
 Controls how the bottom safe area inset affects detent heights.

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -230,16 +230,8 @@ using namespace facebook::react;
     _controller.grabberOptions = nil;
   }
 
-  // Accessibility options - applied to the custom grabber.
-  // Defaults are merged in on the JS side, so all strings are always set.
-  const auto &a11yOpts = newProps.accessibilityOptions;
-  AccessibilityOptions *accessibilityOptions = [[AccessibilityOptions alloc] init];
-  accessibilityOptions.grabberLabel = RCTNSStringFromStringNilIfEmpty(a11yOpts.grabberLabel);
-  accessibilityOptions.grabberHint = RCTNSStringFromStringNilIfEmpty(a11yOpts.grabberHint);
-  accessibilityOptions.expandedValue = RCTNSStringFromStringNilIfEmpty(a11yOpts.expandedValue);
-  accessibilityOptions.collapsedValue = RCTNSStringFromStringNilIfEmpty(a11yOpts.collapsedValue);
-  accessibilityOptions.detentValue = RCTNSStringFromStringNilIfEmpty(a11yOpts.detentValue);
-  _controller.accessibilityOptions = accessibilityOptions;
+  // Accessibility options - applied to the custom grabber
+  _controller.accessibilityOptions = newProps.accessibilityOptions;
 
   _controller.presentation = newProps.presentation;
   _controller.dismissible = newProps.dismissible;

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -230,6 +230,26 @@ using namespace facebook::react;
     _controller.grabberOptions = nil;
   }
 
+  // Accessibility options - applied to the custom grabber
+  const auto &a11yOpts = newProps.accessibilityOptions;
+  NSString *grabberLabel = RCTNSStringFromStringNilIfEmpty(a11yOpts.grabberLabel);
+  NSString *grabberHint = RCTNSStringFromStringNilIfEmpty(a11yOpts.grabberHint);
+  NSString *expandedValue = RCTNSStringFromStringNilIfEmpty(a11yOpts.expandedValue);
+  NSString *collapsedValue = RCTNSStringFromStringNilIfEmpty(a11yOpts.collapsedValue);
+  NSString *detentValue = RCTNSStringFromStringNilIfEmpty(a11yOpts.detentValue);
+
+  if (grabberLabel || grabberHint || expandedValue || collapsedValue || detentValue) {
+    AccessibilityOptions *options = [[AccessibilityOptions alloc] init];
+    options.grabberLabel = grabberLabel;
+    options.grabberHint = grabberHint;
+    options.expandedValue = expandedValue;
+    options.collapsedValue = collapsedValue;
+    options.detentValue = detentValue;
+    _controller.accessibilityOptions = options;
+  } else {
+    _controller.accessibilityOptions = nil;
+  }
+
   _controller.presentation = newProps.presentation;
   _controller.dismissible = newProps.dismissible;
   _controller.draggable = newProps.draggable;

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -230,25 +230,16 @@ using namespace facebook::react;
     _controller.grabberOptions = nil;
   }
 
-  // Accessibility options - applied to the custom grabber
+  // Accessibility options - applied to the custom grabber.
+  // Defaults are merged in on the JS side, so all strings are always set.
   const auto &a11yOpts = newProps.accessibilityOptions;
-  NSString *grabberLabel = RCTNSStringFromStringNilIfEmpty(a11yOpts.grabberLabel);
-  NSString *grabberHint = RCTNSStringFromStringNilIfEmpty(a11yOpts.grabberHint);
-  NSString *expandedValue = RCTNSStringFromStringNilIfEmpty(a11yOpts.expandedValue);
-  NSString *collapsedValue = RCTNSStringFromStringNilIfEmpty(a11yOpts.collapsedValue);
-  NSString *detentValue = RCTNSStringFromStringNilIfEmpty(a11yOpts.detentValue);
-
-  if (grabberLabel || grabberHint || expandedValue || collapsedValue || detentValue) {
-    AccessibilityOptions *options = [[AccessibilityOptions alloc] init];
-    options.grabberLabel = grabberLabel;
-    options.grabberHint = grabberHint;
-    options.expandedValue = expandedValue;
-    options.collapsedValue = collapsedValue;
-    options.detentValue = detentValue;
-    _controller.accessibilityOptions = options;
-  } else {
-    _controller.accessibilityOptions = nil;
-  }
+  AccessibilityOptions *accessibilityOptions = [[AccessibilityOptions alloc] init];
+  accessibilityOptions.grabberLabel = RCTNSStringFromStringNilIfEmpty(a11yOpts.grabberLabel);
+  accessibilityOptions.grabberHint = RCTNSStringFromStringNilIfEmpty(a11yOpts.grabberHint);
+  accessibilityOptions.expandedValue = RCTNSStringFromStringNilIfEmpty(a11yOpts.expandedValue);
+  accessibilityOptions.collapsedValue = RCTNSStringFromStringNilIfEmpty(a11yOpts.collapsedValue);
+  accessibilityOptions.detentValue = RCTNSStringFromStringNilIfEmpty(a11yOpts.detentValue);
+  _controller.accessibilityOptions = accessibilityOptions;
 
   _controller.presentation = newProps.presentation;
   _controller.dismissible = newProps.dismissible;

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -63,6 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSNumber *cornerRadius;
 @property (nonatomic, assign) BOOL grabber;
 @property (nonatomic, strong, nullable) GrabberOptions *grabberOptions;
+@property (nonatomic, strong, nullable) AccessibilityOptions *accessibilityOptions;
 @property (nonatomic, assign) BOOL draggable;
 @property (nonatomic, assign) BOOL dimmed;
 @property (nonatomic, strong, nullable) NSNumber *dimmedDetentIndex;

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSNumber *cornerRadius;
 @property (nonatomic, assign) BOOL grabber;
 @property (nonatomic, strong, nullable) GrabberOptions *grabberOptions;
-@property (nonatomic, strong, nullable) AccessibilityOptions *accessibilityOptions;
+@property (nonatomic, assign) facebook::react::TrueSheetViewAccessibilityOptionsStruct accessibilityOptions;
 @property (nonatomic, assign) BOOL draggable;
 @property (nonatomic, assign) BOOL dimmed;
 @property (nonatomic, strong, nullable) NSNumber *dimmedDetentIndex;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -1102,6 +1102,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     self.sheet.prefersGrabberVisible = NO;
 
     GrabberOptions *options = self.grabberOptions;
+    _grabberView.accessibilityOptions = self.accessibilityOptions;
     _grabberView.grabberWidth = options.width;
     _grabberView.grabberHeight = options.height;
     _grabberView.topMargin = options.topMargin;

--- a/ios/core/TrueSheetGrabberView.h
+++ b/ios/core/TrueSheetGrabberView.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <react/renderer/components/TrueSheetSpec/Props.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,16 +19,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSNumber *cornerRadius;
 @property (nonatomic, strong, nullable) UIColor *color;
 @property (nonatomic, assign) BOOL adaptive;
-
-@end
-
-@interface AccessibilityOptions : NSObject
-
-@property (nonatomic, copy, nullable) NSString *grabberLabel;
-@property (nonatomic, copy, nullable) NSString *grabberHint;
-@property (nonatomic, copy, nullable) NSString *expandedValue;
-@property (nonatomic, copy, nullable) NSString *collapsedValue;
-@property (nonatomic, copy, nullable) NSString *detentValue;
 
 @end
 
@@ -55,8 +46,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Whether the grabber color adapts to the background (default: YES)
 @property (nonatomic, strong, nullable) NSNumber *adaptive;
 
-/// Custom accessibility strings (uses built-in defaults when nil)
-@property (nonatomic, strong, nullable) AccessibilityOptions *accessibilityOptions;
+/// Accessibility strings (defaults come from the codegen prop defaults)
+@property (nonatomic, assign) facebook::react::TrueSheetViewAccessibilityOptionsStruct accessibilityOptions;
 
 /// Called when the grabber is tapped
 @property (nonatomic, copy, nullable) void (^onTap)(void);

--- a/ios/core/TrueSheetGrabberView.h
+++ b/ios/core/TrueSheetGrabberView.h
@@ -21,6 +21,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface AccessibilityOptions : NSObject
+
+@property (nonatomic, copy, nullable) NSString *grabberLabel;
+@property (nonatomic, copy, nullable) NSString *grabberHint;
+@property (nonatomic, copy, nullable) NSString *expandedValue;
+@property (nonatomic, copy, nullable) NSString *collapsedValue;
+@property (nonatomic, copy, nullable) NSString *detentValue;
+
+@end
+
 /**
  * Native grabber (drag handle) view for the bottom sheet.
  * Uses UIVibrancyEffect to adapt color based on the background.
@@ -44,6 +54,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Whether the grabber color adapts to the background (default: YES)
 @property (nonatomic, strong, nullable) NSNumber *adaptive;
+
+/// Custom accessibility strings (uses built-in defaults when nil)
+@property (nonatomic, strong, nullable) AccessibilityOptions *accessibilityOptions;
 
 /// Called when the grabber is tapped
 @property (nonatomic, copy, nullable) void (^onTap)(void);

--- a/ios/core/TrueSheetGrabberView.mm
+++ b/ios/core/TrueSheetGrabberView.mm
@@ -8,6 +8,10 @@
 
 #import "TrueSheetGrabberView.h"
 
+#import <React/RCTConversions.h>
+
+using namespace facebook::react;
+
 @implementation GrabberOptions
 
 - (instancetype)init {
@@ -17,9 +21,6 @@
   return self;
 }
 
-@end
-
-@implementation AccessibilityOptions
 @end
 
 static const CGFloat kDefaultGrabberWidth = 36.0;
@@ -104,10 +105,10 @@ static const CGFloat kHitPaddingVertical = 10.0;
 
 #pragma mark - Public
 
-- (void)setAccessibilityOptions:(AccessibilityOptions *)accessibilityOptions {
+- (void)setAccessibilityOptions:(TrueSheetViewAccessibilityOptionsStruct)accessibilityOptions {
   _accessibilityOptions = accessibilityOptions;
-  self.accessibilityLabel = accessibilityOptions.grabberLabel;
-  self.accessibilityHint = accessibilityOptions.grabberHint;
+  self.accessibilityLabel = RCTNSStringFromStringNilIfEmpty(accessibilityOptions.grabberLabel);
+  self.accessibilityHint = RCTNSStringFromStringNilIfEmpty(accessibilityOptions.grabberHint);
 }
 
 - (void)updateAccessibilityValueWithIndex:(NSInteger)index detentCount:(NSInteger)count {
@@ -117,12 +118,12 @@ static const CGFloat kHitPaddingVertical = 10.0;
   }
 
   if (index >= count - 1) {
-    self.accessibilityValue = _accessibilityOptions.expandedValue;
+    self.accessibilityValue = RCTNSStringFromStringNilIfEmpty(_accessibilityOptions.expandedValue);
   } else if (index == 0) {
-    self.accessibilityValue = _accessibilityOptions.collapsedValue;
+    self.accessibilityValue = RCTNSStringFromStringNilIfEmpty(_accessibilityOptions.collapsedValue);
   } else {
-    NSString *value = [_accessibilityOptions.detentValue stringByReplacingOccurrencesOfString:@"{index}"
-                                                                                   withString:@(index + 1).stringValue];
+    NSString *value = RCTNSStringFromStringNilIfEmpty(_accessibilityOptions.detentValue);
+    value = [value stringByReplacingOccurrencesOfString:@"{index}" withString:@(index + 1).stringValue];
     self.accessibilityValue = [value stringByReplacingOccurrencesOfString:@"{count}" withString:@(count).stringValue];
   }
 }

--- a/ios/core/TrueSheetGrabberView.mm
+++ b/ios/core/TrueSheetGrabberView.mm
@@ -22,9 +22,6 @@
 @implementation AccessibilityOptions
 @end
 
-static NSString *const kDefaultAccessibilityLabel = @"Sheet Grabber";
-static NSString *const kDefaultAccessibilityHint = @"Double-tap to expand. Swipe up or down to resize the sheet";
-
 static const CGFloat kDefaultGrabberWidth = 36.0;
 static const CGFloat kDefaultGrabberHeight = 5.0;
 static const CGFloat kDefaultGrabberTopMargin = 5.0;
@@ -72,9 +69,7 @@ static const CGFloat kHitPaddingVertical = 10.0;
 - (void)setupView {
   self.clipsToBounds = NO;
   self.isAccessibilityElement = YES;
-  self.accessibilityLabel = kDefaultAccessibilityLabel;
   self.accessibilityTraits = UIAccessibilityTraitAdjustable | UIAccessibilityTraitButton;
-  self.accessibilityHint = kDefaultAccessibilityHint;
 
   UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap)];
   [self addGestureRecognizer:tap];
@@ -111,8 +106,8 @@ static const CGFloat kHitPaddingVertical = 10.0;
 
 - (void)setAccessibilityOptions:(AccessibilityOptions *)accessibilityOptions {
   _accessibilityOptions = accessibilityOptions;
-  self.accessibilityLabel = accessibilityOptions.grabberLabel ?: kDefaultAccessibilityLabel;
-  self.accessibilityHint = accessibilityOptions.grabberHint ?: kDefaultAccessibilityHint;
+  self.accessibilityLabel = accessibilityOptions.grabberLabel;
+  self.accessibilityHint = accessibilityOptions.grabberHint;
 }
 
 - (void)updateAccessibilityValueWithIndex:(NSInteger)index detentCount:(NSInteger)count {
@@ -122,15 +117,13 @@ static const CGFloat kHitPaddingVertical = 10.0;
   }
 
   if (index >= count - 1) {
-    self.accessibilityValue = _accessibilityOptions.expandedValue ?: @"Expanded";
+    self.accessibilityValue = _accessibilityOptions.expandedValue;
   } else if (index == 0) {
-    self.accessibilityValue = _accessibilityOptions.collapsedValue ?: @"Collapsed";
-  } else if (_accessibilityOptions.detentValue) {
+    self.accessibilityValue = _accessibilityOptions.collapsedValue;
+  } else {
     NSString *value = [_accessibilityOptions.detentValue stringByReplacingOccurrencesOfString:@"{index}"
                                                                                    withString:@(index + 1).stringValue];
     self.accessibilityValue = [value stringByReplacingOccurrencesOfString:@"{count}" withString:@(count).stringValue];
-  } else {
-    self.accessibilityValue = [NSString stringWithFormat:@"Detent %ld of %ld", (long)(index + 1), (long)count];
   }
 }
 

--- a/ios/core/TrueSheetGrabberView.mm
+++ b/ios/core/TrueSheetGrabberView.mm
@@ -19,6 +19,12 @@
 
 @end
 
+@implementation AccessibilityOptions
+@end
+
+static NSString *const kDefaultAccessibilityLabel = @"Sheet Grabber";
+static NSString *const kDefaultAccessibilityHint = @"Double-tap to expand. Swipe up or down to resize the sheet";
+
 static const CGFloat kDefaultGrabberWidth = 36.0;
 static const CGFloat kDefaultGrabberHeight = 5.0;
 static const CGFloat kDefaultGrabberTopMargin = 5.0;
@@ -66,9 +72,9 @@ static const CGFloat kHitPaddingVertical = 10.0;
 - (void)setupView {
   self.clipsToBounds = NO;
   self.isAccessibilityElement = YES;
-  self.accessibilityLabel = @"Sheet Grabber";
+  self.accessibilityLabel = kDefaultAccessibilityLabel;
   self.accessibilityTraits = UIAccessibilityTraitAdjustable | UIAccessibilityTraitButton;
-  self.accessibilityHint = @"Double-tap to expand. Swipe up or down to resize the sheet";
+  self.accessibilityHint = kDefaultAccessibilityHint;
 
   UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap)];
   [self addGestureRecognizer:tap];
@@ -103,6 +109,12 @@ static const CGFloat kHitPaddingVertical = 10.0;
 
 #pragma mark - Public
 
+- (void)setAccessibilityOptions:(AccessibilityOptions *)accessibilityOptions {
+  _accessibilityOptions = accessibilityOptions;
+  self.accessibilityLabel = accessibilityOptions.grabberLabel ?: kDefaultAccessibilityLabel;
+  self.accessibilityHint = accessibilityOptions.grabberHint ?: kDefaultAccessibilityHint;
+}
+
 - (void)updateAccessibilityValueWithIndex:(NSInteger)index detentCount:(NSInteger)count {
   if (index < 0 || count <= 0) {
     self.accessibilityValue = nil;
@@ -110,9 +122,13 @@ static const CGFloat kHitPaddingVertical = 10.0;
   }
 
   if (index >= count - 1) {
-    self.accessibilityValue = @"Expanded";
+    self.accessibilityValue = _accessibilityOptions.expandedValue ?: @"Expanded";
   } else if (index == 0) {
-    self.accessibilityValue = @"Collapsed";
+    self.accessibilityValue = _accessibilityOptions.collapsedValue ?: @"Collapsed";
+  } else if (_accessibilityOptions.detentValue) {
+    NSString *value = [_accessibilityOptions.detentValue stringByReplacingOccurrencesOfString:@"{index}"
+                                                                                   withString:@(index + 1).stringValue];
+    self.accessibilityValue = [value stringByReplacingOccurrencesOfString:@"{count}" withString:@(count).stringValue];
   } else {
     self.accessibilityValue = [NSString stringWithFormat:@"Detent %ld of %ld", (long)(index + 1), (long)count];
   }

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -460,6 +460,7 @@ export class TrueSheet
       draggable = true,
       grabber = true,
       grabberOptions,
+      accessibilityOptions,
       dimmed = true,
       initialDetentIndex = -1,
       initialDetentAnimated = true,
@@ -518,6 +519,7 @@ export class TrueSheet
         cornerRadius={cornerRadius}
         grabber={grabber}
         grabberOptions={this.resolvedGrabberOptions}
+        accessibilityOptions={accessibilityOptions}
         dimmed={dimmed}
         dimmedDetentIndex={dimmedDetentIndex}
         initialDetentIndex={initialDetentIndex}

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -10,6 +10,7 @@ import {
 
 import type {
   TrueSheetProps,
+  AccessibilityOptions,
   TrueSheetMethods,
   TrueSheetStaticMethods,
   DragBeginEvent,
@@ -65,6 +66,17 @@ const absorbUnclaimedTouches = () => true;
 // Stop raw touch events from bubbling past the sheet to outside ancestors
 const stopTouchPropagation = (event: GestureResponderEvent) => event.stopPropagation();
 
+const DEFAULT_ACCESSIBILITY_OPTIONS: AccessibilityOptions = {
+  grabberLabel: Platform.select({ ios: 'Sheet Grabber', default: 'Drag handle' }),
+  grabberHint: 'Double-tap to expand. Swipe up or down to resize the sheet',
+  expandedValue: 'Expanded',
+  collapsedValue: 'Collapsed',
+  detentValue: 'Detent {index} of {count}',
+  expandActionLabel: 'Expand',
+  collapseActionLabel: 'Collapse',
+  paneTitle: 'Bottom sheet',
+};
+
 interface TrueSheetState {
   shouldRenderNativeView: boolean;
 }
@@ -79,6 +91,8 @@ export class TrueSheet
 
   private cachedGrabberOptions: TrueSheetProps['grabberOptions'] | undefined;
   private resolvedGrabberOptions: Record<string, unknown> | undefined;
+  private cachedAccessibilityOptions: TrueSheetProps['accessibilityOptions'] | undefined;
+  private resolvedAccessibilityOptions: AccessibilityOptions = DEFAULT_ACCESSIBILITY_OPTIONS;
   private backHandlerSubscription: NativeEventSubscription | null = null;
   private isPresented: boolean = false;
   private isSheetVisible: boolean = true;
@@ -507,6 +521,15 @@ export class TrueSheet
       };
     }
 
+    // Merge with defaults so native always receives the full set of strings
+    if (accessibilityOptions !== this.cachedAccessibilityOptions) {
+      this.cachedAccessibilityOptions = accessibilityOptions;
+      this.resolvedAccessibilityOptions = {
+        ...DEFAULT_ACCESSIBILITY_OPTIONS,
+        ...accessibilityOptions,
+      };
+    }
+
     return (
       <TrueSheetViewNativeComponent
         {...rest}
@@ -519,7 +542,7 @@ export class TrueSheet
         cornerRadius={cornerRadius}
         grabber={grabber}
         grabberOptions={this.resolvedGrabberOptions}
-        accessibilityOptions={accessibilityOptions}
+        accessibilityOptions={this.resolvedAccessibilityOptions}
         dimmed={dimmed}
         dimmedDetentIndex={dimmedDetentIndex}
         initialDetentIndex={initialDetentIndex}

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -10,7 +10,6 @@ import {
 
 import type {
   TrueSheetProps,
-  AccessibilityOptions,
   TrueSheetMethods,
   TrueSheetStaticMethods,
   DragBeginEvent,
@@ -66,17 +65,6 @@ const absorbUnclaimedTouches = () => true;
 // Stop raw touch events from bubbling past the sheet to outside ancestors
 const stopTouchPropagation = (event: GestureResponderEvent) => event.stopPropagation();
 
-const DEFAULT_ACCESSIBILITY_OPTIONS: AccessibilityOptions = {
-  grabberLabel: Platform.select({ ios: 'Sheet Grabber', default: 'Drag handle' }),
-  grabberHint: 'Double-tap to expand. Swipe up or down to resize the sheet',
-  expandedValue: 'Expanded',
-  collapsedValue: 'Collapsed',
-  detentValue: 'Detent {index} of {count}',
-  expandActionLabel: 'Expand',
-  collapseActionLabel: 'Collapse',
-  paneTitle: 'Bottom sheet',
-};
-
 interface TrueSheetState {
   shouldRenderNativeView: boolean;
 }
@@ -91,8 +79,6 @@ export class TrueSheet
 
   private cachedGrabberOptions: TrueSheetProps['grabberOptions'] | undefined;
   private resolvedGrabberOptions: Record<string, unknown> | undefined;
-  private cachedAccessibilityOptions: TrueSheetProps['accessibilityOptions'] | undefined;
-  private resolvedAccessibilityOptions: AccessibilityOptions = DEFAULT_ACCESSIBILITY_OPTIONS;
   private backHandlerSubscription: NativeEventSubscription | null = null;
   private isPresented: boolean = false;
   private isSheetVisible: boolean = true;
@@ -521,15 +507,6 @@ export class TrueSheet
       };
     }
 
-    // Merge with defaults so native always receives the full set of strings
-    if (accessibilityOptions !== this.cachedAccessibilityOptions) {
-      this.cachedAccessibilityOptions = accessibilityOptions;
-      this.resolvedAccessibilityOptions = {
-        ...DEFAULT_ACCESSIBILITY_OPTIONS,
-        ...accessibilityOptions,
-      };
-    }
-
     return (
       <TrueSheetViewNativeComponent
         {...rest}
@@ -542,7 +519,7 @@ export class TrueSheet
         cornerRadius={cornerRadius}
         grabber={grabber}
         grabberOptions={this.resolvedGrabberOptions}
-        accessibilityOptions={this.resolvedAccessibilityOptions}
+        accessibilityOptions={accessibilityOptions}
         dimmed={dimmed}
         dimmedDetentIndex={dimmedDetentIndex}
         initialDetentIndex={initialDetentIndex}

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -89,6 +89,71 @@ export interface GrabberOptions {
 }
 
 /**
+ * Options for customizing (e.g. localizing) the accessibility strings
+ * announced by screen readers.
+ *
+ * On iOS, the grabber strings only apply when `grabberOptions` is provided.
+ * Without it, iOS uses the system grabber which is already localized.
+ */
+export interface AccessibilityOptions {
+  /**
+   * The accessibility label of the grabber.
+   *
+   * @default iOS: 'Sheet Grabber', Android: 'Drag handle'
+   */
+  grabberLabel?: string;
+  /**
+   * The accessibility hint of the grabber.
+   *
+   * @platform ios
+   * @default 'Double-tap to expand. Swipe up or down to resize the sheet'
+   */
+  grabberHint?: string;
+  /**
+   * The value announced when the sheet is at the last detent.
+   *
+   * @default 'Expanded'
+   */
+  expandedValue?: string;
+  /**
+   * The value announced when the sheet is at the first detent.
+   *
+   * @default 'Collapsed'
+   */
+  collapsedValue?: string;
+  /**
+   * The value announced when the sheet is at an intermediate detent.
+   * Supports `{index}` and `{count}` placeholders.
+   *
+   * @default 'Detent {index} of {count}'
+   */
+  detentValue?: string;
+  /**
+   * The label of the expand accessibility action.
+   *
+   * @platform android
+   * @default 'Expand'
+   */
+  expandActionLabel?: string;
+  /**
+   * The label of the collapse accessibility action.
+   *
+   * @platform android
+   * @default 'Collapse'
+   */
+  collapseActionLabel?: string;
+  /**
+   * The title announced when the sheet appears.
+   * Sets the accessibility pane title on Android and the
+   * hidden dialog title on Web.
+   *
+   * @platform android, web
+   * @default Android: 'Bottom sheet', Web: 'Sheet'
+   */
+  paneTitle?: string;
+}
+
+/**
  * Scroll edge effect style for iOS 26+.
  * Controls the blur/gradient overlay applied to scroll view edges.
  *
@@ -353,6 +418,12 @@ export interface TrueSheetProps extends ViewProps {
    * Only applies when `grabber` is `true`.
    */
   grabberOptions?: GrabberOptions;
+
+  /**
+   * Options for customizing (e.g. localizing) the accessibility strings
+   * announced by screen readers.
+   */
+  accessibilityOptions?: AccessibilityOptions;
 
   /**
    * Controls the sheet presentation style on iPad and web (landscape/tablet).

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -69,6 +69,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     anchorOffset = DEFAULT_ANCHOR_OFFSET,
     grabber = true,
     grabberOptions,
+    accessibilityOptions,
     detents = [0.5, 1],
     dimmed = true,
     dimmedDetentIndex = 0,
@@ -999,7 +1000,9 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
               ) : undefined
             }
           >
-            <Drawer.Title style={visuallyHiddenStyle}>Sheet</Drawer.Title>
+            <Drawer.Title style={visuallyHiddenStyle}>
+              {accessibilityOptions?.paneTitle ?? 'Sheet'}
+            </Drawer.Title>
             {grabber && <Drawer.Handle style={handleStyle} />}
             {scrollable ? (
               // vaul wraps children in `[data-vaul-auto-size-wrapper]` (display:

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -17,14 +17,14 @@ type GrabberOptionsType = Readonly<{
 }>;
 
 type AccessibilityOptionsType = Readonly<{
-  grabberLabel?: string;
-  grabberHint?: string;
-  expandedValue?: string;
-  collapsedValue?: string;
-  detentValue?: string;
-  expandActionLabel?: string;
-  collapseActionLabel?: string;
-  paneTitle?: string;
+  grabberLabel?: WithDefault<string, 'Sheet Grabber'>;
+  grabberHint?: WithDefault<string, 'Double-tap to expand. Swipe up or down to resize the sheet'>;
+  expandedValue?: WithDefault<string, 'Expanded'>;
+  collapsedValue?: WithDefault<string, 'Collapsed'>;
+  detentValue?: WithDefault<string, 'Detent {index} of {count}'>;
+  expandActionLabel?: WithDefault<string, 'Expand'>;
+  collapseActionLabel?: WithDefault<string, 'Collapse'>;
+  paneTitle?: WithDefault<string, 'Bottom sheet'>;
 }>;
 
 type BlurOptionsType = Readonly<{

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -16,6 +16,17 @@ type GrabberOptionsType = Readonly<{
   adaptive?: WithDefault<boolean, true>;
 }>;
 
+type AccessibilityOptionsType = Readonly<{
+  grabberLabel?: string;
+  grabberHint?: string;
+  expandedValue?: string;
+  collapsedValue?: string;
+  detentValue?: string;
+  expandActionLabel?: string;
+  collapseActionLabel?: string;
+  paneTitle?: string;
+}>;
+
 type BlurOptionsType = Readonly<{
   intensity?: WithDefault<Double, -1>;
   interaction?: WithDefault<boolean, true>;
@@ -99,6 +110,7 @@ export interface NativeProps extends ViewProps {
   // Boolean properties - match defaults from TrueSheet.types.ts
   grabber?: WithDefault<boolean, true>;
   grabberOptions?: GrabberOptionsType;
+  accessibilityOptions?: AccessibilityOptionsType;
   dismissible?: WithDefault<boolean, true>;
   draggable?: WithDefault<boolean, true>;
   dimmed?: WithDefault<boolean, true>;

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -129,6 +129,7 @@ export type TrueSheetNavigationSheetProps = Pick<
   | 'draggable'
   | 'grabber'
   | 'grabberOptions'
+  | 'accessibilityOptions'
   | 'dimmed'
   | 'dimmedDetentIndex'
   | 'backgroundBlur'


### PR DESCRIPTION
## Summary

Adds a new `accessibilityOptions` prop so users can override (e.g. localize) the accessibility strings that were previously hardcoded in English:

- Grabber label — `'Sheet Grabber'` (iOS) / `'Drag handle'` (Android)
- Grabber hint (iOS) — `'Double-tap to expand. Swipe up or down to resize the sheet'`
- Detent state values — `'Expanded'`, `'Collapsed'`, `'Detent {index} of {count}'` (supports `{index}`/`{count}` placeholders)
- Expand/collapse accessibility action labels (Android) — `'Expand'` / `'Collapse'`
- `paneTitle` — accessibility pane title on Android (`'Bottom sheet'`) and hidden dialog title on Web (`'Sheet'`)

All fields are optional and fall back to the existing defaults.

```tsx
<TrueSheet
  accessibilityOptions={{
    grabberLabel: 'Poignée de déplacement',
    expandedValue: 'Développé',
    collapsedValue: 'Réduit',
    detentValue: 'Position {index} sur {count}',
    paneTitle: 'Feuille',
  }}
>
```

Note: on iOS, the grabber strings only apply when `grabberOptions` is provided (custom grabber). Without it, iOS uses the system grabber which is already localized by the system.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- `yarn typecheck`, `yarn lint`, ktlint, objclint pass
- All 44 unit tests pass

## Screenshots / Videos

N/A

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)