### PR TITLE
fix(android): keep parent sheet in sync with child during auto detent resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- **Android**: A stacked parent sheet now follows its child frame-by-frame when the child resizes (e.g. `auto` detent content changes) instead of lagging behind and peeking out above it. Also fixes the sheet getting stuck at stale detents after a half-expanded settle, and reduces per-frame work during position emission. ([#797](https://github.com/lodev09/react-native-true-sheet/pull/797) by [@lodev09](https://github.com/lodev09))
 - The keyboard-driven scroll inset now accounts for a floating footer's height — focused inputs no longer hide behind it. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))
 - Auto detents now measure scrollable content in the shared layout tree, correctly sizing explicit-height and deeply nested scrollables on iOS and Android. ([#783](https://github.com/lodev09/react-native-true-sheet/pull/783) by [@lodev09](https://github.com/lodev09))
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -492,7 +492,12 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
       if (viewController.containerView == null) return@post
 
       viewController.setupSheetDetentsForSizeChange()
-      TrueSheetStackManager.updateParentTranslation(this)
+      // While settling, onSlide drives the parent translation in realtime —
+      // an animated update here would race it frame-by-frame, staggering the
+      // emitted position
+      if (!viewController.isSettling) {
+        TrueSheetStackManager.updateParentTranslation(this)
+      }
     }
   }
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -521,13 +521,45 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
   }
 
   /**
+   * Realtime counterpart of updateTranslationForChild, driven by the child's
+   * onSlide frames so stacked sheets move in lockstep instead of on
+   * independently-timed animations.
+   */
+  fun syncTranslationForChild(childSheetTop: Int, childMinSheetTop: Int) {
+    if (!viewController.isSheetVisible || viewController.isExpanded) return
+
+    val mySheetTop = viewController.detentCalculator.getSheetTopForDetentIndex(viewController.currentDetentIndex)
+    val targetTranslation = maxOf(0, childMinSheetTop - mySheetTop)
+    val actualTranslation = maxOf(0, childSheetTop - mySheetTop)
+    val currentTranslation = viewController.currentTranslationY
+
+    // Ride the child's actual position, but only between the current
+    // translation and the settled target — tracks the child frame-by-frame
+    // when the alignment changes (auto detent resize) while staying put when
+    // the child moves between detents above its minimum. Returning early on
+    // no-ops avoids cancelling an in-flight realign animation.
+    val newTranslation = actualTranslation.coerceIn(
+      minOf(currentTranslation, targetTranslation),
+      maxOf(currentTranslation, targetTranslation)
+    )
+    if (newTranslation == currentTranslation) return
+
+    viewController.translateSheet(newTranslation, animated = false)
+
+    val additionalTranslation = newTranslation - currentTranslation
+    if (additionalTranslation > 0) {
+      TrueSheetStackManager.getParentSheet(this)?.addTranslation(additionalTranslation, animated = false)
+    }
+  }
+
+  /**
    * Recursively adds translation to this sheet and all parent sheets.
    */
-  private fun addTranslation(amount: Int) {
+  private fun addTranslation(amount: Int, animated: Boolean = true) {
     if (viewController.isExpanded) return
 
-    viewController.translateSheet(viewController.currentTranslationY + amount)
-    TrueSheetStackManager.getParentSheet(this)?.addTranslation(amount)
+    viewController.translateSheet(viewController.currentTranslationY + amount, animated)
+    TrueSheetStackManager.getParentSheet(this)?.addTranslation(amount, animated)
   }
 
   /**

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -162,6 +162,10 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   private var pendingDetentIndex: Int = -1
 
   private var interactionState: InteractionState = InteractionState.Idle
+
+  // A content/header/footer size change arrived mid-drag — reconfiguring then
+  // would reset behavior state and kill the gesture, so it's applied on settle.
+  private var hasPendingSizeChange = false
   internal var isBeingDismissed = false
     private set
   var wasHiddenByScreen = false
@@ -395,6 +399,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     sheetView = null
 
     interactionState = InteractionState.Idle
+    hasPendingSizeChange = false
     isBeingDismissed = false
     isPresented = false
     isSheetVisible = false
@@ -592,7 +597,15 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     // whether settled at the target, interrupted by drag, or superseded.
     pendingDetentIndex = -1
 
-    val index = detentCalculator.getDetentIndexForState(newState) ?: return
+    val index = detentCalculator.getDetentIndexForState(newState) ?: run {
+      // Unmapped settle — end any drag anyway so deferred size changes aren't
+      // dropped forever (a leaked Dragging state skips every reconfigure)
+      if (interactionState is InteractionState.Dragging) {
+        interactionState = InteractionState.Idle
+      }
+      flushPendingSizeChange()
+      return
+    }
     val position = getPositionDpForView(sheetView)
     val detentInfo = DetentInfo(index, position)
 
@@ -640,6 +653,14 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     }
 
     TrueSheetStackManager.updateBackgroundAccessibility()
+
+    flushPendingSizeChange()
+  }
+
+  private fun flushPendingSizeChange() {
+    if (!hasPendingSizeChange) return
+    hasPendingSizeChange = false
+    setupSheetDetentsForSizeChange()
   }
 
   // =============================================================================
@@ -925,10 +946,15 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   }
 
   fun setupSheetDetentsForSizeChange() {
-    // Skip while dragging — the size change is driven by the drag itself (the
+    // Defer while dragging — the size change is driven by the drag itself (the
     // container tracks the sheet's visible height), and reconfiguring resets
-    // behavior state, killing the gesture.
-    if (interactionState is InteractionState.Dragging) return
+    // behavior state, killing the gesture. Applied on settle so a real content
+    // change mid-drag (e.g. items removed from a list) isn't lost.
+    if (interactionState is InteractionState.Dragging) {
+      hasPendingSizeChange = true
+      return
+    }
+    hasPendingSizeChange = false
 
     setupSheetDetents()
     positionFooter()

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -37,6 +37,7 @@ import com.lodev09.truesheet.core.TrueSheetDimViewDelegate
 import com.lodev09.truesheet.core.TrueSheetKeyboardObserver
 import com.lodev09.truesheet.core.TrueSheetKeyboardObserverDelegate
 import com.lodev09.truesheet.core.TrueSheetStackManager
+import com.lodev09.truesheet.utils.Insets
 import com.lodev09.truesheet.utils.KeyboardUtils
 import com.lodev09.truesheet.utils.ScreenUtils
 import com.lodev09.truesheet.utils.TouchEventDeduper
@@ -277,9 +278,29 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   val screenWidth: Int
     get() = ScreenUtils.getScreenWidth(reactContext)
 
+  // Cached per layout/configuration pass — the WindowManager and
+  // rootWindowInsets queries behind these allocate, and they're read many
+  // times per animation frame (position emission, detent interpolation,
+  // stacked sheet sync)
+  private var cachedRealScreenHeight: Int = 0
+  private var cachedInsets: Insets? = null
+
+  private fun invalidateScreenMetrics() {
+    cachedRealScreenHeight = 0
+    cachedInsets = null
+  }
+
   // Includes system bars for accurate positioning
   override val realScreenHeight: Int
-    get() = ScreenUtils.getRealScreenHeight(reactContext)
+    get() {
+      if (cachedRealScreenHeight == 0) {
+        cachedRealScreenHeight = ScreenUtils.getRealScreenHeight(reactContext)
+      }
+      return cachedRealScreenHeight
+    }
+
+  private val insets: Insets
+    get() = cachedInsets ?: ScreenUtils.getInsets(reactContext).also { cachedInsets = it }
 
   // Content Measurements
   // Cached values used during dismiss when container is unmounted
@@ -322,10 +343,10 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   }
 
   val bottomInset: Int
-    get() = if (edgeToEdgeEnabled) ScreenUtils.getInsets(reactContext).bottom else 0
+    get() = if (edgeToEdgeEnabled) insets.bottom else 0
 
   override val topInset: Int
-    get() = if (edgeToEdgeEnabled) ScreenUtils.getInsets(reactContext).top else 0
+    get() = if (edgeToEdgeEnabled) insets.top else 0
 
   override val contentBottomInset: Int
     get() = if (insetAdjustment == TrueSheetInsetAdjustment.AUTOMATIC) bottomInset else 0
@@ -338,6 +359,9 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     }
 
   // Sheet State
+  val isSettling: Boolean
+    get() = behavior?.state == BottomSheetBehavior.STATE_SETTLING
+
   val isExpanded: Boolean
     get() {
       val sheetTop = sheetView?.top ?: return false
@@ -448,6 +472,8 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   // =============================================================================
 
   override fun coordinatorLayoutDidLayout(changed: Boolean) {
+    if (changed) invalidateScreenMetrics()
+
     // Reposition footer when layout changes
     if (isPresented && changed) {
       positionFooter()
@@ -455,6 +481,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   }
 
   override fun coordinatorLayoutDidChangeConfiguration() {
+    invalidateScreenMetrics()
     if (!isPresented) return
 
     sheetView?.updateGravity()
@@ -730,6 +757,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     val sheet = this.sheetView ?: return
     if (isPresented) return
 
+    invalidateScreenMetrics()
     shouldAnimatePresent = animated
     currentDetentIndex = detentIndex
     interactionState = InteractionState.Idle
@@ -1293,8 +1321,7 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     lastEmittedPositionPx = currentTop
     val visibleHeight = realScreenHeight - currentTop
     val position = detentCalculator.getPositionDp(visibleHeight)
-    val interpolatedIndex = detentCalculator.getInterpolatedIndexForPosition(currentTop)
-    val detent = detentCalculator.getInterpolatedDetentForPosition(currentTop)
+    val (interpolatedIndex, detent) = detentCalculator.getInterpolatedPositionInfo(currentTop)
     delegate?.viewControllerDidChangePosition(interpolatedIndex, position, detent, realtime)
   }
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -578,6 +578,14 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
     emitChangePositionDelegate(sheetView.top)
 
+    // Drive the parent's stack translation from our actual frame position —
+    // an independently-timed animation lags behind (e.g. auto detent shrink)
+    // and reveals the parent above this sheet's top edge. Skipped while
+    // dragging so the parent stays put during drag-to-dismiss.
+    if (!isPresentAnimating && interactionState !is InteractionState.Dragging) {
+      syncParentTranslation(sheetView.top)
+    }
+
     // Position on every slide frame — during keyboard transitions the IME
     // animation callbacks are sparser than the sheet's settle frames, and the
     // footer rides the sheet between them, jittering against the keyboard.
@@ -1365,8 +1373,26 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
     delegate?.viewControllerDidChangeSize(width, height)
   }
 
-  fun translateSheet(translationY: Int, onEnd: (() -> Unit)? = null) {
+  /**
+   * Realtime (non-animated) counterpart of TrueSheetStackManager.updateParentTranslation,
+   * driven by onSlide so the parent tracks this sheet's actual position.
+   */
+  private fun syncParentTranslation(sheetTop: Int) {
+    val parent = parentSheetView ?: return
+    val minSheetTop = detentCalculator.getSheetTopForDetentIndex(0)
+    parent.syncTranslationForChild(sheetTop, minSheetTop)
+  }
+
+  fun translateSheet(translationY: Int, animated: Boolean = true, onEnd: (() -> Unit)? = null) {
     val sheet = sheetView ?: return
+
+    if (!animated) {
+      sheet.animate().cancel()
+      sheet.translationY = translationY.toFloat()
+      emitChangePositionDelegate(sheet.top + translationY)
+      onEnd?.invoke()
+      return
+    }
 
     sheet.animate()
       .translationY(translationY.toFloat())

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
@@ -201,7 +201,7 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
    * Find which segment the position falls into for interpolation.
    * @return Triple(fromIndex, toIndex, progress) where progress is 0-1, or null if no detents
    */
-  fun findSegmentForPosition(positionPx: Int): Triple<Int, Int, Float>? {
+  private fun findSegmentForPosition(positionPx: Int): Triple<Int, Int, Float>? {
     val count = detents.size
     if (count == 0) return null
 
@@ -242,37 +242,23 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
   }
 
   /**
-   * Returns continuous index (e.g., 0.5 = halfway between detent 0 and 1).
+   * Returns interpolated continuous index (e.g., 0.5 = halfway between detent
+   * 0 and 1) and screen fraction for a position, sharing a single segment
+   * lookup — this runs on every position frame.
    */
-  fun getInterpolatedIndexForPosition(positionPx: Int): Float {
-    val count = detents.size
-    if (count == 0) return -1f
+  fun getInterpolatedPositionInfo(positionPx: Int): Pair<Float, Float> {
+    if (detents.isEmpty()) return Pair(-1f, 0f)
 
-    val segment = findSegmentForPosition(positionPx) ?: return 0f
-    val (fromIndex, _, progress) = segment
-
-    if (fromIndex == -1) return -progress
-    return fromIndex + progress
-  }
-
-  /**
-   * Returns interpolated screen fraction for position.
-   */
-  fun getInterpolatedDetentForPosition(positionPx: Int): Float {
-    val count = detents.size
-    if (count == 0) return 0f
-
-    val segment = findSegmentForPosition(positionPx) ?: return getDetentValueForIndex(0)
-    val (fromIndex, toIndex, progress) = segment
+    val (fromIndex, toIndex, progress) = findSegmentForPosition(positionPx)
+      ?: return Pair(0f, getDetentValueForIndex(0))
 
     if (fromIndex == -1) {
-      val firstDetent = getDetentValueForIndex(0)
-      return maxOf(0f, firstDetent * (1 - progress))
+      return Pair(-progress, maxOf(0f, getDetentValueForIndex(0) * (1 - progress)))
     }
 
     val fromDetent = getDetentValueForIndex(fromIndex)
     val toDetent = getDetentValueForIndex(toIndex)
-    return fromDetent + progress * (toDetent - fromDetent)
+    return Pair(fromIndex + progress, fromDetent + progress * (toDetent - fromDetent))
   }
 
   companion object {

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetDetentCalculator.kt
@@ -169,8 +169,12 @@ class TrueSheetDetentCalculator(private val reactContext: ThemedReactContext) {
    */
   private fun getDetentStateMap(): Map<Int, Int>? =
     when (detents.size) {
+      // With one detent halfExpandedRatio matches the peek height, so the
+      // behavior can settle HALF_EXPANDED at the same position (e.g. an upward
+      // drag release) — map it too, or the settle is unmappable
       1 -> mapOf(
         BottomSheetBehavior.STATE_COLLAPSED to 0,
+        BottomSheetBehavior.STATE_HALF_EXPANDED to 0,
         BottomSheetBehavior.STATE_EXPANDED to 0
       )
 


### PR DESCRIPTION
## Summary

When a child sheet resizes (auto detent content change), the parent's stack translation ran on an independently-timed 200ms animation that lagged behind the child's `BottomSheetBehavior` settle — revealing the parent above the child's top edge. The parent translation is now driven frame-by-frame from the child's `onSlide`, clamped between the current translation and the settled alignment (the child's min detent), so stacked sheets move in lockstep in both directions while the parent stays put when the child moves between detents above its minimum.

Also includes:
- **fix**: sheet stuck at stale detents after a half-expanded settle leaked the `Dragging` interaction state, silently dropping subsequent size-change reconfigures
- **perf**: skip the posted animated parent update while settling (`onSlide` already drives it), cache `realScreenHeight`/insets per layout/config pass instead of querying `WindowManager`/`rootWindowInsets` on every read, and interpolate index/detent with a single segment lookup per emitted position frame

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Example app MapScreen with a child sheet (auto detent), adding/removing content while presented — parent tracks the child's top edge with no gap, verified with a transparent child sheet
- Emitted `onPositionChange` values confirmed monotonic and per-frame via logcat during resize
- Drag-to-dismiss, detent changes above the minimum, keyboard show/hide, and stacked present/dismiss unaffected

## Screenshots / Videos

N/A

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)