### PR TITLE
refactor: measure auto detent natural height in shadow node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - The keyboard-driven scroll inset now accounts for a floating footer's height — focused inputs no longer hide behind it. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))
+- Auto detents now measure scrollable content in the shared layout tree, correctly sizing explicit-height and deeply nested scrollables on iOS and Android. ([#783](https://github.com/lodev09/react-native-true-sheet/pull/783) by [@lodev09](https://github.com/lodev09))
 
 ### 💥 Breaking changes
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
@@ -118,6 +118,9 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
         child.hasAutoDetent = hasAutoDetent
         contentView = child
 
+        // State lands before the view is attached, so pull the current value
+        contentHeight = child.naturalHeight
+
         // Children mount bottom-up, so the content subtree is complete here.
         // Late-mounted peek views attach themselves instead (see TrueSheetPeekView).
         findPeekView(child)?.let { attachPeekView(it) }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -47,40 +47,28 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
   var delegate: TrueSheetContentViewDelegate? = null
   var stateWrapper: StateWrapper? = null
 
-  private var lastWidth = 0
-  private var lastHeight = 0
-
   private var pinnedScrollView: ViewGroup? = null
-  private var observedScrollChild: View? = null
   private var originalScrollViewPaddingBottom: Int = 0
   private var bottomInset: Int = 0
   private var scrollableBounded = false
-  private var isReportPending = false
-
-  // Content growth is invisible to layout once the viewport is bounded, so track
-  // the scroll content size directly to keep the auto detent height in sync.
-  private val scrollChildLayoutListener =
-    View.OnLayoutChangeListener { _, _, top, _, bottom, _, oldTop, _, oldBottom ->
-      if (bottom - top != oldBottom - oldTop) {
-        reportSizeIfChanged()
-      }
-    }
 
   /**
-   * Content height with the pinned ScrollView's viewport replaced by its content
-   * size — the height the content wants regardless of container bounds.
-   * Falls back to the view height when no ScrollView is pinned.
+   * Content height measured unconstrained by the shadow node — the height the
+   * content wants regardless of container bounds (see
+   * TrueSheetContentViewShadowNode). Falls back to the view height before the
+   * first state update.
    */
   val naturalHeight: Int
-    get() {
-      var naturalHeight = height
-      pinnedScrollView?.let { scrollView ->
-        scrollView.getChildAt(0)?.let { child ->
-          naturalHeight += child.height - scrollView.height
-        }
-      }
-      return maxOf(0, naturalHeight)
-    }
+    get() = if (lastNaturalHeight > 0) lastNaturalHeight else height
+
+  private var lastNaturalHeight = 0
+
+  fun updateNaturalHeight(heightDp: Double) {
+    val heightPx = heightDp.toFloat().dpToPx().toInt()
+    if (heightPx == lastNaturalHeight) return
+    lastNaturalHeight = heightPx
+    delegate?.contentViewDidChangeSize(width, heightPx)
+  }
 
   private var keyboardScrollOffset: Float = 0f
   private var keyboardObserver: TrueSheetKeyboardObserver? = null
@@ -121,39 +109,6 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
   private fun checkScrollViewChanged() {
     if (pinnedScrollView == null || pinnedScrollView?.isDescendantOf(this) == false) {
       delegate?.contentViewScrollViewDidChange()
-    }
-  }
-
-  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
-    super.onSizeChanged(w, h, oldw, oldh)
-    reportSizeIfChanged()
-  }
-
-  private fun reportSizeIfChanged() {
-    // naturalHeight mixes sizes from different views; mid-layout they're
-    // momentarily inconsistent (parent resizes before its children), which
-    // feeds back into the auto detent and oscillates. Coalesce to the next
-    // frame so sizes are settled before measuring.
-    if (pinnedScrollView != null) {
-      if (isReportPending) return
-      isReportPending = true
-
-      post {
-        isReportPending = false
-        reportSizeNow()
-      }
-      return
-    }
-
-    reportSizeNow()
-  }
-
-  private fun reportSizeNow() {
-    val newHeight = naturalHeight
-    if (width != lastWidth || newHeight != lastHeight) {
-      lastWidth = width
-      lastHeight = newHeight
-      delegate?.contentViewDidChangeSize(width, newHeight)
     }
   }
 
@@ -200,12 +155,7 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
         }
       }
 
-      scrollView.getChildAt(0)?.let { child ->
-        observedScrollChild = child
-        child.addOnLayoutChangeListener(scrollChildLayoutListener)
-      }
       setScrollableBounded(hasAutoDetent)
