### PR TITLE
feat: Add lazy prop to control mounting content before presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🎉 New features
 
+- Added a JS-only `prewarm` prop to mount sheet content before presentation, allowing `auto` detents to measure settled content before the sheet opens. ([#792](https://github.com/lodev09/react-native-true-sheet/pull/792) by [@maxlapides](https://github.com/maxlapides))
 - **iOS**: Smoother `onPositionChange`, and `onWillDismiss` now fires only when a drag-to-dismiss is committed. ([#744](https://github.com/lodev09/react-native-true-sheet/pull/744), [#756](https://github.com/lodev09/react-native-true-sheet/pull/756) by [@lodev09](https://github.com/lodev09))
 - The `auto` detent now works with plugged scrollables — the sheet sizes to the scrollable's content height. ([#743](https://github.com/lodev09/react-native-true-sheet/pull/743) by [@lodev09](https://github.com/lodev09))
 - New `headerOptions` prop with a `position` option — set to `'absolute'` to float the header over the content and exclude it from the `auto` detent height. ([#747](https://github.com/lodev09/react-native-true-sheet/pull/747) by [@lodev09](https://github.com/lodev09))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🎉 New features
 
-- Added a JS-only `prewarm` prop to mount sheet content before presentation, allowing `auto` detents to measure settled content before the sheet opens. ([#792](https://github.com/lodev09/react-native-true-sheet/pull/792) by [@maxlapides](https://github.com/maxlapides))
+- Added a JS-only `lazy` prop — set to `false` to mount sheet content before presentation, allowing `auto` detents to measure settled content before the sheet opens. ([#792](https://github.com/lodev09/react-native-true-sheet/pull/792) by [@maxlapides](https://github.com/maxlapides))
 - **iOS**: Smoother `onPositionChange`, and `onWillDismiss` now fires only when a drag-to-dismiss is committed. ([#744](https://github.com/lodev09/react-native-true-sheet/pull/744), [#756](https://github.com/lodev09/react-native-true-sheet/pull/756) by [@lodev09](https://github.com/lodev09))
 - The `auto` detent now works with plugged scrollables — the sheet sizes to the scrollable's content height. ([#743](https://github.com/lodev09/react-native-true-sheet/pull/743) by [@lodev09](https://github.com/lodev09))
 - New `headerOptions` prop with a `position` option — set to `'absolute'` to float the header over the content and exclude it from the `auto` detent height. ([#747](https://github.com/lodev09/react-native-true-sheet/pull/747) by [@lodev09](https://github.com/lodev09))

--- a/docs/docs/reference/01-configuration.mdx
+++ b/docs/docs/reference/01-configuration.mdx
@@ -216,13 +216,13 @@ Used with `initialDetentIndex`.
 | - | - | - | - | - |
 | `boolean` | `true` | ✅ | ✅ | ✅ |
 
-## `prewarm`
+## `lazy`
 
-Mounts the sheet content before presentation without presenting the sheet. Use this when content is not ready on the first render, then call [`present()`](methods#present) after your readiness signal so [`auto`](types#sheetdetent) detents measure the settled content.
+Specify whether the sheet content should mount lazily, on first presentation. Set to `false` to mount the content before presentation without presenting the sheet. Use this when content is not ready on the first render, then call [`present()`](methods#present) after your readiness signal so [`auto`](types#sheetdetent) detents measure the settled content.
 
 | Type | Default | 🍎 | 🤖 | 🌐 |
 | - | - | - | - | - |
-| `boolean` | `false` | ✅ | ✅ | |
+| `boolean` | `true` | ✅ | ✅ | |
 
 :::note
 Content that requires window attachment to measure, such as SwiftUI-hosted views, still only measures during presentation.

--- a/docs/docs/reference/01-configuration.mdx
+++ b/docs/docs/reference/01-configuration.mdx
@@ -216,6 +216,18 @@ Used with `initialDetentIndex`.
 | - | - | - | - | - |
 | `boolean` | `true` | ✅ | ✅ | ✅ |
 
+## `prewarm`
+
+Mounts the sheet content before presentation without presenting the sheet. Use this when content is not ready on the first render, then call [`present()`](methods#present) after your readiness signal so [`auto`](types#sheetdetent) detents measure the settled content.
+
+| Type | Default | 🍎 | 🤖 | 🌐 |
+| - | - | - | - | - |
+| `boolean` | `false` | ✅ | ✅ | |
+
+:::note
+Content that requires window attachment to measure, such as SwiftUI-hosted views, still only measures during presentation.
+:::
+
 ## `grabber`
 
 Shows a native grabber (or drag handle) on the sheet.

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -17,7 +17,8 @@ jest.mock('./src/fabric/TrueSheetViewNativeComponent', () => {
   return {
     __esModule: true,
     default: React.forwardRef((props, ref) => {
-      return React.createElement(View, { ...props, ref });
+      React.useImperativeHandle(ref, () => ({ _nativeTag: 1 }));
+      return React.createElement(View, props);
     }),
   };
 });

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -130,10 +130,10 @@ export class TrueSheet
 
     this.validateDetents();
 
-    // Lazy load by default, except when auto-presenting or prewarming content
+    // Lazy load by default, except when auto-presenting or when lazy is disabled
     const shouldRenderImmediately =
       (props.initialDetentIndex !== undefined && props.initialDetentIndex >= 0) ||
-      props.prewarm === true;
+      props.lazy === false;
 
     this.state = {
       shouldRenderNativeView: shouldRenderImmediately,
@@ -351,8 +351,8 @@ export class TrueSheet
     this.backHandlerSubscription?.remove();
     this.backHandlerSubscription = null;
 
-    // Keep prewarmed content mounted; otherwise clean it up unless another presentation is active.
-    if (!this.isPresenting && this.props.prewarm !== true) {
+    // Non-lazy content stays mounted; otherwise clean it up unless another presentation is active.
+    if (!this.isPresenting && this.props.lazy !== false) {
       this.setState({ shouldRenderNativeView: false });
     }
 
@@ -485,8 +485,8 @@ export class TrueSheet
     this.updateScrollableHandle();
 
     if (
-      prevProps.prewarm !== true &&
-      this.props.prewarm === true &&
+      prevProps.lazy !== false &&
+      this.props.lazy === false &&
       !this.state.shouldRenderNativeView
     ) {
       this.setState({ shouldRenderNativeView: true });
@@ -551,7 +551,7 @@ export class TrueSheet
       insetAdjustment = 'automatic',
       ...rest
     } = this.props;
-    delete rest.prewarm;
+    delete rest.lazy;
 
     // Trim to max 3 detents and clamp fractions
     const resolvedDetents: number[] = detents.slice(0, 3).map((detent) => {

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -130,9 +130,10 @@ export class TrueSheet
 
     this.validateDetents();
 
-    // Lazy load by default, except when initialDetentIndex is set (for auto-presentation)
+    // Lazy load by default, except when auto-presenting or prewarming content
     const shouldRenderImmediately =
-      props.initialDetentIndex !== undefined && props.initialDetentIndex >= 0;
+      (props.initialDetentIndex !== undefined && props.initialDetentIndex >= 0) ||
+      props.prewarm === true;
 
     this.state = {
       shouldRenderNativeView: shouldRenderImmediately,
@@ -350,9 +351,8 @@ export class TrueSheet
     this.backHandlerSubscription?.remove();
     this.backHandlerSubscription = null;
 
-    // Clean up native view after dismiss for lazy loading.
-    // Skip unmount if a present is in progress to avoid race condition.
-    if (!this.isPresenting) {
+    // Keep prewarmed content mounted; otherwise clean it up unless another presentation is active.
+    if (!this.isPresenting && this.props.prewarm !== true) {
       this.setState({ shouldRenderNativeView: false });
     }
 
@@ -484,6 +484,14 @@ export class TrueSheet
     this.registerInstance();
     this.updateScrollableHandle();
 
+    if (
+      prevProps.prewarm !== true &&
+      this.props.prewarm === true &&
+      !this.state.shouldRenderNativeView
+    ) {
+      this.setState({ shouldRenderNativeView: true });
+    }
+
     // Validate when detents prop changes
     if (prevProps.detents !== this.props.detents) {
       this.validateDetents();
@@ -543,6 +551,7 @@ export class TrueSheet
       insetAdjustment = 'automatic',
       ...rest
     } = this.props;
+    delete rest.prewarm;
 
     // Trim to max 3 detents and clamp fractions
     const resolvedDetents: number[] = detents.slice(0, 3).map((detent) => {

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -432,6 +432,20 @@ export interface TrueSheetProps extends ViewProps {
   initialDetentAnimated?: boolean;
 
   /**
+   * Mounts the sheet content before presentation without presenting the sheet.
+   * Use this when content is not ready on the first render, then call `present()`
+   * after your readiness signal so auto detents measure the settled content.
+   *
+   * Content that requires window attachment to measure, such as SwiftUI-hosted views,
+   * still only measures during presentation.
+   *
+   * @platform android
+   * @platform ios
+   * @default false
+   */
+  prewarm?: boolean;
+
+  /**
    * The detent index that the sheet should start to dim the background.
    * This is ignored if `dimmed` is set to `false`.
    *

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -432,7 +432,8 @@ export interface TrueSheetProps extends ViewProps {
   initialDetentAnimated?: boolean;
 
   /**
-   * Mounts the sheet content before presentation without presenting the sheet.
+   * Specify whether the sheet content should mount lazily, on first presentation.
+   * Set to `false` to mount the content before presentation without presenting the sheet.
    * Use this when content is not ready on the first render, then call `present()`
    * after your readiness signal so auto detents measure the settled content.
    *
@@ -441,9 +442,9 @@ export interface TrueSheetProps extends ViewProps {
    *
    * @platform android
    * @platform ios
-   * @default false
+   * @default true
    */
-  prewarm?: boolean;
+  lazy?: boolean;
 
   /**
    * The detent index that the sheet should start to dim the background.

--- a/src/__tests__/TrueSheet.test.tsx
+++ b/src/__tests__/TrueSheet.test.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable dot-notation -- bracket access reaches TrueSheet's private test hooks with full typing */
+import { createRef } from 'react';
 import { Text } from 'react-native';
 import { render, act } from '@testing-library/react-native';
 import { TrueSheet, TrueSheetPeek } from '../index';
+import TrueSheetModule from '../specs/NativeTrueSheetModule';
 import type {
   DidDismissEvent,
   WillFocusEvent,
@@ -115,6 +117,69 @@ describe('TrueSheet', () => {
       );
       // Content should be rendered immediately
       expect(getByText('Eager Content')).toBeDefined();
+    });
+
+    it('should render native view content without presentation when prewarm is enabled', () => {
+      const { getByText, getByTestId } = render(
+        <TrueSheet name="prewarm-test" prewarm testID="prewarm-host">
+          <Text>Prewarmed Content</Text>
+        </TrueSheet>
+      );
+
+      expect(getByText('Prewarmed Content')).toBeDefined();
+      expect(getByTestId('prewarm-host').props.prewarm).toBeUndefined();
+    });
+
+    it('should render native view content when prewarm becomes enabled', () => {
+      const sheet = (
+        <TrueSheet name="deferred-prewarm-test">
+          <Text>Deferred Prewarmed Content</Text>
+        </TrueSheet>
+      );
+      const { queryByText, rerender } = render(sheet);
+
+      expect(queryByText('Deferred Prewarmed Content')).toBeNull();
+
+      rerender(<TrueSheet {...sheet.props} prewarm />);
+
+      expect(queryByText('Deferred Prewarmed Content')).not.toBeNull();
+
+      rerender(sheet);
+
+      expect(queryByText('Deferred Prewarmed Content')).not.toBeNull();
+    });
+
+    it('should keep prewarmed native view content mounted after dismiss', () => {
+      const { getByTestId, queryByText } = render(
+        <TrueSheet name="prewarm-dismiss-test" prewarm testID="prewarm-dismiss-host">
+          <Text>Persistent Prewarmed Content</Text>
+        </TrueSheet>
+      );
+
+      act(() => {
+        getByTestId('prewarm-dismiss-host').props.onDidDismiss({
+          nativeEvent: null,
+        });
+      });
+
+      expect(queryByText('Persistent Prewarmed Content')).not.toBeNull();
+    });
+
+    it('should present prewarmed content without waiting for another mount', async () => {
+      const sheetRef = createRef<TrueSheet>();
+      const onMountMock = jest.fn();
+      render(
+        <TrueSheet ref={sheetRef} name="prewarm-present-test" prewarm onMount={onMountMock}>
+          <Text>Ready Prewarmed Content</Text>
+        </TrueSheet>
+      );
+
+      await act(async () => {
+        await sheetRef.current?.present();
+      });
+
+      expect(onMountMock).not.toHaveBeenCalled();
+      expect(TrueSheetModule?.presentByRef).toHaveBeenCalledTimes(1);
     });
 
     it('should render native view content when present is called', async () => {

--- a/src/__tests__/TrueSheet.test.tsx
+++ b/src/__tests__/TrueSheet.test.tsx
@@ -119,58 +119,58 @@ describe('TrueSheet', () => {
       expect(getByText('Eager Content')).toBeDefined();
     });
 
-    it('should render native view content without presentation when prewarm is enabled', () => {
+    it('should render native view content without presentation when lazy is disabled', () => {
       const { getByText, getByTestId } = render(
-        <TrueSheet name="prewarm-test" prewarm testID="prewarm-host">
-          <Text>Prewarmed Content</Text>
+        <TrueSheet name="non-lazy-test" lazy={false} testID="non-lazy-host">
+          <Text>Non-Lazy Content</Text>
         </TrueSheet>
       );
 
-      expect(getByText('Prewarmed Content')).toBeDefined();
-      expect(getByTestId('prewarm-host').props.prewarm).toBeUndefined();
+      expect(getByText('Non-Lazy Content')).toBeDefined();
+      expect(getByTestId('non-lazy-host').props.lazy).toBeUndefined();
     });
 
-    it('should render native view content when prewarm becomes enabled', () => {
+    it('should render native view content when lazy becomes disabled', () => {
       const sheet = (
-        <TrueSheet name="deferred-prewarm-test">
-          <Text>Deferred Prewarmed Content</Text>
+        <TrueSheet name="deferred-non-lazy-test">
+          <Text>Deferred Non-Lazy Content</Text>
         </TrueSheet>
       );
       const { queryByText, rerender } = render(sheet);
 
-      expect(queryByText('Deferred Prewarmed Content')).toBeNull();
+      expect(queryByText('Deferred Non-Lazy Content')).toBeNull();
 
-      rerender(<TrueSheet {...sheet.props} prewarm />);
+      rerender(<TrueSheet {...sheet.props} lazy={false} />);
 
-      expect(queryByText('Deferred Prewarmed Content')).not.toBeNull();
+      expect(queryByText('Deferred Non-Lazy Content')).not.toBeNull();
 
       rerender(sheet);
 
-      expect(queryByText('Deferred Prewarmed Content')).not.toBeNull();
+      expect(queryByText('Deferred Non-Lazy Content')).not.toBeNull();
     });
 
-    it('should keep prewarmed native view content mounted after dismiss', () => {
+    it('should keep non-lazy native view content mounted after dismiss', () => {
       const { getByTestId, queryByText } = render(
-        <TrueSheet name="prewarm-dismiss-test" prewarm testID="prewarm-dismiss-host">
-          <Text>Persistent Prewarmed Content</Text>
+        <TrueSheet name="non-lazy-dismiss-test" lazy={false} testID="non-lazy-dismiss-host">
+          <Text>Persistent Non-Lazy Content</Text>
         </TrueSheet>
       );
 
       act(() => {
-        getByTestId('prewarm-dismiss-host').props.onDidDismiss({
+        getByTestId('non-lazy-dismiss-host').props.onDidDismiss({
           nativeEvent: null,
         });
       });
 
-      expect(queryByText('Persistent Prewarmed Content')).not.toBeNull();
+      expect(queryByText('Persistent Non-Lazy Content')).not.toBeNull();
     });
 
-    it('should present prewarmed content without waiting for another mount', async () => {
+    it('should present non-lazy content without waiting for another mount', async () => {
       const sheetRef = createRef<TrueSheet>();
       const onMountMock = jest.fn();
       render(
-        <TrueSheet ref={sheetRef} name="prewarm-present-test" prewarm onMount={onMountMock}>
-          <Text>Ready Prewarmed Content</Text>
+        <TrueSheet ref={sheetRef} name="non-lazy-present-test" lazy={false} onMount={onMountMock}>
+          <Text>Ready Non-Lazy Content</Text>
         </TrueSheet>
       );
 


### PR DESCRIPTION

## Summary

Add a JS-only `lazy` prop (default `true`). Setting `lazy={false}` mounts sheet children while the sheet remains unpresented. Keep the existing lazy behavior by default, begin rendering when `lazy` changes to `false`, preserve mounted content when it changes back to `true`, and keep non-lazy content mounted across dismissals. Do not forward the prop to the native component.

Without this option, a sheet using `detents={['auto']}` cannot mount its content before `present()`. Content that starts with a Suspense fallback, asynchronous loading state, or skeleton can therefore present at the placeholder height and visibly resize when the final content arrives.

Use `lazy={false}` to mount content early, wait for the app's readiness signal such as Suspense resolution, loaded data, or settled `onLayout`, and then call `present()`. This lets the auto detent measure settled React Native content before the presentation animation begins.

Document the new prop and its measurement limitation, add its public type, and cover the mounting and presentation lifecycle in unit tests.

Content that requires window attachment to measure, such as SwiftUI-hosted views rendered through `expo-ui`, still measures only during presentation. React Native/Yoga content was verified to lay out fully while unpresented in a production React Native app on an iOS 26 simulator.

> [!NOTE]
> Originally proposed as a `prewarm` prop; renamed to `lazy={false}` per maintainer feedback.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test` — 69 tests pass
- [x] Verify the default lazy behavior remains unchanged
- [x] Verify `lazy={false}` renders children while unpresented and when set after mount
- [x] Verify re-enabling `lazy` and dismissing a non-lazy sheet preserve mounted children
- [x] Verify `present()` on a non-lazy sheet skips the additional mount wait
- [x] Verify `lazy` is not forwarded to the native component
- [x] Verify React Native/Yoga content lays out while unpresented on an iOS 26 simulator

## Screenshots / Videos

N/A — this changes when hidden sheet content mounts and does not introduce a visible UI change.

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)
