### PR TITLE
feat: add keyboardOffset to scrollableOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The `auto` detent now works with plugged scrollables — the sheet sizes to the scrollable's content height. ([#743](https://github.com/lodev09/react-native-true-sheet/pull/743) by [@lodev09](https://github.com/lodev09))
 - New `headerOptions` prop with a `position` option — set to `'absolute'` to float the header over the content and exclude it from the `auto` detent height. ([#747](https://github.com/lodev09/react-native-true-sheet/pull/747) by [@lodev09](https://github.com/lodev09))
 - The footer now absorbs the bottom safe-area inset as padding when `insetAdjustment` is `automatic` — no manual safe-area padding needed. Skipped while the keyboard is open. ([#749](https://github.com/lodev09/react-native-true-sheet/pull/749), [#750](https://github.com/lodev09/react-native-true-sheet/pull/750) by [@lodev09](https://github.com/lodev09))
+- New `keyboardOffset` option in `scrollableOptions` — adjusts the scrollable's keyboard bottom inset. Pass `-insets.bottom` to cancel out safe-area padding already in your content's `paddingBottom`. ([#785](https://github.com/lodev09/react-native-true-sheet/pull/785) by [@lodev09](https://github.com/lodev09))
 
 ### 🐛 Bug fixes
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -20,7 +20,11 @@ import com.lodev09.truesheet.utils.isDescendantOf
 import com.lodev09.truesheet.utils.smoothScrollBy
 import com.lodev09.truesheet.utils.smoothScrollTo
 
-data class ScrollableOptions(val keyboardScrollOffset: Float = 0f, val scrollingExpandsSheet: Boolean = true)
+data class ScrollableOptions(
+  val keyboardScrollOffset: Float = 0f,
+  val keyboardOffset: Float = 0f,
+  val scrollingExpandsSheet: Boolean = true
+)
 
 /**
  * Delegate interface for content view size changes
@@ -71,6 +75,20 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
   }
 
   private var keyboardScrollOffset: Float = 0f
+
+  /**
+   * Adjustment added to the keyboard bottom inset applied to the detected
+   * scrollable — negative values reduce the inset (e.g. to cancel out safe-area
+   * padding already baked into the content's paddingBottom).
+   */
+  private var keyboardOffset: Float = 0f
+
+  /**
+   * How much of keyboardOffset actually landed in the applied padding — the
+   * caret reveal compensates by this so it still targets the real keyboard edge.
+   */
+  private var appliedKeyboardOffset = 0
+
   private var keyboardObserver: TrueSheetKeyboardObserver? = null
 
   private var watchedEditText: EditText? = null
@@ -80,6 +98,7 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     set(value) {
       field = value
       keyboardScrollOffset = value?.keyboardScrollOffset?.dpToPx() ?: 0f
+      keyboardOffset = value?.keyboardOffset?.dpToPx() ?: 0f
     }
 
   /**
@@ -180,6 +199,7 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     setScrollableBounded(false)
     detectedScrollView = null
     originalScrollViewPaddingBottom = 0
+    appliedKeyboardOffset = 0
   }
 
   fun findScrollView(): ViewGroup? {
@@ -274,8 +294,12 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     // floats within the viewport — its clearance is the content padding's job
     // (the caret reveal accounts for it, see scrollToFocusedInput).
     val totalBottomInset = if (keyboardHeight > 0) {
-      maxOf(0, keyboardHeight + minOf(0, delegate?.footerKeyboardOcclusion ?: 0))
+      val baseInset = maxOf(0, keyboardHeight + minOf(0, delegate?.footerKeyboardOcclusion ?: 0))
+      val adjustedInset = maxOf(0, baseInset + keyboardOffset.toInt())
+      appliedKeyboardOffset = adjustedInset - baseInset
+      adjustedInset
     } else {
+      appliedKeyboardOffset = 0
       0
     }
     setScrollViewPaddingBottom(originalScrollViewPaddingBottom + totalBottomInset)
@@ -322,7 +346,7 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     val footerOcclusion = maxOf(0, delegate?.footerKeyboardOcclusion ?: 0)
 
     val offset = keyboardScrollOffset.toInt()
-    val visibleHeight = scrollView.height - scrollView.paddingBottom
+    val visibleHeight = scrollView.height - scrollView.paddingBottom + appliedKeyboardOffset
     val visibleTop = scrollView.scrollY
     val visibleBottom = scrollView.scrollY + visibleHeight
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -241,6 +241,7 @@ class TrueSheetViewManager :
 
     val scrollableOptions = ScrollableOptions(
       keyboardScrollOffset = if (options.hasKey("keyboardScrollOffset")) options.getDouble("keyboardScrollOffset").toFloat() else 0f,
+      keyboardOffset = if (options.hasKey("keyboardOffset")) options.getDouble("keyboardOffset").toFloat() else 0f,
       scrollingExpandsSheet = if (options.hasKey("scrollingExpandsSheet")) options.getBoolean("scrollingExpandsSheet") else true
     )
     view.setScrollableOptions(scrollableOptions)

--- a/docs/docs/guides/keyboard.mdx
+++ b/docs/docs/guides/keyboard.mdx
@@ -52,6 +52,18 @@ You can use `keyboardScrollOffset` in [`scrollableOptions`](../reference/configu
 
 This is especially useful for forms with multiple inputs — as the user taps between fields, the scroll view adjusts automatically to keep the active input in view.
 
+While the keyboard is open, the scrollable gets a bottom inset matching the keyboard height. If your content already renders its own bottom padding (e.g. safe-area padding via `paddingBottom`), that padding stacks on top of the inset and leaves a gap above the keyboard. Use `keyboardOffset` to adjust the inset — pass a negative value to cancel out the padding:
+
+```tsx
+const insets = useSafeAreaInsets()
+
+<TrueSheet scrollableOptions={{ keyboardOffset: -insets.bottom }}>
+  <ScrollView contentContainerStyle={{ paddingBottom: insets.bottom }}>
+    <TextInput placeholder="Input 1" />
+  </ScrollView>
+</TrueSheet>
+```
+
 ## Footer Behavior
 
 A relative [`footer`](../reference/configuration#footer) (the default) stays in the layout flow — it doesn't float above the keyboard. The keyboard simply covers it, and it's revealed again when the keyboard hides.

--- a/docs/docs/reference/04-types.mdx
+++ b/docs/docs/reference/04-types.mdx
@@ -97,6 +97,7 @@ Options for customizing scrollable behavior. Applies when the sheet contains a `
 | - | - | - | - |
 | `scrollingExpandsSheet` | `boolean` | When `false`, scrolling the content does not expand the sheet to the next detent. Only dragging the grabber or sheet background expands it. Useful for YouTube-style comments sheets. | `true` |
 | `keyboardScrollOffset` | `number` | Additional offset when scrolling to a focused input above the keyboard. | `0` |
+| `keyboardOffset` | `number` | Adjusts the bottom inset applied to the scrollable when the keyboard is shown. Negative values reduce it — pass `-insets.bottom` to cancel out safe-area padding already included in the content's `paddingBottom`. | `0` |
 | `topScrollEdgeEffect` | [`ScrollEdgeEffect`](#scrolledgeeffect) | The scroll edge effect applied to the top edge of the scroll view and header. iOS 26+ only. | `'hidden'` |
 | `bottomScrollEdgeEffect` | [`ScrollEdgeEffect`](#scrolledgeeffect) | The scroll edge effect applied to the bottom edge of the scroll view and footer. iOS 26+ only. | `'hidden'` |
 

--- a/example/shared/src/components/sheets/PromptSheet.tsx
+++ b/example/shared/src/components/sheets/PromptSheet.tsx
@@ -52,6 +52,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
       style={styles.sheet}
       scrollableOptions={{
         keyboardScrollOffset: SPACING,
+        keyboardOffset: -insets.bottom,
         topScrollEdgeEffect: 'soft',
         bottomScrollEdgeEffect: 'soft',
       }}

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ScrollableOptions : NSObject
 
 @property (nonatomic, assign) CGFloat keyboardScrollOffset;
+@property (nonatomic, assign) CGFloat keyboardOffset;
 @property (nonatomic, assign) BOOL scrollingExpandsSheet;
 @property (nonatomic, assign) facebook::react::TrueSheetViewTopScrollEdgeEffect topScrollEdgeEffect;
 @property (nonatomic, assign) facebook::react::TrueSheetViewBottomScrollEdgeEffect bottomScrollEdgeEffect;

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -33,6 +33,7 @@ using namespace facebook::react;
 - (instancetype)init {
   if (self = [super init]) {
     _keyboardScrollOffset = 0;
+    _keyboardOffset = 0;
     _scrollingExpandsSheet = YES;
     _topScrollEdgeEffect = TrueSheetViewTopScrollEdgeEffect::Hidden;
     _bottomScrollEdgeEffect = TrueSheetViewBottomScrollEdgeEffect::Hidden;
@@ -148,6 +149,7 @@ using namespace facebook::react;
 - (void)setScrollableOptions:(ScrollableOptions *)scrollableOptions {
   _scrollableOptions = scrollableOptions;
   _contentView.keyboardScrollOffset = scrollableOptions ? scrollableOptions.keyboardScrollOffset : 0;
+  _contentView.keyboardOffset = scrollableOptions ? scrollableOptions.keyboardOffset : 0;
 }
 
 - (void)setupScrollable {

--- a/ios/TrueSheetContentView.h
+++ b/ios/TrueSheetContentView.h
@@ -32,6 +32,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak, nullable) id<TrueSheetContentViewDelegate> delegate;
 @property (nonatomic, assign) CGFloat keyboardScrollOffset;
+
+/**
+ * Adjustment added to the keyboard bottom inset applied to the detected
+ * scrollable — negative values reduce the inset (e.g. to cancel out safe-area
+ * padding already baked into the content's paddingBottom).
+ */
+@property (nonatomic, assign) CGFloat keyboardOffset;
+
 @property (nonatomic, weak, nullable) TrueSheetKeyboardObserver *keyboardObserver;
 
 /**

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -28,6 +28,7 @@ using namespace facebook::react;
   TrueSheetContentViewShadowNode::ConcreteState::Shared _state;
   RCTScrollViewComponentView *_detectedScrollView;
   CGFloat _lastReportedNaturalHeight;
+  CGFloat _appliedKeyboardOffset;
   BOOL _observingTextChanges;
   BOOL _scrollableBounded;
 }
@@ -164,6 +165,7 @@ using namespace facebook::react;
 
 - (void)clearScrollable {
   [self setKeyboardInset:0];
+  _appliedKeyboardOffset = 0;
   [self setScrollableBounded:NO];
   _detectedScrollView = nil;
 }
@@ -204,14 +206,20 @@ using namespace facebook::react;
     inset = MAX(0, height - self.footerView.frame.size.height);
   }
 
+  // Track how much of keyboardOffset actually lands in the inset so the caret
+  // reveal can compensate — the offset shifts the inset, not the keyboard edge.
+  CGFloat adjustedInset = MAX(0, inset + self.keyboardOffset);
+  _appliedKeyboardOffset = adjustedInset - inset;
+
   // Content that already fits above the keyboard has nothing to reveal — the
   // inset would only open blank scroll range below it (huge gap at the bottom).
   UIScrollView *scrollView = _detectedScrollView.scrollView;
-  if (scrollView.contentSize.height <= scrollView.bounds.size.height - inset) {
+  if (scrollView.contentSize.height <= scrollView.bounds.size.height - adjustedInset) {
+    _appliedKeyboardOffset = 0;
     return 0;
   }
 
-  return inset;
+  return adjustedInset;
 }
 
 // An absolute footer floats over the viewport's bottom edge — extend the
@@ -373,7 +381,7 @@ using namespace facebook::react;
     }
   }
 
-  targetRect.size.height += self.keyboardScrollOffset + [self footerOcclusion];
+  targetRect.size.height += self.keyboardScrollOffset + [self footerOcclusion] - _appliedKeyboardOffset;
   [scrollView scrollRectToVisible:targetRect animated:animated];
 }
 

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -281,13 +281,14 @@ using namespace facebook::react;
   BOOL scrollingExpandsSheet = scrollableOpts.scrollingExpandsSheet;
   auto topEdgeEffect = scrollableOpts.topScrollEdgeEffect;
   auto bottomEdgeEffect = scrollableOpts.bottomScrollEdgeEffect;
-  BOOL hasScrollableOptions = scrollableOpts.keyboardScrollOffset > 0 || !scrollingExpandsSheet ||
-                              topEdgeEffect != TrueSheetViewTopScrollEdgeEffect::Hidden ||
+  BOOL hasScrollableOptions = scrollableOpts.keyboardScrollOffset > 0 || scrollableOpts.keyboardOffset != 0 ||
+                              !scrollingExpandsSheet || topEdgeEffect != TrueSheetViewTopScrollEdgeEffect::Hidden ||
                               bottomEdgeEffect != TrueSheetViewBottomScrollEdgeEffect::Hidden;
 
   if (hasScrollableOptions) {
     ScrollableOptions *options = [[ScrollableOptions alloc] init];
     options.keyboardScrollOffset = scrollableOpts.keyboardScrollOffset;
+    options.keyboardOffset = scrollableOpts.keyboardOffset;
     options.scrollingExpandsSheet = scrollingExpandsSheet;
     options.topScrollEdgeEffect = topEdgeEffect;
     options.bottomScrollEdgeEffect = bottomEdgeEffect;

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -173,6 +173,18 @@ export interface ScrollableOptions {
   keyboardScrollOffset?: number;
 
   /**
+   * Adjusts the bottom inset applied to the scrollable when the keyboard is shown.
+   * Positive values increase the inset; negative values reduce it.
+   * Pass `-insets.bottom` to cancel out safe-area padding already included in
+   * the content's `paddingBottom`.
+   * Does not affect the auto scroll of the focused input — it always targets
+   * the keyboard edge.
+   *
+   * @default 0
+   */
+  keyboardOffset?: number;
+
+  /**
    * Whether scrolling the content expands the sheet to the next detent.
    * When `false`, only the grabber can expand the sheet.
    *

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -36,6 +36,7 @@ type ScrollEdgeEffect = 'automatic' | 'hard' | 'soft' | 'hidden';
 
 type ScrollableOptionsType = Readonly<{
   keyboardScrollOffset?: WithDefault<Double, 0>;
+  keyboardOffset?: WithDefault<Double, 0>;
   scrollingExpandsSheet?: WithDefault<boolean, true>;
   topScrollEdgeEffect?: WithDefault<ScrollEdgeEffect, 'hidden'>;
   bottomScrollEdgeEffect?: WithDefault<ScrollEdgeEffect, 'hidden'>;


### PR DESCRIPTION
## Summary

Adds a `keyboardOffset` option to `scrollableOptions` that adjusts the bottom inset applied to the detected scrollable while the keyboard is shown. Negative values reduce the inset — e.g. pass `-insets.bottom` to cancel out safe-area padding already included in the content's `paddingBottom`, removing the extra gap above the keyboard.

The offset only shifts the inset, not the focused-input auto scroll — both platforms compensate in the caret reveal so it still targets the real keyboard edge.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Focus inputs in the example `PromptSheet` (now passes `keyboardOffset: -insets.bottom`) on iOS and Android
- Verify the scrollable's bottom padding hugs the keyboard without the safe-area gap
- Verify tapping between inputs still scrolls the caret clear of the keyboard

## Screenshots / Videos

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)