### PR TITLE
fix: stop responder negotiation at sheet boundary instead of claiming it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- Touchables inside a sheet fire their `onPress` again when the sheet content contains a nested native-stack screen (or a second finger touches the sheet mid-press) — since [#767](https://github.com/lodev09/react-native-true-sheet/pull/767), the sheet claimed the responder whenever the negotiation re-ran mid-gesture, stealing it from the pressed touchable. The sheet now stops the negotiation at its boundary without claiming, which also keeps the touch-leak fix without any `setJSResponder` side effects. ([#786](https://github.com/lodev09/react-native-true-sheet/pull/786) by [@lodev09](https://github.com/lodev09))
+
 ## 3.11.11
 
 ### 🐛 Bug fixes

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -58,12 +58,21 @@ if (!TrueSheetModule) {
 
 type NativeRef = ComponentRef<typeof TrueSheetViewNativeComponent>;
 
-// Claim touches that no descendant claimed so the responder negotiation
-// doesn't bubble up to touchables outside the sheet
-const absorbUnclaimedTouches = () => true;
-
 // Stop raw touch events from bubbling past the sheet to outside ancestors
 const stopTouchPropagation = (event: GestureResponderEvent) => event.stopPropagation();
+
+// Stop the responder negotiation at the sheet boundary without claiming the
+// responder. Views inside the sheet are asked before this one, so in-sheet
+// touchables work normally; views outside are asked after, so stopping here
+// keeps unclaimed touches from leaking to touchables behind the sheet.
+// Claiming instead (returning true) would steal the responder from a pressed
+// touchable whenever the negotiation re-runs mid-gesture — e.g. a second
+// finger, or the duplicate touch stream from a nested react-native-screens
+// screen that attaches its own touch handler inside the sheet.
+const stopResponderNegotiation = (event: GestureResponderEvent) => {
+  event.stopPropagation();
+  return false;
+};
 
 interface TrueSheetState {
   shouldRenderNativeView: boolean;
@@ -552,10 +561,11 @@ export class TrueSheet
         onVisibilityChange={this.onVisibilityChange}
         // These must stay on this host view, not on the container. The container is
         // reparented into the native sheet, so this view is never a native ancestor of
-        // the sheet content. Claiming the responder here stops the negotiation at the
-        // sheet boundary without making an ancestor of the content the JS responder,
-        // which would block scrolling inside the sheet.
-        onStartShouldSetResponder={absorbUnclaimedTouches}
+        // the sheet content — this is the React-tree boundary between the sheet and
+        // the presenting screen, where both the responder negotiation and raw touch
+        // bubbling must stop.
+        onStartShouldSetResponder={stopResponderNegotiation}
+        onMoveShouldSetResponder={stopResponderNegotiation}
         onTouchStart={stopTouchPropagation}
         onTouchMove={stopTouchPropagation}
         onTouchEnd={stopTouchPropagation}


### PR DESCRIPTION
## Summary

Fixes #782 — since 3.11.10, `onPress` inside a sheet silently dies when the sheet content contains a nested native-stack (react-native-screens) screen.

**Root cause:** a nested screen inside the sheet isn't mounted under an `RCTRootComponentView`, so react-native-screens attaches its own `RCTSurfaceTouchHandler` to it — one tap produces two JS touch streams. The first grants the responder to the `Pressable`; the second re-runs React's responder negotiation, which skips the current responder and asks its ancestors. The host view's unconditional `onStartShouldSetResponder={() => true}` (added in #767, moved in #777) claimed it, terminating the `Pressable` — pressed state showed, `onPress` never fired. A second finger on the sheet triggered the same steal.

**Fix:** don't claim — stop. `onStartShouldSetResponder`/`onMoveShouldSetResponder` on the host now call `stopPropagation()` and return `false`. React's negotiation loop checks `isPropagationStopped()` between listeners, so:

- In-sheet views are asked **before** the host → touchables/scrollables work normally
- Outside views are asked **after** → the #767 touch leak stays fixed
- The host never becomes responder → nothing to steal, no `setJSResponder` side effects (the scroll-blocking that #777 worked around can't occur by construction)
- The move-negotiation stop also closes the equivalent leak to outside `PanResponder`s

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Reproduced #782 in both example apps (settings sheet content wrapped in a nested native-stack, `detents: [1]` + `scrollable: true`) — buttons pressed but never fired
- With this fix (iOS): nested-stack sheet buttons fire, flat sheets unaffected, scrolling works, taps on the sheet don't leak to touchables behind it
- `yarn typecheck`, `yarn lint`, `yarn test` (44 tests) pass

## Screenshots / Videos

See #782

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)