-      reportSizeIfChanged()
     }
 
     this.bottomInset = bottomInset
@@ -235,13 +185,10 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     pinnedScrollView?.isNestedScrollingEnabled = false
     (pinnedScrollView?.parent as? SwipeRefreshLayout)?.isNestedScrollingEnabled = true
     setScrollViewPaddingBottom(originalScrollViewPaddingBottom)
-    observedScrollChild?.removeOnLayoutChangeListener(scrollChildLayoutListener)
-    observedScrollChild = null
     setScrollableBounded(false)
     pinnedScrollView = null
     originalScrollViewPaddingBottom = 0
     bottomInset = 0
-    reportSizeIfChanged()
   }
 
   fun findScrollView(): ViewGroup? {

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentViewManager.kt
@@ -21,6 +21,11 @@ class TrueSheetContentViewManager : ViewGroupManager<TrueSheetContentView>() {
 
   override fun updateState(view: TrueSheetContentView, props: ReactStylesDiffMap?, stateWrapper: StateWrapper?): Any? {
     view.stateWrapper = stateWrapper
+    stateWrapper?.stateData?.let { data ->
+      if (data.hasKey("naturalHeight")) {
+        view.updateNaturalHeight(data.getDouble("naturalHeight"))
+      }
+    }
     return null
   }
 

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.cpp
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.cpp
@@ -1,12 +1,20 @@
 #include "TrueSheetContentViewShadowNode.h"
 
+#include <limits>
+
 #include <react/renderer/components/view/conversions.h>
+#include <react/renderer/core/LayoutConstraints.h>
+#include <react/renderer/core/LayoutContext.h>
 
 namespace facebook::react {
 
 using namespace yoga;
 
 extern const char TrueSheetContentViewComponentName[] = "TrueSheetContentView";
+
+// measure() lays out a clone of this node, which re-enters layout() on the
+// clone — guard so the measurement pass doesn't measure again recursively.
+static thread_local bool gIsMeasuringNaturalHeight = false;
 
 void TrueSheetContentViewShadowNode::adjustLayoutWithState() {
   ensureUnsealed();
@@ -20,9 +28,9 @@ void TrueSheetContentViewShadowNode::adjustLayoutWithState() {
   // When a ScrollView is pinned under an auto detent, fill the container so
   // descendant flex layouts (flex:1 wrappers, the ScrollView itself) resolve
   // against a definite height and the viewport is bounded — natural layout is
-  // circular there since the sheet height derives from the ScrollView's content
-  // size instead (see ContentView's naturalHeight on each platform). For fixed
-  // detents, content lays out naturally like a regular view.
+  // circular there since the sheet height derives from the content's natural
+  // height instead (see updateNaturalHeightIfNeeded). For fixed detents,
+  // content lays out naturally like a regular view.
   auto flexGrow = stateData.scrollableBounded
       ? FloatOptional{1.0f}
       : props.yogaStyle.flexGrow();
@@ -37,6 +45,44 @@ void TrueSheetContentViewShadowNode::adjustLayoutWithState() {
     adjustedStyle.setFlexShrink(flexShrink);
     yogaNode_.setStyle(adjustedStyle);
     yogaNode_.setDirty(true);
+  }
+}
+
+void TrueSheetContentViewShadowNode::layout(LayoutContext layoutContext) {
+  ConcreteViewShadowNode::layout(layoutContext);
+  updateNaturalHeightIfNeeded(layoutContext);
+}
+
+// The natural height is the height the content wants when unbounded — the
+// source for the auto detent. Once the container bounds the content
+// (scrollableBounded), the committed layout no longer reflects it, so lay out
+// a clone of the subtree with an unconstrained height. Yoga respects the
+// user's styles: an explicit-height ScrollView keeps its height while a
+// flexible one expands to its content — no ScrollView discovery involved.
+void TrueSheetContentViewShadowNode::updateNaturalHeightIfNeeded(
+    const LayoutContext &layoutContext) {
+  if (gIsMeasuringNaturalHeight) {
+    return;
+  }
+
+  auto stateData = getStateData();
+  auto size = getLayoutMetrics().frame.size;
+
+  Float naturalHeight = size.height;
+  if (stateData.scrollableBounded) {
+    auto constraints = LayoutConstraints{};
+    constraints.minimumSize = {size.width, 0};
+    constraints.maximumSize = {size.width, std::numeric_limits<Float>::infinity()};
+    constraints.layoutDirection = getLayoutMetrics().layoutDirection;
+
+    gIsMeasuringNaturalHeight = true;
+    naturalHeight = measure(layoutContext, constraints).height;
+    gIsMeasuringNaturalHeight = false;
+  }
+
+  if (stateData.naturalHeight != naturalHeight) {
+    stateData.naturalHeight = naturalHeight;
+    setStateData(std::move(stateData));
   }
 }
 

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.h
@@ -23,6 +23,13 @@ class JSI_EXPORT TrueSheetContentViewShadowNode final
 
  public:
   void adjustLayoutWithState();
+
+#pragma mark - LayoutableShadowNode
+
+  void layout(LayoutContext layoutContext) override;
+
+ private:
+  void updateNaturalHeightIfNeeded(const LayoutContext &layoutContext);
 };
 
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.cpp
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.cpp
@@ -4,7 +4,8 @@ namespace facebook::react {
 
 #ifdef ANDROID
 folly::dynamic TrueSheetContentViewState::getDynamic() const {
-  return folly::dynamic::object("scrollableBounded", scrollableBounded);
+  return folly::dynamic::object("scrollableBounded", scrollableBounded)(
+      "naturalHeight", naturalHeight);
 }
 #endif
 

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <react/renderer/graphics/Float.h>
+
 #ifdef ANDROID
 #include <folly/dynamic.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
@@ -10,8 +12,10 @@ namespace facebook::react {
 
 /*
  * State for <TrueSheetContentView> component.
- * Set from native when a ScrollView is pinned so the shadow node bounds the
- * content to the container via flexShrink (see TrueSheetContentViewShadowNode).
+ * `scrollableBounded` is set from native when a ScrollView is pinned so the
+ * shadow node bounds the content to the container via flexShrink.
+ * `naturalHeight` is measured by the shadow node during layout — the height
+ * the content wants when unbounded (see TrueSheetContentViewShadowNode).
  */
 class TrueSheetContentViewState final {
  public:
@@ -21,10 +25,14 @@ class TrueSheetContentViewState final {
   TrueSheetContentViewState(
       TrueSheetContentViewState const &previousState,
       folly::dynamic data)
-      : scrollableBounded(data["scrollableBounded"].getBool()) {}
+      : scrollableBounded(
+            data.getDefault("scrollableBounded", previousState.scrollableBounded)
+                .getBool()),
+        naturalHeight(previousState.naturalHeight) {}
 #endif
 
   bool scrollableBounded{false};
+  Float naturalHeight{0};
 
 #ifdef ANDROID
   folly::dynamic getDynamic() const;

--- a/example/bare/ios/Podfile.lock
+++ b/example/bare/ios/Podfile.lock
@@ -2110,7 +2110,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNTrueSheet (4.0.0-beta.2):
+  - RNTrueSheet (4.0.0-beta.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2546,7 +2546,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 92172e79df6e88e0e93b6341f9dcd8b5a02746ba
   RNReanimated: a9bf68fb5f19ce1c363b7d1413dcf8ee323185b8
   RNScreens: 991cc417cd396602a6cf59a42139e5a9d91462a9
-  RNTrueSheet: b10794540cf98d6f705d8bc2d047c1f1f735b66f
+  RNTrueSheet: 8bb9b9dd413336b6b9980195b118f85bf0f9d0fd
   RNWorklets: ae7f2b95d75b903387e6359583f2fd67bc9a93ff
   Yoga: fe50ab299e578f397fef753cf309c6703a4db29b
 

--- a/example/shared/src/components/sheets/FlatListSheet.tsx
+++ b/example/shared/src/components/sheets/FlatListSheet.tsx
@@ -36,28 +36,26 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
       footerOptions={{ position: 'absolute' }}
       {...props}
     >
-      <View style={styles.wrapper}>
-        <FlatList
-          ref={scrollRef}
-          data={times(itemCount, (i) => i)}
-          contentContainerStyle={styles.content}
-          indicatorStyle="black"
-          ItemSeparatorComponent={Spacer}
-          renderItem={({ item }) => <DemoContent color={DARK_GRAY} text={`Item #${item}`} />}
-          ListFooterComponent={
-            <>
-              <Spacer />
-              <ButtonGroup>
-                <Button text="Add Item" onPress={() => setItemCount((count) => count + 1)} />
-                <Button
-                  text="Remove Item"
-                  onPress={() => setItemCount((count) => Math.max(0, count - 1))}
-                />
-              </ButtonGroup>
-            </>
-          }
-        />
-      </View>
+      <FlatList
+        ref={scrollRef}
+        data={times(itemCount, (i) => i)}
+        contentContainerStyle={styles.content}
+        indicatorStyle="black"
+        ItemSeparatorComponent={Spacer}
+        renderItem={({ item }) => <DemoContent color={DARK_GRAY} text={`Item #${item}`} />}
+        ListFooterComponent={
+          <>
+            <Spacer />
+            <ButtonGroup>
+              <Button text="Add Item" onPress={() => setItemCount((count) => count + 1)} />
+              <Button
+                text="Remove Item"
+                onPress={() => setItemCount((count) => Math.max(0, count - 1))}
+              />
+            </ButtonGroup>
+          </>
+        }
+      />
       <TrueSheet detents={[0.3]} ref={testRef}>
         <DemoContent />
       </TrueSheet>
@@ -68,9 +66,6 @@ export const FlatListSheet = forwardRef<TrueSheet, FlatListSheetProps>((props, r
 FlatListSheet.displayName = 'FlatListSheet';
 
 const styles = StyleSheet.create({
-  wrapper: {
-    flex: 1,
-  },
   footer: {
     backgroundColor: Platform.select({
       default: DARK_GRAY,

--- a/ios/TrueSheetContentView.h
+++ b/ios/TrueSheetContentView.h
@@ -48,9 +48,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL hasAutoDetent;
 
 /**
- * Content height with the pinned ScrollView's viewport replaced by its content
- * size — the height the content wants regardless of container bounds.
- * Falls back to the frame height when no ScrollView is pinned.
+ * Content height measured unconstrained by the shadow node — the height the
+ * content wants regardless of container bounds (see
+ * TrueSheetContentViewShadowNode). Falls back to the frame height before the
+ * first state update.
  */
 @property (nonatomic, readonly) CGFloat naturalHeight;
 

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -24,18 +24,14 @@
 
 using namespace facebook::react;
 
-static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
-
 @implementation TrueSheetContentView {
   TrueSheetContentViewShadowNode::ConcreteState::Shared _state;
   RCTScrollViewComponentView *_pinnedScrollView;
-  UIScrollView *_observedScrollView;
-  CGSize _lastSize;
+  CGFloat _lastReportedNaturalHeight;
   CGFloat _bottomInset;
   CGFloat _originalIndicatorBottomInset;
   BOOL _observingTextChanges;
   BOOL _scrollableBounded;
-  BOOL _isReportPending;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider {
@@ -52,11 +48,16 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
 
 - (void)dealloc {
   [self stopObservingTextChanges];
-  [self unobserveScrollViewContentSize];
 }
 
 - (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState {
   _state = std::static_pointer_cast<TrueSheetContentViewShadowNode::ConcreteState const>(state);
+
+  CGFloat naturalHeight = _state->getData().naturalHeight;
+  if (naturalHeight != _lastReportedNaturalHeight) {
+    _lastReportedNaturalHeight = naturalHeight;
+    [self.delegate contentViewDidChangeSize:CGSizeMake(self.frame.size.width, naturalHeight)];
+  }
 }
 
 // Tells the shadow node to fill the container (flexGrow/flexShrink) so the
@@ -69,7 +70,7 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
   _scrollableBounded = bounded;
 
   if (_state) {
-    TrueSheetContentViewState newState;
+    auto newState = _state->getData();
     newState.scrollableBounded = bounded;
     _state->updateState(std::move(newState));
   }
@@ -111,58 +112,25 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
 #pragma mark - Layout
 
 - (CGFloat)naturalHeight {
-  CGFloat height = self.frame.size.height;
-  if (_pinnedScrollView) {
-    height += _pinnedScrollView.scrollView.contentSize.height - _pinnedScrollView.frame.size.height;
-  }
-  return MAX(0, height);
-}
-
-- (void)reportSizeIfChanged {
-  // A deep ScrollView unmount doesn't pass through this view's mount hooks —
-  // detect the stale pin here so it (and its contentSize observation) is
-  // released instead of lingering until the next explicit setup or recycle.
-  if (_pinnedScrollView && ![_pinnedScrollView isDescendantOfView:self]) {
-    [self.delegate contentViewScrollViewDidChange];
-  }
-
-  // naturalHeight mixes frames from different views; mid-transaction they're
-  // momentarily inconsistent (parent updates before the ScrollView), which
-  // feeds back into the auto detent and oscillates. Coalesce to the next
-  // main-queue tick so frames are settled before measuring.
-  if (_pinnedScrollView) {
-    if (_isReportPending) {
-      return;
+  if (_state) {
+    CGFloat height = _state->getData().naturalHeight;
+    if (height > 0) {
+      return height;
     }
-    _isReportPending = YES;
-
-    __weak __typeof(self) weakSelf = self;
-    dispatch_async(dispatch_get_main_queue(), ^{
-      __typeof(self) strongSelf = weakSelf;
-      if (!strongSelf) {
-        return;
-      }
-      strongSelf->_isReportPending = NO;
-      [strongSelf reportSizeNow];
-    });
-    return;
   }
-
-  [self reportSizeNow];
-}
-
-- (void)reportSizeNow {
-  CGSize newSize = CGSizeMake(self.frame.size.width, self.naturalHeight);
-  if (!CGSizeEqualToSize(newSize, _lastSize)) {
-    _lastSize = newSize;
-    [self.delegate contentViewDidChangeSize:newSize];
-  }
+  return self.frame.size.height;
 }
 
 - (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
            oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics {
   [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
-  [self reportSizeIfChanged];
+
+  // A deep ScrollView unmount doesn't pass through this view's mount hooks —
+  // detect the stale pin here so it's released instead of lingering until the
+  // next explicit setup or recycle.
+  if (_pinnedScrollView && ![_pinnedScrollView isDescendantOfView:self]) {
+    [self.delegate contentViewScrollViewDidChange];
+  }
 }
 
 #pragma mark - Child Mounting
@@ -202,12 +170,10 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
   if (_pinnedScrollView) {
     [self setScrollViewContentInset:0 indicatorInset:_originalIndicatorBottomInset];
   }
-  [self unobserveScrollViewContentSize];
   [self setScrollableBounded:NO];
   _pinnedScrollView = nil;
   _bottomInset = 0;
   _originalIndicatorBottomInset = 0;
-  [self reportSizeIfChanged];
 }
 
 - (void)setupScrollableWithBottomInset:(CGFloat)bottomInset {
@@ -231,9 +197,7 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
     _originalIndicatorBottomInset = scrollView.scrollView.verticalScrollIndicatorInsets.bottom;
     _pinnedScrollView = scrollView;
 
-    [self observeScrollViewContentSize];
     [self setScrollableBounded:_hasAutoDetent];
-    [self reportSizeIfChanged];
   }
 
   _bottomInset = bottomInset;
@@ -260,39 +224,6 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
     return height + [self.footerView keyboardOcclusionHeight];
   }
   return MAX(0, height - self.footerView.frame.size.height);
-}
-
-// Content growth is invisible to layout once the viewport is bounded, so track
-// the scroll content size directly to keep the auto detent height in sync.
-- (void)observeScrollViewContentSize {
-  UIScrollView *scrollView = _pinnedScrollView.scrollView;
-  if (_observedScrollView == scrollView) {
-    return;
-  }
-  [self unobserveScrollViewContentSize];
-  _observedScrollView = scrollView;
-  [scrollView addObserver:self
-               forKeyPath:@"contentSize"
-                  options:NSKeyValueObservingOptionNew
-                  context:TrueSheetContentSizeContext];
-}
-
-- (void)unobserveScrollViewContentSize {
-  if (_observedScrollView) {
-    [_observedScrollView removeObserver:self forKeyPath:@"contentSize" context:TrueSheetContentSizeContext];
-    _observedScrollView = nil;
-  }
-}
-
-- (void)observeValueForKeyPath:(NSString *)keyPath
-                      ofObject:(id)object
-                        change:(NSDictionary *)change
-                       context:(void *)context {
-  if (context == TrueSheetContentSizeContext) {
-    [self reportSizeIfChanged];
-    return;
-  }
-  [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
 }
 
 - (RCTScrollViewComponentView *)findScrollView {
@@ -472,7 +403,7 @@ static void *TrueSheetContentSizeContext = &TrueSheetContentSizeContext;
   _state.reset();
   _scrollableBounded = NO;
   _hasAutoDetent = NO;
-  _lastSize = CGSizeZero;
+  _lastReportedNaturalHeight = 0;
 }
 
 @end


### PR DESCRIPTION
## Summary

- Measure auto-detent natural height in the shared Fabric shadow node.
- Publish the measured height through state instead of observing native scroll content size.
- Support explicit-height and deeply nested scrollables without platform heuristics.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Not run (not requested).

## Screenshots / Videos

Not applicable.

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)