### PR TITLE
fix: restore sheet scrolling, and stop touch leak on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug fixes
 
+- **Android**: Touches on the sheet no longer fire the `onPress` of a `Pressable` outside it — the fix in [#767](https://github.com/lodev09/react-native-true-sheet/pull/767) never took effect here. A touch that hit no React child was dispatched to JS twice (once from `onInterceptTouchEvent`, once from `onTouchEvent`), and the second stream found the sheet already holding the responder, so React only asked its ancestors. ([#777](https://github.com/lodev09/react-native-true-sheet/pull/777) by [@lodev09](https://github.com/lodev09))
 - Scrollable sheets scroll again when their content isn't wrapped in a touchable — [#767](https://github.com/lodev09/react-native-true-sheet/pull/767) claimed unclaimed touches on the sheet container, making an ancestor of the `ScrollView` the JS responder, which blocks scrolling on both platforms. The touch handlers moved to the sheet's host view, which is never a native ancestor of the content. ([#777](https://github.com/lodev09/react-native-true-sheet/pull/777) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- Scrollable sheets scroll again when their content isn't wrapped in a touchable — [#767](https://github.com/lodev09/react-native-true-sheet/pull/767) claimed unclaimed touches on the sheet container, making an ancestor of the `ScrollView` the JS responder, which blocks scrolling on both platforms. The touch handlers moved to the sheet's host view, which is never a native ancestor of the content. ([#777](https://github.com/lodev09/react-native-true-sheet/pull/777) by [@lodev09](https://github.com/lodev09))
+
 ## 3.11.10
 
 ### 🎉 New features

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetFooterView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetFooterView.kt
@@ -12,6 +12,7 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.view.ReactViewGroup
 import com.lodev09.truesheet.core.TrueSheetCoordinatorLayout
+import com.lodev09.truesheet.utils.TouchEventDeduper
 
 /**
  * Delegate interface for footer view size changes and event dispatching
@@ -43,6 +44,7 @@ class TrueSheetFooterView(private val reactContext: ThemedReactContext) :
 
   private val jsTouchDispatcher = JSTouchDispatcher(this)
   private var jsPointerDispatcher: JSPointerDispatcher? = null
+  private val touchDeduper = TouchEventDeduper()
 
   init {
     jsPointerDispatcher = JSPointerDispatcher(this)
@@ -62,7 +64,9 @@ class TrueSheetFooterView(private val reactContext: ThemedReactContext) :
 
   override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
     eventDispatcher?.let { dispatcher ->
-      jsTouchDispatcher.handleTouchEvent(event, dispatcher, reactContext)
+      if (touchDeduper.shouldDispatch(event)) {
+        jsTouchDispatcher.handleTouchEvent(event, dispatcher, reactContext)
+      }
       jsPointerDispatcher?.handleMotionEvent(event, dispatcher, true)
     }
     return super.onInterceptTouchEvent(event)
@@ -80,7 +84,9 @@ class TrueSheetFooterView(private val reactContext: ThemedReactContext) :
     }
 
     eventDispatcher?.let { dispatcher ->
-      jsTouchDispatcher.handleTouchEvent(event, dispatcher, reactContext)
+      if (touchDeduper.shouldDispatch(event)) {
+        jsTouchDispatcher.handleTouchEvent(event, dispatcher, reactContext)
+      }
       jsPointerDispatcher?.handleMotionEvent(event, dispatcher, false)
     }
     super.onTouchEvent(event)

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -39,6 +39,7 @@ import com.lodev09.truesheet.core.TrueSheetKeyboardObserverDelegate
 import com.lodev09.truesheet.core.TrueSheetStackManager
 import com.lodev09.truesheet.utils.KeyboardUtils
 import com.lodev09.truesheet.utils.ScreenUtils
+import com.lodev09.truesheet.utils.TouchEventDeduper
 
 // =============================================================================
 // MARK: - Data Types & Delegate Protocol
@@ -198,6 +199,8 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   // ACTION_DOWN so subsequent MOVE events keep routing to the footer even if
   // the finger drifts outside the footer's rect mid-gesture.
   private var footerOwnsTouchStream = false
+
+  private val touchDeduper = TouchEventDeduper()
 
   private val eventDispatcher
     get() = delegate?.eventDispatcher
@@ -1354,7 +1357,9 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
     eventDispatcher?.let {
-      jsTouchDispatcher.handleTouchEvent(event, it, reactContext)
+      if (touchDeduper.shouldDispatch(event)) {
+        jsTouchDispatcher.handleTouchEvent(event, it, reactContext)
+      }
       jsPointerDispatcher.handleMotionEvent(event, it, true)
     }
     return super.onInterceptTouchEvent(event)
@@ -1368,7 +1373,9 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   override fun onTouchEvent(event: MotionEvent): Boolean {
     eventDispatcher?.let {
-      jsTouchDispatcher.handleTouchEvent(event, it, reactContext)
+      if (touchDeduper.shouldDispatch(event)) {
+        jsTouchDispatcher.handleTouchEvent(event, it, reactContext)
+      }
       jsPointerDispatcher.handleMotionEvent(event, it, false)
     }
     super.onTouchEvent(event)

--- a/android/src/main/java/com/lodev09/truesheet/utils/TouchEventDeduper.kt
+++ b/android/src/main/java/com/lodev09/truesheet/utils/TouchEventDeduper.kt
@@ -1,0 +1,31 @@
+package com.lodev09.truesheet.utils
+
+import android.view.MotionEvent
+
+/**
+ * Guards a nested RootView against dispatching the same [MotionEvent] to JS twice.
+ *
+ * An event that no child consumes reaches both `onInterceptTouchEvent` and `onTouchEvent`,
+ * so dispatching from both starts a second JS touch stream for the same gesture.
+ *
+ * A plain root can live with that, but the sheet's roots are nested: touches that hit no
+ * React child resolve to the root's own tag, and the second stream then finds that view
+ * already holding the responder, so React only asks its ancestors - handing the touch to
+ * touchables outside the sheet.
+ */
+internal class TouchEventDeduper {
+  private var downTime = Long.MIN_VALUE
+  private var eventTime = Long.MIN_VALUE
+  private var action = -1
+
+  fun shouldDispatch(event: MotionEvent): Boolean {
+    if (event.downTime == downTime && event.eventTime == eventTime && event.action == action) {
+      return false
+    }
+
+    downTime = event.downTime
+    eventTime = event.eventTime
+    action = event.action
+    return true
+  }
+}

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -550,15 +550,20 @@ export class TrueSheet
         onWillBlur={this.onWillBlur}
         onDidBlur={this.onDidBlur}
         onVisibilityChange={this.onVisibilityChange}
+        // These must stay on this host view, not on the container. The container is
+        // reparented into the native sheet, so this view is never a native ancestor of
+        // the sheet content. Claiming the responder here stops the negotiation at the
+        // sheet boundary without making an ancestor of the content the JS responder,
+        // which would block scrolling inside the sheet.
+        onStartShouldSetResponder={absorbUnclaimedTouches}
+        onTouchStart={stopTouchPropagation}
+        onTouchMove={stopTouchPropagation}
+        onTouchEnd={stopTouchPropagation}
+        onTouchCancel={stopTouchPropagation}
       >
         {this.state.shouldRenderNativeView && (
           <TrueSheetContainerViewNativeComponent
             style={scrollable ? styles.scrollableContainer : undefined}
-            onStartShouldSetResponder={absorbUnclaimedTouches}
-            onTouchStart={stopTouchPropagation}
-            onTouchMove={stopTouchPropagation}
-            onTouchEnd={stopTouchPropagation}
-            onTouchCancel={stopTouchPropagation}
           >
             {header && (
               <TrueSheetHeaderViewNativeComponent style={[styles.header, headerStyle]}>


### PR DESCRIPTION
## Summary

Fixes #774, and makes the #767 touch-leak fix actually work on Android.

### Scroll regression (#774)

With `scrollable`, a `ScrollView` whose items are plain `View`s could no longer be scrolled — only items wrapped in `Pressable` responded.

#767 put `onStartShouldSetResponder` on the sheet **container**, making an ancestor of the `ScrollView` the JS responder. That blocks scrolling:

- **iOS** — `RCTScrollViewComponentView._shouldDisableScrollInteraction` walks ancestors for `isJSResponder`; when found, `touchesShouldCancelInContentView:` returns `NO` and the pan never takes over.
- **Android** — `JSResponderHandler.onInterceptTouchEvent` returns `view.id == currentJSResponder`, so the responder view intercepts the gesture.

Touching a `Pressable` worked because it won the responder first (bubble runs deepest-first), so the container never claimed it.

The handlers move to the **host view**. The container is reparented into the native sheet on mount, so the host view is never a native ancestor of the sheet content — the responder negotiation still ends at the sheet boundary, but native gestures are untouched.

### Touch leak on Android (#763, never fixed there)

Tapping the sheet still fired the parent `Pressable`'s `onPress`. Logging the repro showed the sheet claiming the responder correctly, and *then* a second `pointerDown`/press arriving on the parent.

Cause: an event that no React child consumes reaches both `onInterceptTouchEvent` and `onTouchEvent`, and the sheet's roots dispatched to `jsTouchDispatcher` from both — two JS touch streams for one gesture. Such touches resolve to the root's own tag (the host view), so in the second stream React sees that node already holding the responder and, per the lowest-common-ancestor rule, asks only its **ancestors** — handing the touch to the `Pressable` outside the sheet. It also produced the `Got DOWN touch before receiving UP or CANCEL from last gesture` warnings.

`TouchEventDeduper` now guards both nested roots (`TrueSheetViewController`, `TrueSheetFooterView`) so each `MotionEvent` reaches JS once. RN's own `ReactRootView` dispatches from both callbacks too, but a top-level root has no React ancestors to leak to.

The two fixes depend on each other: taps that hit no React child resolve to the host view's tag, so a container-level claim never runs for them.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

1. `scrollable` sheet with plain `View` items — scrolling works
2. Same with `Pressable` items — scrolling and taps still work
3. Example `ScrollViewSheet`: tap an item to open the nested sheet, then tap the nested sheet's surface and its empty padding — the item's `onPress` does NOT fire
4. Pressables inside the sheet and inside the footer still work
5. Sheet dragging, refresh control, buttons

## Screenshots / Videos

N/A

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)