### PR TITLE
fix(ios): keep opaque backgroundColor exact on iOS 26.1+ over full-screen presenters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Opaque `backgroundColor` now renders exactly on iOS 26.1+ when the sheet is presented over a full-screen presenter (e.g. a `fullScreenModal` route or RN `Modal`) — `UIColorEffect` tints the liquid glass rather than replacing it, shifting dark low-chroma colors, so the controller view is now painted as well. ([#779](https://github.com/lodev09/react-native-true-sheet/pull/779) by [@lodev09](https://github.com/lodev09))
 - **Android**: Touches on the sheet no longer fire the `onPress` of a `Pressable` outside it — the fix in [#767](https://github.com/lodev09/react-native-true-sheet/pull/767) never took effect here. A touch that hit no React child was dispatched to JS twice (once from `onInterceptTouchEvent`, once from `onTouchEvent`), and the second stream found the sheet already holding the responder, so React only asked its ancestors. ([#777](https://github.com/lodev09/react-native-true-sheet/pull/777) by [@lodev09](https://github.com/lodev09))
 - Scrollable sheets scroll again when their content isn't wrapped in a touchable — [#767](https://github.com/lodev09/react-native-true-sheet/pull/767) claimed unclaimed touches on the sheet container, making an ancestor of the `ScrollView` the JS responder, which blocks scrolling on both platforms. The touch handlers moved to the sheet's host view, which is never a native ancestor of the content. ([#777](https://github.com/lodev09/react-native-true-sheet/pull/777) by [@lodev09](https://github.com/lodev09))
 

--- a/example/shared/src/screens/ModalScreen.tsx
+++ b/example/shared/src/screens/ModalScreen.tsx
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect } from 'react';
 import { Modal, StyleSheet, Text, View } from 'react-native';
 import { TrueSheet, TrueSheetProvider } from '@lodev09/react-native-true-sheet';
 
-import { BLUE, DARK_GRAY, GAP, LIGHT_GRAY, SPACING } from '../utils';
+import { BLUE, DARK, DARK_GRAY, GAP, LIGHT_GRAY, SPACING } from '../utils';
 import { Button, Input, Spacer } from '../components';
 import {
   PromptSheet,
@@ -56,7 +56,7 @@ export const ModalScreen = ({ onNavigateToTest, onDismiss }: ModalScreenProps) =
         <Spacer />
         <Button text="Open RN Modal" onPress={() => setModalVisible(true)} />
 
-        <BasicSheet dimmedDetentIndex={1} ref={basicSheet} />
+        <BasicSheet dimmedDetentIndex={1} backgroundColor={DARK} ref={basicSheet} />
         <BlankSheet dimmed={false} ref={blankSheet} />
         <PromptSheet dimmed={false} ref={promptSheet} />
         <FlatListSheet ref={flatlistSheet} />
@@ -84,7 +84,7 @@ export const ModalScreen = ({ onNavigateToTest, onDismiss }: ModalScreenProps) =
               <Button text="FlatList Sheet" onPress={() => modalFlatlistSheet.current?.present()} />
               <Spacer />
 
-              <BasicSheet ref={modalBasicSheet} />
+              <BasicSheet backgroundColor={DARK} ref={modalBasicSheet} />
               <PromptSheet dimmed={false} ref={modalPromptSheet} />
               <FlatListSheet ref={modalFlatlistSheet} />
               <ScrollViewSheet ref={modalScrollViewSheet} />

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -1087,11 +1087,13 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
       } else {
         self.sheet.backgroundEffect = nil;
       }
-      return;
     }
   }
 #endif
 
+  // UIColorEffect tints the glass rather than replacing it. Over a full-screen
+  // presenter this shifts dark, low-chroma colors, so paint the view as well
+  // to keep the background exact.
   self.view.backgroundColor = self.backgroundColor;
 }
 

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -1082,6 +1082,11 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     if (!self.isDesignCompatibilityMode) {
       if (self.backgroundColor) {
         self.sheet.backgroundEffect = [UIColorEffect effectWithColor:self.backgroundColor];
+        // Translucent colors blend with the glass through the effect alone;
+        // painting the view too would apply them twice.
+        if (CGColorGetAlpha(self.backgroundColor.CGColor) < 1) {
+          return;
+        }
       } else if (hasBlur) {
         self.sheet.backgroundEffect = [UIColorEffect effectWithColor:[UIColor clearColor]];
       } else {

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -1080,14 +1080,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 #if RNTS_IPHONE_OS_VERSION_AVAILABLE(26_1) && !TARGET_OS_MACCATALYST
   if (@available(iOS 26.1, *)) {
     if (!self.isDesignCompatibilityMode) {
-      if (self.backgroundColor) {
-        self.sheet.backgroundEffect = [UIColorEffect effectWithColor:self.backgroundColor];
-        // Translucent colors blend with the glass through the effect alone;
-        // painting the view too would apply them twice.
-        if (CGColorGetAlpha(self.backgroundColor.CGColor) < 1) {
-          return;
-        }
-      } else if (hasBlur) {
+      if (self.backgroundColor || hasBlur) {
         self.sheet.backgroundEffect = [UIColorEffect effectWithColor:[UIColor clearColor]];
       } else {
         self.sheet.backgroundEffect = nil;
@@ -1096,9 +1089,6 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   }
 #endif
 
-  // UIColorEffect tints the glass rather than replacing it. Over a full-screen
-  // presenter this shifts dark, low-chroma colors, so paint the view as well
-  // to keep the background exact.
   self.view.backgroundColor = self.backgroundColor;
 }
 


### PR DESCRIPTION
## Summary

On iOS 26.1+ (Liquid Glass), `backgroundColor` is applied as a `UIColorEffect` on `sheetPresentationController.backgroundEffect`. `UIColorEffect` tints the glass rather than replacing it — when the sheet is presented from a view controller that is itself presented full-screen (e.g. a native-stack `fullScreenModal` route or an RN `Modal`), dark low-chroma colors drift (e.g. `#1A1A1A` renders as olive `rgb(19, 23, 15)`).

Fix: remove the early `return` in the iOS 26.1 branch of `setupBackground` so it falls through to the existing `self.view.backgroundColor` assignment. Painting the view keeps the background exact everywhere.

Also sets `backgroundColor` on the `BasicSheet` instances in the example's `ModalScreen` so the fullScreenModal context exercises an opaque background.

Fixes #778

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Presented a sheet with `backgroundColor="#1A1A2E"` from the map screen (baseline) and from a full-screen modal on an iOS 26.1+ simulator in dark mode — both render the exact color after the fix; before, the modal one rendered green-shifted. Verified sheets without `backgroundColor` (default glass, blur) are unaffected.

## Screenshots / Videos

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)