### PR TITLE
fix(ios): Retry blocked auto-present after recycled controller sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- **iOS**: Fast dismiss/re-present cycles no longer strand an `initialDetentIndex` auto-present when the host is recycled while its controller is still dismissing — blocked attempts now retry, and teardown and lifecycle events from the recycled controller session stay scoped to its original mount. ([#793](https://github.com/lodev09/react-native-true-sheet/pull/793) by [@maxlapides](https://github.com/maxlapides))
+
 ## 3.11.12
 
 ### 🐛 Bug fixes

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -41,6 +41,8 @@ using namespace facebook::react;
 @interface TrueSheetView () <TrueSheetViewControllerDelegate,
   TrueSheetContainerViewDelegate,
   RNScreensEventObserverDelegate>
+- (facebook::react::SharedViewEventEmitter)activeEventEmitter;
+- (void)clearStaleControllerSessionOwnershipIfNeeded;
 @end
 
 @implementation TrueSheetView {
@@ -51,6 +53,8 @@ using namespace facebook::react;
   UIView *_snapshotView;
   CGSize _lastStateSize;
   NSInteger _initialDetentIndex;
+  NSUInteger _initialPresentGeneration;
+  NSUInteger _mountGeneration;
   TrueSheetViewInsetAdjustment _insetAdjustment;
   BOOL _scrollable;
   ScrollableOptions *_scrollableOptions;
@@ -58,6 +62,7 @@ using namespace facebook::react;
   BOOL _isSheetUpdatePending;
   BOOL _pendingLayoutUpdate;
   BOOL _didInitiallyPresent;
+  BOOL _controllerSessionOwnedByPreviousMount;
   BOOL _dismissedByNavigation;
   BOOL _pendingNavigationRepresent;
   BOOL _pendingMountEvent;
@@ -85,9 +90,12 @@ using namespace facebook::react;
     _snapshotView = nil;
     _lastStateSize = CGSizeZero;
     _initialDetentIndex = -1;
+    _initialPresentGeneration = 0;
+    _mountGeneration = 0;
     _initialDetentAnimated = YES;
     _scrollable = NO;
     _isSheetUpdatePending = NO;
+    _controllerSessionOwnedByPreviousMount = NO;
 
     _screensEventObserver = [[RNScreensEventObserver alloc] init];
     _screensEventObserver.delegate = self;
@@ -111,18 +119,57 @@ using namespace facebook::react;
     return;
   }
 
-  if (_initialDetentIndex >= 0 && !_didInitiallyPresent) {
-    UIViewController *vc = [self findPresentingViewController];
+  [self presentInitialIfNeeded];
+}
 
-    // Only present if the view controller is in the same window and not being dismissed
-    if (vc && vc.view.window == self.window && !_controller.isBeingDismissed) {
-      _didInitiallyPresent = YES;
-      [self presentAtIndex:_initialDetentIndex animated:_initialDetentAnimated completion:nil];
-    } else {
-      // Animate next time when sheet finally moves to the correct window
-      _initialDetentAnimated = YES;
-    }
+// A recycled controller session must end before its replacement can auto-present.
+// Attachment, prop, or session completion can retry an unlatched attempt.
+- (void)presentInitialIfNeeded {
+  [self clearStaleControllerSessionOwnershipIfNeeded];
+
+  if (_initialDetentIndex < 0 || _didInitiallyPresent)
+    return;
+
+  UIViewController *vc = [self findPresentingViewController];
+  if (!vc || vc.view.window != self.window || _controllerSessionOwnedByPreviousMount || _controller.isPresented ||
+      _controller.isBeingDismissed) {
+    _initialDetentAnimated = YES;
+    return;
   }
+
+  _didInitiallyPresent = YES;
+  NSUInteger generation = _initialPresentGeneration;
+  NSInteger initialDetentIndex = _initialDetentIndex;
+  BOOL initialDetentAnimated = _initialDetentAnimated;
+
+  // Defer so finalizeUpdates completes the Fabric mount transaction before UIKit presentation.
+  __weak __typeof(self) weakSelf = self;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    __typeof(self) strongSelf = weakSelf;
+    if (!strongSelf || strongSelf->_initialPresentGeneration != generation)
+      return;
+
+    if (strongSelf->_controller.isBeingPresented)
+      return;
+
+    if (!strongSelf.window || strongSelf->_controller.isBeingDismissed) {
+      strongSelf->_didInitiallyPresent = NO;
+      return;
+    }
+
+    if (strongSelf->_controller.isPresented) {
+      strongSelf->_didInitiallyPresent = NO;
+      return;
+    }
+
+    [strongSelf presentAtIndex:initialDetentIndex
+                      animated:initialDetentAnimated
+                    completion:^(BOOL success, NSError *_Nullable error) {
+                      if (!success && strongSelf->_initialPresentGeneration == generation) {
+                        strongSelf->_didInitiallyPresent = NO;
+                      }
+                    }];
+  });
 }
 
 - (void)dealloc {
@@ -333,6 +380,10 @@ using namespace facebook::react;
     _pendingPropsUpdate = YES;
   } else if (_initialDetentIndex >= 0) {
     _pendingLayoutUpdate = NO;
+    if (self.window) {
+      // The first insert follows finalizeUpdates, so a window here identifies a retry.
+      [self presentInitialIfNeeded];
+    }
   }
 }
 
