### PR TITLE
fix(android): apply pointerEvents prop on host view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug fixes
 
+- **Android**: Touchables rendered after a `View` with `zIndex > 0` that contains a `TrueSheet` respond again — the host view's `pointerEvents` (`box-none`) was silently dropped by the codegen delegate, so hit-testing could target the full-screen hidden host and swallow touches behind it. ([#787](https://github.com/lodev09/react-native-true-sheet/pull/787) by [@lodev09](https://github.com/lodev09))
 - Touchables inside a sheet fire their `onPress` again when the sheet content contains a nested native-stack screen (or a second finger touches the sheet mid-press) — since [#767](https://github.com/lodev09/react-native-true-sheet/pull/767), the sheet claimed the responder whenever the negotiation re-ran mid-gesture, stealing it from the pressed touchable. The sheet now stops the negotiation at its boundary without claiming, which also keeps the touch-leak fix without any `setJSResponder` side effects. ([#786](https://github.com/lodev09/react-native-true-sheet/pull/786) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.11

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.PixelUtil.dpToPx
+import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
@@ -54,6 +55,20 @@ class TrueSheetViewManager :
   }
 
   override fun getDelegate(): ViewManagerDelegate<TrueSheetView> = delegate
+
+  // The codegen delegate drops props outside the spec (pointerEvents comes from the
+  // host's style), so apply it here after the delegate pass.
+  override fun updateProperties(viewToUpdate: TrueSheetView, props: ReactStylesDiffMap) {
+    super.updateProperties(viewToUpdate, props)
+    if (props.hasKey("pointerEvents")) {
+      setPointerEvents(viewToUpdate, props.getString("pointerEvents"))
+    }
+  }
+
+  @ReactProp(name = "pointerEvents")
+  fun setPointerEvents(view: TrueSheetView, pointerEventsStr: String?) {
+    view.pointerEvents = PointerEvents.parsePointerEvents(pointerEventsStr)
+  }
 
   /**
    * Export custom direct event types for Fabric


### PR DESCRIPTION
## Summary

Fixes #781. On Android, touches were blocked for elements rendered after a `View` with `zIndex > 0` containing a `TrueSheet` — even when the sheet was never presented.

`TrueSheetViewManager` routes all props through the codegen delegate, which silently drops props outside the spec — including `pointerEvents`. The host's `box-none` style was never applied natively, so RN's `TouchTargetHelper` (which ignores `GONE` visibility) could target the full-screen hidden host and swallow touches. A `zIndex > 0` wrapper made the host's subtree hit-test first, exposing the bug.

This applies `pointerEvents` in `updateProperties` after the delegate pass.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Applied the repro from #781 (wrap `BasicSheet` + button in a `View` with `zIndex: 1` in `MapScreen`) — buttons after the wrapper now respond correctly. Verified sheet presentation, dragging, and content touches still work.

## Screenshots / Videos

N/A

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)