@@ -341,10 +392,29 @@ using namespace facebook::react;
 
   [TrueSheetModule unregisterViewWithTag:@(self.tag)];
 
+  _initialPresentGeneration += 1;
+  _mountGeneration += 1;
+
+  if (_controller.isPresented || _controller.isBeingPresented || _controller.isBeingDismissed) {
+    _controllerSessionOwnedByPreviousMount = YES;
+  }
+
+  if (_controller.isPresented && !_controller.isBeingDismissed) {
+    [self dismissAnimated:NO completion:nil];
+  }
+
+  [self cleanupContainerView];
+
   _lastStateSize = CGSizeZero;
   _didInitiallyPresent = NO;
   _dismissedByNavigation = NO;
   _pendingNavigationRepresent = NO;
+  _pendingMountEvent = NO;
+  _pendingPropsUpdate = NO;
+  _pendingLayoutUpdate = NO;
+  _isSheetUpdatePending = NO;
+  _pendingDetents = nil;
+  _pendingSizeChange = NO;
 }
 
 #pragma mark - Child Component Mounting
@@ -438,6 +508,8 @@ using namespace facebook::react;
 - (void)presentAtIndex:(NSInteger)index
               animated:(BOOL)animated
             completion:(nullable TrueSheetCompletionBlock)completion {
+  [self clearStaleControllerSessionOwnershipIfNeeded];
+
   if (_controller.isBeingPresented || _controller.isPresented) {
     RCTLogWarn(@"TrueSheet: sheet is already presented. Use resize() to change detent.");
     if (completion) {
@@ -511,6 +583,8 @@ using namespace facebook::react;
 }
 
 - (void)dismissAnimated:(BOOL)animated completion:(nullable TrueSheetCompletionBlock)completion {
+  _initialPresentGeneration += 1;
+
   if (_controller.isBeingDismissed || !_controller.isPresented) {
     RCTLogWarn(@"TrueSheet: sheet is already dismissed. No need to dismiss it again.");
 
@@ -572,8 +646,12 @@ using namespace facebook::react;
   }
 
   _isSheetUpdatePending = YES;
+  NSUInteger generation = _mountGeneration;
 
   dispatch_async(dispatch_get_main_queue(), ^{
+    if (self->_mountGeneration != generation)
+      return;
+
     self->_isSheetUpdatePending = NO;
     if (!self->_containerView)
       return;
@@ -614,12 +692,18 @@ using namespace facebook::react;
 
 - (void)viewControllerWillPresentAtIndex:(NSInteger)index position:(CGFloat)position detent:(CGFloat)detent {
   _controller.activeDetentIndex = index;
-  [TrueSheetLifecycleEvents emitWillPresent:_eventEmitter index:index position:position detent:detent];
+  [TrueSheetLifecycleEvents emitWillPresent:self.activeEventEmitter index:index position:position detent:detent];
 }
 
 - (void)viewControllerDidPresentAtIndex:(NSInteger)index position:(CGFloat)position detent:(CGFloat)detent {
+  if (_controllerSessionOwnedByPreviousMount) {
+    [self dismissAnimated:NO completion:nil];
+    return;
+  }
+
+  _didInitiallyPresent = YES;
   [_containerView setupKeyboardObserverWithViewController:_controller];
-  [TrueSheetLifecycleEvents emitDidPresent:_eventEmitter index:index position:position detent:detent];
+  [TrueSheetLifecycleEvents emitDidPresent:self.activeEventEmitter index:index position:position detent:detent];
 
   if (_pendingPropsUpdate) {
     _pendingPropsUpdate = NO;
@@ -638,14 +722,14 @@ using namespace facebook::react;
                        detent:(CGFloat)detent {
   switch (state) {
     case UIGestureRecognizerStateBegan:
-      [TrueSheetDragEvents emitDragBegin:_eventEmitter index:index position:position detent:detent];
+      [TrueSheetDragEvents emitDragBegin:self.activeEventEmitter index:index position:position detent:detent];
       break;
     case UIGestureRecognizerStateChanged:
-      [TrueSheetDragEvents emitDragChange:_eventEmitter index:index position:position detent:detent];
+      [TrueSheetDragEvents emitDragChange:self.activeEventEmitter index:index position:position detent:detent];
       break;
     case UIGestureRecognizerStateEnded:
     case UIGestureRecognizerStateCancelled:
-      [TrueSheetDragEvents emitDragEnd:_eventEmitter index:index position:position detent:detent];
+      [TrueSheetDragEvents emitDragEnd:self.activeEventEmitter index:index position:position detent:detent];
       break;
     default:
       break;
@@ -654,18 +738,33 @@ using namespace facebook::react;
 
 - (void)viewControllerWillDismiss {
   if (!_dismissedByNavigation) {
-    [TrueSheetLifecycleEvents emitWillDismiss:_eventEmitter];
+    [TrueSheetLifecycleEvents emitWillDismiss:self.activeEventEmitter];
   }
 }
 
 - (void)viewControllerDidDismiss {
   [_containerView cleanupKeyboardObserver];
+  facebook::react::SharedViewEventEmitter eventEmitter = self.activeEventEmitter;
+  _controllerSessionOwnedByPreviousMount = NO;
+
   if (!_dismissedByNavigation) {
     _dismissedByNavigation = NO;
     _pendingNavigationRepresent = NO;
 
     _controller.activeDetentIndex = -1;
-    [TrueSheetLifecycleEvents emitDidDismiss:_eventEmitter];
+    [TrueSheetLifecycleEvents emitDidDismiss:eventEmitter];
+  }
+
+  if (self.window) {
+    NSUInteger generation = _initialPresentGeneration;
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      __typeof(self) strongSelf = weakSelf;
+      if (!strongSelf || strongSelf->_initialPresentGeneration != generation)
+        return;
+
+      [strongSelf presentInitialIfNeeded];
+    });
   }
 }
 
@@ -673,14 +772,18 @@ using namespace facebook::react;
   if (_controller.activeDetentIndex != index) {
     _controller.activeDetentIndex = index;
   }
-  [TrueSheetStateEvents emitDetentChange:_eventEmitter index:index position:position detent:detent];
+  [TrueSheetStateEvents emitDetentChange:self.activeEventEmitter index:index position:position detent:detent];
 }
 
 - (void)viewControllerDidChangePosition:(CGFloat)index
                                position:(CGFloat)position
                                  detent:(CGFloat)detent
                                realtime:(BOOL)realtime {
-  [TrueSheetStateEvents emitPositionChange:_eventEmitter index:index position:position detent:detent realtime:realtime];
+  [TrueSheetStateEvents emitPositionChange:self.activeEventEmitter
+                                     index:index
+                                  position:position
+                                    detent:detent
+                                  realtime:realtime];
 }
 
 - (void)viewControllerDidChangeSize:(CGSize)size {
@@ -691,19 +794,19 @@ using namespace facebook::react;
 }
 
 - (void)viewControllerWillFocus {
-  [TrueSheetFocusEvents emitWillFocus:_eventEmitter];
+  [TrueSheetFocusEvents emitWillFocus:self.activeEventEmitter];
 }
 
 - (void)viewControllerDidFocus {
-  [TrueSheetFocusEvents emitDidFocus:_eventEmitter];
+  [TrueSheetFocusEvents emitDidFocus:self.activeEventEmitter];
 }
 
 - (void)viewControllerWillBlur {
-  [TrueSheetFocusEvents emitWillBlur:_eventEmitter];
+  [TrueSheetFocusEvents emitWillBlur:self.activeEventEmitter];
 }
 
 - (void)viewControllerDidBlur {
-  [TrueSheetFocusEvents emitDidBlur:_eventEmitter];
+  [TrueSheetFocusEvents emitDidBlur:self.activeEventEmitter];
 }
 
 #pragma mark - RNScreensEventObserverDelegate
@@ -750,6 +853,17 @@ using namespace facebook::react;
 }
 
 #pragma mark - Private Helpers
+
+- (facebook::react::SharedViewEventEmitter)activeEventEmitter {
+  return _controllerSessionOwnedByPreviousMount ? nullptr : _eventEmitter;
+}
+
+- (void)clearStaleControllerSessionOwnershipIfNeeded {
+  if (_controllerSessionOwnedByPreviousMount && !_controller.isPresented && !_controller.isBeingPresented &&
+      !_controller.isBeingDismissed) {
+    _controllerSessionOwnedByPreviousMount = NO;
+  }
+}
 
 - (void)setupScrollable {
   if (!_containerView)

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -52,6 +52,7 @@ using namespace facebook::react;
   TrueSheetViewShadowNode::ConcreteState::Shared _state;
   UIView *_snapshotView;
   CGSize _lastStateSize;
+  NSInteger _registeredTag;
   NSInteger _initialDetentIndex;
   NSUInteger _initialPresentGeneration;
   NSUInteger _mountGeneration;
@@ -89,6 +90,7 @@ using namespace facebook::react;
     _containerView = nil;
     _snapshotView = nil;
     _lastStateSize = CGSizeZero;
+    _registeredTag = 0;
     _initialDetentIndex = -1;
     _initialPresentGeneration = 0;
     _mountGeneration = 0;
@@ -110,6 +112,7 @@ using namespace facebook::react;
     return;
 
   if (self.tag > 0) {
+    _registeredTag = self.tag;
     [TrueSheetModule registerView:self withTag:@(self.tag)];
   }
 
@@ -195,7 +198,10 @@ using namespace facebook::react;
   [_snapshotView removeFromSuperview];
   _snapshotView = nil;
 
-  [TrueSheetModule unregisterViewWithTag:@(self.tag)];
+  if (_registeredTag > 0) {
+    [TrueSheetModule unregisterViewWithTag:@(_registeredTag)];
+    _registeredTag = 0;
+  }
 }
 
 #pragma mark - RCTComponentViewProtocol
@@ -390,8 +396,6 @@ using namespace facebook::react;
 - (void)prepareForRecycle {
   [super prepareForRecycle];
 
-  [TrueSheetModule unregisterViewWithTag:@(self.tag)];
-
   _initialPresentGeneration += 1;
   _mountGeneration += 1;
 
@@ -401,6 +405,11 @@ using namespace facebook::react;
 
   if (_controller.isPresented && !_controller.isBeingDismissed) {
     [self dismissAnimated:NO completion:nil];
+  }
+
+  if (_registeredTag > 0) {
+    [TrueSheetModule unregisterViewWithTag:@(_registeredTag)];
+    _registeredTag = 0;
   }
 
   [self cleanupContainerView];


### PR DESCRIPTION
## Summary

A fast dismiss/re-present cycle can recycle the Fabric host while its retained controller is still dismissing. The replacement mount then sees an in-flight controller transition, skips `initialDetentIndex` auto-presentation, and can remain stranded because nothing retries it. Retry initial presentation after attachment, prop updates, or the previous controller session ends, while keeping the previous session's teardown and lifecycle events scoped to its original mount.

Port the `presentInitialIfNeeded` retry shape from #751 to the v3 line for v4 parity. The `prepareForRecycle` hygiene and controller-session ownership handling go beyond what v4 does and are not covered by #751.

Fixes #789

Reproduction: [maxlapides/true-sheet-mount-stall-repro](https://github.com/maxlapides/true-sheet-mount-stall-repro)

## Commits

- `fix(ios): retry blocked auto-present and end recycled controller sessions` adds the retry path, resets recycled mount state, and prevents a retained controller session from emitting lifecycle events through its replacement host.
- `fix(ios): unregister the view tag actually registered with TrueSheetModule` preserves the registered React tag before recycle so the module removes the correct strong-registry entry. This is a separable commit that maintainers can drop, although the recycle path benefits from it.

**Behavior notes:** In a pathological fast cycle where a sheet finishes presenting after its host was already recycled, the previous sheet now snaps closed (`animated:NO`) before the replacement animates in; UIKit cannot cancel an in-flight presentation, and this replaces silently stranding the new sheet.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Verification

- `yarn typecheck`, `yarn lint`, and `yarn test --watchman=false` (44 Jest tests) pass.
- The linked repro app was extended with two auto-cycled shapes: Mode B performs a key-swap remount 30–330 ms into the dismissal animation; Mode C keeps one sheet mounted, swaps its keyed content mid-dismissal, then remounts after dismissal completes to mirror a production sheet-host.
- Red/green testing used Fabric debug builds on a physical iPhone 11 running iOS 26 with React Native 0.86.2. Native `RNSVGSvgView.didMoveToWindow` attach probes were captured through the unified log.
- Unpatched 3.11.12: Mode B wedged 158 of 316 cycles before presentation because auto-present was blocked by `isBeingDismissed` and never retried; the stale dismissal's `onDidDismiss` also emitted into the new mount. Mode C wedged on all 134 of 134 mid-dismissal swaps. The failure reproduced deterministically across the full 30–330 ms sweep.
- Patched: 0 wedges across 325 Mode B cycles and 294 Mode C cycles. Every cycle that presented attached all six second-commit SVG views (6/6), verified from the unified log.
- Limitation: the “presented but SVG fills missing” variant from the original issue report was captured in a production app and did not reproduce in the standalone harness on this hardware with either build. The patched code eliminates every failure this harness can produce.

## Screenshots / Videos

Not applicable; this changes lifecycle handling without changing the sheet's visual design.

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (not needed)
- [x] I added a changelog entry (if needed)
