### PR TITLE
docs(skills): update truesheet-usage skill for v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@
 ### 💡 Others
 
 - Upgrade the examples to Expo SDK 57 and React Native 0.86. ([#755](https://github.com/lodev09/react-native-true-sheet/pull/755) by [@lodev09](https://github.com/lodev09))
+- Update the `truesheet-usage` AI skill for the v4 API. ([#799](https://github.com/lodev09/react-native-true-sheet/pull/799) by [@lodev09](https://github.com/lodev09))

--- a/docs/docs/reference/03-methods.mdx
+++ b/docs/docs/reference/03-methods.mdx
@@ -125,7 +125,7 @@ If no sheets are presented on top, `dismissStack()` does nothing.
 
 ```tsx
 // Resize to 80%
-await TrueSheet.resize('my-sheet', 0.8)
+await TrueSheet.resize('my-sheet', 1)
 ```
 
 ### `dismissAll`

--- a/docs/versioned_docs/version-3.11.12/reference/03-methods.mdx
+++ b/docs/versioned_docs/version-3.11.12/reference/03-methods.mdx
@@ -125,7 +125,7 @@ If no sheets are presented on top, `dismissStack()` does nothing.
 
 ```tsx
 // Resize to 80%
-await TrueSheet.resize('my-sheet', 0.8)
+await TrueSheet.resize('my-sheet', 1)
 ```
 
 ### `dismissAll`

--- a/skills/truesheet-usage/SKILL.md
+++ b/skills/truesheet-usage/SKILL.md
@@ -5,15 +5,17 @@ description: >-
   Use this skill whenever the user wants to add, configure, control, or debug a bottom sheet using TrueSheet —
   including ref-based sheets, named global sheets, web support with TrueSheetProvider/useTrueSheet,
   React Navigation or Expo Router sheet flows, Reanimated-driven animations, scrolling content,
-  stacking, headers/footers, detents, side sheets, keyboard handling, dimming, liquid glass,
-  and Jest testing. Also use when the user is migrating from v2 to v3, troubleshooting layout or
+  stacking, headers/footers, detents, peeking, side sheets, keyboard handling, dimming, liquid glass,
+  and Jest testing. Also use when the user is migrating from v3 to v4, troubleshooting layout or
   gesture issues, or asking about any TrueSheet prop, event, or method — even if they don't
   mention "TrueSheet" by name but describe a bottom sheet in a React Native context.
 ---
 
 # TrueSheet Consumer Guide
 
-Use this skill to produce correct, idiomatic code for apps that consume `@lodev09/react-native-true-sheet`. It covers choosing the right integration pattern, applying the public API correctly, and avoiding platform-specific pitfalls.
+Use this skill to produce correct, idiomatic code for apps that consume `@lodev09/react-native-true-sheet` (v4). It covers choosing the right integration pattern, applying the public API correctly, and avoiding platform-specific pitfalls.
+
+Requires React Native >= 0.82 (Expo SDK 55+) with the New Architecture.
 
 ## Quick Start
 
@@ -41,6 +43,23 @@ export function App() {
 }
 ```
 
+## Content Layout (v4)
+
+The sheet's content lays out **naturally** — it wraps its children's height like a regular view or a React Navigation screen. It does **not** fill the sheet by default. Consequences:
+
+- A `flex: 1` child collapses to zero height unless the content is filled.
+- To fill the sheet's visible height per detent (spacers, centered content, bounded scroll views), pass `flex: 1` via the sheet's `style` prop:
+
+```tsx
+<TrueSheet style={{ flex: 1 }} detents={[0.5, 1]}>
+  <View style={{ flex: 1, justifyContent: 'center' }}>
+    <Text>Centered</Text>
+  </View>
+</TrueSheet>
+```
+
+The content is sized to the sheet's visible height per detent and tracks it in realtime while dragging, so flex layouts follow the sheet's edge frame-by-frame.
+
 ## Choose the Right Control Pattern
 
 Pick one based on where the trigger lives relative to the sheet and which platforms you target.
@@ -50,7 +69,7 @@ Pick one based on where the trigger lives relative to the sheet and which platfo
 | **Ref** | Trigger and sheet in the same component | All |
 | **Named + global methods** | Trigger is far from the sheet (different screen, deep in tree) | Native only |
 | **`TrueSheetProvider` + `useTrueSheet()`** | Web support needed, or you want hook-based control | All (required on web) |
-| **`createTrueSheetNavigator()`** | Sheets are part of a navigation flow | All |
+| **`createTrueSheetNavigator()` / Expo Router `Sheet`** | Sheets are part of a navigation flow | All |
 | **`ReanimatedTrueSheet`** | You need animated values synced to sheet position | All |
 
 ### Ref-based
@@ -78,7 +97,7 @@ Every `name` must be unique. Static methods don't exist on web — use the provi
 
 ### Web control with provider
 
-Wrap your app with `TrueSheetProvider` (on native this is a pass-through with zero overhead):
+Wrap your app with `TrueSheetProvider` (on native this is a pass-through with zero overhead). Web also needs `@radix-ui/react-dialog` and `@radix-ui/react-presence` installed (optional peer deps):
 
 ```tsx
 import { TrueSheet, TrueSheetProvider, useTrueSheet } from '@lodev09/react-native-true-sheet'
@@ -102,7 +121,7 @@ export function App() {
 
 ### Navigation (React Navigation / Expo Router)
 
-See [advanced patterns reference](./references/advanced-patterns.md#react-navigation) for full setup with `createTrueSheetNavigator`, Expo Router layouts, screen options, and `useTrueSheetNavigation`.
+See [advanced patterns reference](./references/advanced-patterns.md#react-navigation) for full setup with `createTrueSheetNavigator`, the static API (`createTrueSheetScreen`), the Expo Router `Sheet` layout from `/navigation/expo-router`, screen options, and `useTrueSheetNavigation`.
 
 ### Reanimated
 
@@ -110,11 +129,12 @@ See [advanced patterns reference](./references/advanced-patterns.md#reanimated) 
 
 ## Detents
 
-Detents define the heights the sheet can snap to. You get up to **3 detents**, sorted smallest to largest.
+Detents define the heights the sheet can snap to. You get up to **3 detents**, sorted smallest to largest. Default: `[0.5, 1]`.
 
 | Value | Meaning |
 |-------|---------|
-| `'auto'` | Size to fit the content (iOS 16+, Android, Web) |
+| `'auto'` | Size to fit the content (iOS 16+, Android, Web). Works with scrollables — sizes to the scroll content and resizes as it grows/shrinks |
+| `'peek'` | Collapsed height from the measured `header` + absolute `footer` + content through a `TrueSheetPeek` marker (iOS 16+, Android, Web). Falls back to `150` when none provided |
 | `0` – `1` | Fraction of the screen height |
 
 ```tsx
@@ -124,34 +144,39 @@ Detents define the heights the sheet can snap to. You get up to **3 detents**, s
 // Half and full screen
 <TrueSheet detents={[0.5, 1]} />
 
-// Three stops: peek, half, full
-<TrueSheet detents={[0.25, 0.5, 1]} />
+// Collapsed summary that expands to near-full
+<TrueSheet detents={['peek', 0.9]} />
 ```
-
-**The one rule you can't break:** never combine `'auto'` with `scrollable`. Auto-sizing needs to measure the full content, but a scrollable sheet clips it — they're fundamentally incompatible. Use fractional detents for scrollable sheets.
 
 ## Common Recipes
 
 ### Scrollable content
 
+Point the sheet at your scroll view with `scrollableRef`. For fixed detents, bound the scroll view with `flex: 1` on the sheet's `style`:
+
 ```tsx
-<TrueSheet detents={[0.5, 1]} scrollable cornerRadius={24} grabber>
-  <ScrollView>
+const scrollableRef = useRef<ScrollView>(null)
+
+<TrueSheet scrollableRef={scrollableRef} style={{ flex: 1 }} detents={[0.5, 1]} grabber>
+  <ScrollView ref={scrollableRef}>
     {items.map(item => <ItemRow key={item.id} item={item} />)}
   </ScrollView>
 </TrueSheet>
 ```
 
-- The `scrollable` prop auto-detects ScrollView/FlatList up to 2 levels deep
-- On iOS, scrolling to top expands to next detent — disable with `scrollableOptions={{ scrollingExpandsSheet: false }}`
-- On Android, nested scrolling is handled automatically
+- With `detents={['auto']}` no `flex: 1` is needed — the sheet sizes to the scroll content and bounds the viewport automatically
+- The scroll view doesn't have to be a direct child — a wrapping `View` works
+- Keyboard handling, nested scrolling (Android), and the bottom safe-area inset are wired automatically
+- Scrolling to top expands to the next detent — disable with `scrollableOptions={{ scrollingExpandsSheet: false }}` (YouTube-style comments)
+- The bottom safe-area inset is applied natively while content can scroll — don't add manual safe-area padding, or opt out with `scrollableOptions={{ contentInsetAdjustmentBehavior: false }}`
 
 ### Fixed header and footer
 
 ```tsx
 <TrueSheet
   detents={[0.5, 1]}
-  scrollable
+  scrollableRef={scrollableRef}
+  style={{ flex: 1 }}
   header={
     <View style={{ padding: 16 }}>
       <Text style={{ fontSize: 18, fontWeight: 'bold' }}>Title</Text>
@@ -159,11 +184,30 @@ Detents define the heights the sheet can snap to. You get up to **3 detents**, s
   }
   footer={<BottomActions />}
 >
-  <ScrollView>{/* ... */}</ScrollView>
+  <ScrollView ref={scrollableRef}>{/* ... */}</ScrollView>
 </TrueSheet>
 ```
 
-Use the `header` and `footer` props — they render in native container views, so the layout math is handled for you. Don't fake it with absolute positioning.
+- Use the `header` and `footer` props — they render in native container views, so the layout math is handled for you. Don't fake it with absolute positioning.
+- Both are **relative** by default: header takes space above the content, footer below it, and both count toward the `'auto'` detent.
+- The footer **absorbs the bottom safe-area inset** natively — remove manual `paddingBottom: insets.bottom` from footer content or it doubles up. Set the footer background via `footerStyle` so it fills the inset.
+- A relative footer is laid out below the content — with fixed detents, bound the content with `flex: 1` (sheet `style`) so the footer stays visible.
+- To float them over the content instead (excluded from `'auto'` height), use `headerOptions={{ position: 'absolute' }}` / `footerOptions={{ position: 'absolute' }}`. An absolute footer rises above the keyboard; a relative one stays in the layout flow behind it.
+
+### Peeking (map-style collapsed sheet)
+
+```tsx
+import { TrueSheet, TrueSheetPeek } from '@lodev09/react-native-true-sheet'
+
+<TrueSheet detents={['peek', 0.9]} initialDetentIndex={0} header={<Summary />}>
+  <TrueSheetPeek>
+    <QuickActions />
+  </TrueSheetPeek>
+  <FullDetails />
+</TrueSheet>
+```
+
+Collapsed, the sheet shows everything from the top through the **bottom edge** of `TrueSheetPeek`; content below stays hidden until expanded. An empty `<TrueSheetPeek />` works as a fold marker between existing views. One peek component per sheet. Absolute footers count toward the peek height; relative footers don't (pushed off-screen at peek).
 
 ### Non-dismissible confirmation
 
@@ -228,31 +272,37 @@ await sheet.current?.resize(2) // expands to full (index 2)
 ## Rules That Save Debugging Time
 
 1. **Max 3 detents**, sorted smallest → largest.
-2. **Never `'auto'` + `scrollable`** — they're incompatible.
-3. **`resize()` takes an index**, not a fraction. `resize(1)` means "go to the second detent."
-4. **Sheet names must be unique** across your entire app.
-5. **Static methods are native-only** — use `useTrueSheet()` on web.
-6. **Don't use `autoFocus` on TextInputs** inside sheets. Focus in `onDidPresent` instead:
+2. **Content doesn't fill the sheet by default** — pass `style={{ flex: 1 }}` on the sheet when children use `flex: 1`, or they render with zero height.
+3. **`scrollableRef` replaces the v3 `scrollable` prop** — pass a ref of the ScrollView/FlatList. Bound it with `flex: 1` on the sheet `style` for fixed detents; `'auto'` needs no flex.
+4. **`resize()` takes an index**, not a fraction. `resize(1)` means "go to the second detent."
+5. **Sheet names must be unique** across your entire app.
+6. **Static methods are native-only** — use `useTrueSheet()` on web.
+7. **Don't add manual safe-area padding** to footers or plugged scroll content — the footer absorbs the bottom inset and the scrollable gets it natively. Doubling up is the most common v4 layout bug.
+8. **Don't use `autoFocus` on TextInputs** inside sheets. Focus in `onDidPresent` instead:
    ```tsx
    <TrueSheet onDidPresent={() => inputRef.current?.focus()}>
    ```
-7. **Use `flexGrow: 1`** (not `flex: 1`) inside `GestureHandlerRootView` on Android.
-8. **Dismiss sheets before closing Modals** on iOS — React Native has a bug where dismissing a Modal while a sheet is visible causes a blank screen.
-9. **Use `header`/`footer` props** for fixed chrome — don't reach for absolute positioning.
-10. **Liquid Glass** is automatic on iOS 26+. Set `backgroundColor` to disable it per-sheet, or add `UIDesignRequiresCompatibility` to Info.plist to disable app-wide.
+9. **Use `flexGrow: 1`** (not `flex: 1`) on `GestureHandlerRootView` inside the sheet on Android — unless the sheet itself has `style={{ flex: 1 }}`.
+10. **Dismiss sheets before closing Modals** on iOS — React Native has a bug where dismissing a Modal while a sheet is visible causes a blank screen.
+11. **Use `header`/`footer` props** for fixed chrome — don't reach for absolute positioning. Float them with `headerOptions`/`footerOptions` `position: 'absolute'` when they should overlay content.
+12. **Liquid Glass** is automatic on iOS 26+. Set `backgroundColor` or `backgroundBlur` to disable it per-sheet (iOS 26.1+), or add `UIDesignRequiresCompatibility` to Info.plist to disable app-wide.
 
 ## Platform Differences at a Glance
 
 | Feature | iOS | Android | Web |
 |---------|-----|---------|-----|
 | `'auto'` detent | iOS 16+ | Yes | Yes |
+| `'peek'` detent / `TrueSheetPeek` | iOS 16+ | Yes | Yes |
 | `backgroundBlur` | Yes | No | No |
 | Liquid Glass | iOS 26+ | No | No |
 | Static global methods | Yes | Yes | No (use provider) |
-| `scrollable` | Yes | Yes | No |
+| `scrollableRef` | Yes | Yes | Yes |
+| Scroll edge effects | iOS 26+ | No | No |
+| `grabberOptions` | Yes | Yes | No |
 | `anchor` / side sheets | System-controlled margins | `anchorOffset` prop | `anchorOffset` prop |
 | `presentation` | iOS 17+ (iPad) | N/A | Landscape/tablet |
 | `detached` mode | No | No | Yes |
+| `insetAdjustment` | Yes | Yes | No |
 | Edge-to-edge | N/A | Auto-detected | N/A |
 | Keyboard handling | Built-in | Built-in | N/A |
 
@@ -306,5 +356,5 @@ When you need the full picture, load these reference files:
 |-----------|--------------|
 | [Configuration](./references/configuration.md) | Every prop with type, default, platform support, and notes |
 | [API](./references/api.md) | Complete events and methods reference with payload types |
-| [Advanced Patterns](./references/advanced-patterns.md) | Navigation, Reanimated, Web, Side sheets, Liquid Glass, Jest mocking, Migration v2→v3 |
+| [Advanced Patterns](./references/advanced-patterns.md) | Navigation, Reanimated, Web, Side sheets, Liquid Glass, Jest mocking, Migration v3→v4 |
 | [Troubleshooting](./references/troubleshooting.md) | Common issues and fixes by platform |

--- a/skills/truesheet-usage/references/advanced-patterns.md
+++ b/skills/truesheet-usage/references/advanced-patterns.md
@@ -13,13 +13,21 @@ Deeper integration guides for Navigation, Reanimated, Web, Side sheets, Liquid G
 - [Overlays on sheets](#overlays-on-sheets)
 - [Edge-to-edge (Android)](#edge-to-edge-android)
 - [Jest testing](#jest-testing)
-- [Migration v2 → v3](#migration-v2--v3)
+- [Migration v3 → v4](#migration-v3--v4)
 
 ---
 
 ## React Navigation
 
-Use `createTrueSheetNavigator()` to treat sheets as screens in your navigation tree.
+Use `createTrueSheetNavigator()` to treat sheets as screens in your navigation tree. The first screen (or `initialRouteName`) is the base content; other screens present as sheets.
+
+### Requirements
+
+The navigator is built on `standard-navigation`, so one implementation works with both React Navigation and Expo Router. Install the optional peers:
+
+```sh
+yarn add @react-navigation/native@^7.3.0 standard-navigation
+```
 
 ### Setup
 
@@ -51,6 +59,29 @@ function App() {
 }
 ```
 
+To present sheets from anywhere, wrap your root stack: `<Sheet.Screen name="Root" component={RootStack} />` plus sheet screens as siblings.
+
+### Static API
+
+React Navigation's [static configuration](https://reactnavigation.org/docs/static-configuration) is supported via `createTrueSheetScreen`:
+
+```tsx
+import {
+  createTrueSheetNavigator,
+  createTrueSheetScreen,
+} from '@lodev09/react-native-true-sheet/navigation'
+
+const Sheet = createTrueSheetNavigator({
+  screens: {
+    Main: MainScreen,
+    Details: createTrueSheetScreen({
+      screen: DetailsSheet,
+      options: { detents: ['auto', 1] },
+    }),
+  },
+})
+```
+
 ### Screen options
 
 All TrueSheet props are available as screen `options`, plus:
@@ -58,8 +89,10 @@ All TrueSheet props are available as screen `options`, plus:
 | Option | Type | Description |
 |--------|------|-------------|
 | `detentIndex` | `number` | Initial detent when the sheet presents (default: `0`) |
-| `reanimated` | `boolean` | Enable worklet-based position tracking |
-| `positionChangeHandler` | `worklet` | Worklet called on position changes (requires `reanimated: true`) |
+| `reanimated` | `boolean` | Enable worklet-based position events for this screen |
+| `positionChangeHandler` | `function` | Callback for position change events. Must be a worklet when `reanimated: true` |
+
+The reanimated integration is lazy-loaded — screens without `reanimated: true` don't require `react-native-reanimated`.
 
 ### `useTrueSheetNavigation()` hook
 
@@ -69,7 +102,7 @@ const navigation = useTrueSheetNavigation()
 navigation.resize(1)         // resize to a detent
 navigation.goBack()          // dismiss current sheet
 
-// Dynamic options
+// Dynamic options — any TrueSheet prop (header, footer, grabber, dismissible, ...)
 navigation.setOptions({
   footer: <UpdatedFooter />,
 })
@@ -78,29 +111,34 @@ navigation.setOptions({
 ### Screen event listeners
 
 ```tsx
-navigation.addListener('sheetDidPresent', (e) => {})
-navigation.addListener('sheetDetentChange', (e) => {})
+navigation.addListener('sheetDidPresent', (e) => {
+  console.log(e.data.index)
+})
 ```
 
-Available events: `sheetWillPresent`, `sheetDidPresent`, `sheetWillDismiss`, `sheetDidDismiss`, `sheetDetentChange`, `sheetDragBegin`, `sheetDragChange`, `sheetDragEnd`, `sheetPositionChange`.
+Also available as `screenListeners` on the navigator or `listeners` on a screen. Events: `sheetWillPresent`, `sheetDidPresent`, `sheetWillDismiss`, `sheetDidDismiss`, `sheetDetentChange`, `sheetDragBegin`, `sheetDragChange`, `sheetDragEnd`, `sheetPositionChange`.
+
+### Navigating from sheets
+
+Sheets remain visible when presenting screens on top — `navigation.navigate('SomeScreen')` works directly, no dismissing first. This requires a [patch to react-native-screens](https://github.com/lodev09/react-native-true-sheet/blob/main/.yarn/patches/react-native-screens-npm-4.25.2.patch) (see [PR #3415](https://github.com/software-mansion/react-native-screens/pull/3415)). On Expo SDK 56+ EAS builds the patch is silently dropped — see [Troubleshooting](./troubleshooting.md#patched-react-native-screens-not-applied-on-eas).
 
 ### Web caveat
 
-On web, navigation-based sheets need `useFocusEffect` to trigger present/dismiss since the native lifecycle differs.
+Sheet visibility during navigation relies on `react-native-screens` detection, which isn't supported on web. Use `useFocusEffect` to present/dismiss manually when the screen gains/loses focus.
 
 ---
 
 ## Expo Router
 
-Use `withLayoutContext` to create an Expo Router-compatible layout:
+v4 ships a ready-to-use `Sheet` layout via the `/navigation/expo-router` entry point — no `withLayoutContext` wrapper and no `@react-navigation/*` install needed. Requires Expo SDK 57+ and the `standard-navigation` optional peer:
+
+```sh
+yarn add standard-navigation
+```
 
 ```tsx
-// app/sheet/_layout.tsx
-import { withLayoutContext } from 'expo-router'
-import { createTrueSheetNavigator } from '@lodev09/react-native-true-sheet/navigation'
-
-const { Navigator } = createTrueSheetNavigator()
-const Sheet = withLayoutContext(Navigator)
+// app/_layout.tsx
+import { Sheet } from '@lodev09/react-native-true-sheet/navigation/expo-router'
 
 export default function SheetLayout() {
   return (
@@ -114,6 +152,14 @@ export default function SheetLayout() {
   )
 }
 ```
+
+Inside sheet screens, import the hook from the **same entry point**:
+
+```tsx
+import { useTrueSheetNavigation } from '@lodev09/react-native-true-sheet/navigation/expo-router'
+```
+
+All navigator features (screen options, reanimated, dynamic header/footer via `setOptions`, listeners) apply here too.
 
 ---
 
@@ -145,6 +191,8 @@ import { ReanimatedTrueSheet } from '@lodev09/react-native-true-sheet/reanimated
 </ReanimatedTrueSheet>
 ```
 
+Note: `onPositionChange` on `ReanimatedTrueSheet` runs on the UI thread — if you override it, add the `'worklet'` directive to your handler.
+
 ### Animated values
 
 Access shared values from anywhere inside the provider:
@@ -173,6 +221,14 @@ function AnimatedBackdrop() {
 
 ## Web
 
+### Installation
+
+Web needs the underlying dialog primitives, declared as optional peer dependencies:
+
+```sh
+yarn add @radix-ui/react-dialog @radix-ui/react-presence
+```
+
 ### Provider (required on web, pass-through on native)
 
 ```tsx
@@ -189,7 +245,7 @@ function App() {
 
 ### Control via hook
 
-Static methods (`TrueSheet.present`, etc.) don't work on web. Use the hook:
+Static methods (`TrueSheet.present`, etc.) don't work on web. Use refs, or the hook:
 
 ```tsx
 const { present, dismiss, dismissAll, dismissStack, resize } = useTrueSheet()
@@ -235,7 +291,7 @@ Liquid Glass is the frosted glass visual effect introduced in iOS 26. It's autom
 
 **When it activates:** iOS 26+ with no `backgroundColor` and no `backgroundBlur` set.
 
-**Disable per-sheet:**
+**Disable per-sheet (iOS 26.1+):** set `backgroundColor` and/or `backgroundBlur`:
 ```tsx
 <TrueSheet backgroundColor="#ffffff">
 ```
@@ -245,6 +301,8 @@ Liquid Glass is the frosted glass visual effect introduced in iOS 26. It's autom
 <key>UIDesignRequiresCompatibility</key>
 <true/>
 ```
+
+Or via Expo config: `expo.ios.infoPlist.UIDesignRequiresCompatibility: true`. This disables Liquid Glass for the entire app, not just sheets.
 
 ---
 
@@ -297,6 +355,10 @@ jest.mock('@lodev09/react-native-true-sheet/navigation', () =>
   require('@lodev09/react-native-true-sheet/navigation/mock')
 )
 
+jest.mock('@lodev09/react-native-true-sheet/navigation/expo-router', () =>
+  require('@lodev09/react-native-true-sheet/navigation/expo-router/mock')
+)
+
 jest.mock('@lodev09/react-native-true-sheet/reanimated', () =>
   require('@lodev09/react-native-true-sheet/reanimated/mock')
 )
@@ -306,18 +368,21 @@ jest.mock('@lodev09/react-native-true-sheet/reanimated', () =>
 
 ```json
 {
-  "setupFilesAfterSetup": ["<rootDir>/jest.setup.js"],
+  "setupFilesAfterEnv": ["<rootDir>/jest.setup.js"],
   "transformIgnorePatterns": [
     "node_modules/(?!(react-native|@react-native|@lodev09/react-native-true-sheet)/)"
   ]
 }
 ```
 
+`transformIgnorePatterns` is required because the mock files use ESM syntax.
+
 ### Available mocks
 
-- `TrueSheet`, `TrueSheetProvider`, `useTrueSheet`
-- `createTrueSheetNavigator`, `useTrueSheetNavigation`
-- `ReanimatedTrueSheet`, `ReanimatedTrueSheetProvider`, `useReanimatedTrueSheet`
+- `/mock`: `TrueSheet` (mocked `present`/`dismiss`/`resize`), `TrueSheetProvider`, `useTrueSheet`
+- `/navigation/mock`: `createTrueSheetNavigator`, `createTrueSheetScreen`, `TrueSheetActions`, `useTrueSheetNavigation`
+- `/navigation/expo-router/mock`: `Sheet` (pass-through with `Screen` and `Protected`), `TrueSheetActions`, `useTrueSheetNavigation`
+- `/reanimated/mock`: `ReanimatedTrueSheet`, `ReanimatedTrueSheetProvider`, `useReanimatedTrueSheet`, `useReanimatedPositionChangeHandler`
 
 Static methods are jest mocks, so you can assert on them:
 
@@ -325,50 +390,67 @@ Static methods are jest mocks, so you can assert on them:
 expect(TrueSheet.present).toHaveBeenCalledWith('my-sheet', 0)
 ```
 
+All mocked methods return resolved Promises — `await` them in tests, and `jest.clearAllMocks()` between tests.
+
 ---
 
-## Migration v2 → v3
+## Migration v3 → v4
+
+v4 rewrites the layout engine — the sheet lays out synchronously per detent with Yoga owning all frames. Upgrading from v2? Migrate to v3 first (prop renames: `sizes`→`detents`, `onPresent`→`onDidPresent`, `onSizeChange`→`onDetentChange`, `FooterComponent`→`footer`, percentage strings→fractions).
 
 ### Requirements
 
-- React Native >= 0.76 (Expo SDK 52+)
-- New Architecture enabled (default in RN 0.76+)
+- React Native >= 0.82 (Expo SDK 55+), New Architecture enabled
+- Sheet Navigator: `@react-navigation/native` 7.3+ and `standard-navigation`
+- Expo Router: Expo SDK 57+ and `standard-navigation`
 
-### Prop renames
-
-| v2 | v3 |
-|----|----|
-| `sizes` | `detents` |
-| `initialIndex` | `initialDetentIndex` |
-| `initialIndexAnimated` | `initialDetentAnimated` |
-| `FooterComponent` | `footer` |
-| `onPresent` | `onDidPresent` |
-| `onDismiss` | `onDidDismiss` |
-| `onSizeChange` | `onDetentChange` |
-| `dimmedIndex` | `dimmedDetentIndex` |
-
-### Removed props
-
-| v2 prop | What to do in v3 |
-|---------|-----------------|
-| `grabberProps` | Use `grabber: true` with `grabberOptions` |
-| `scrollRef` | Use `scrollable: true` — auto-detected |
-| `contentContainerStyle` | No longer needed |
-| `edgeToEdge` | Auto-detected on Android |
-
-### Detent value format
+### 1. `scrollable` → `scrollableRef`
 
 ```tsx
-// v2
-sizes={["50%", "80%", "100%"]}
+// ❌ v3
+<TrueSheet scrollable detents={[0.5, 1]}>
+  <ScrollView>{/* ... */}</ScrollView>
+</TrueSheet>
 
-// v3
-detents={[0.5, 0.8, 1]}
+// ✅ v4 — plug the scroll view, bound it with flex: 1
+<TrueSheet scrollableRef={scrollableRef} style={{ flex: 1 }} detents={[0.5, 1]}>
+  <ScrollView ref={scrollableRef}>{/* ... */}</ScrollView>
+</TrueSheet>
+
+// ✅ v4 — 'auto' now works with scrollables, no flex needed
+<TrueSheet scrollableRef={scrollableRef} detents={['auto']}>
+  <ScrollView ref={scrollableRef}>{/* ... */}</ScrollView>
+</TrueSheet>
 ```
 
-### Behavioral changes
+### 2. Content lays out naturally
 
-- **`backgroundColor`** defaults to system (transparent on iOS) instead of white
-- **`backgroundBlur`** now applies over `backgroundColor` instead of replacing it
-- **Safe area** is handled natively — the sheet is taller than the detent fraction to account for the bottom inset. Footer components should add bottom safe area padding themselves
-- **Event system** expanded: lifecycle events now have will/did pairs, plus focus/blur events for stacking
+Content wraps its children's height instead of filling the sheet. If your layout relied on filling (spacers, centered content, bounded scroll views), pass `flex: 1` via the sheet's `style` prop.
+
+### 3. Footer is relative by default
+
+The footer now takes space below the content (still pinned to the bottom edge) and counts toward the `'auto'` detent. To restore the v3 floating behavior:
+
+```tsx
+<TrueSheet footer={<MyFooter />} footerOptions={{ position: 'absolute' }}>
+```
+
+`footerOptions.keyboardOffset` only applies to absolute footers — a relative footer stays behind the keyboard.
+
+### 4. Safe-area padding is now native
+
+- The footer absorbs the bottom safe-area inset — remove manual `useSafeAreaInsets()` padding from footers.
+- A plugged scrollable gets the bottom inset natively while it can scroll — remove manual padding, or opt out with `scrollableOptions={{ contentInsetAdjustmentBehavior: false }}`.
+
+### 5. Navigation entry points
+
+- React Navigation: install `standard-navigation`, bump `@react-navigation/native` to 7.3+. API is unchanged. Static API now available via `createTrueSheetScreen`.
+- Expo Router: replace the `withLayoutContext` wrapper with the `Sheet` layout from `/navigation/expo-router`, and import `useTrueSheetNavigation` from that entry point.
+
+### New in v4
+
+- `'auto'` detent works with scrollables
+- `'peek'` detent + `TrueSheetPeek` component
+- `headerOptions` (floating header)
+- `accessibilityOptions`
+- Synchronous per-detent layout — flex layouts track the sheet edge frame-by-frame while dragging

--- a/skills/truesheet-usage/references/configuration.md
+++ b/skills/truesheet-usage/references/configuration.md
@@ -11,6 +11,7 @@ Every TrueSheet prop with type, default value, and platform support.
 - [Appearance](#appearance)
 - [Blur](#blur)
 - [Grabber](#grabber)
+- [Accessibility](#accessibility)
 - [Interaction](#interaction)
 - [Dimming](#dimming)
 - [Header and Footer](#header-and-footer)
@@ -32,24 +33,32 @@ Every TrueSheet prop with type, default value, and platform support.
 
 | Prop | Type | Default | Platforms | Description |
 |------|------|---------|-----------|-------------|
-| `detents` | `SheetDetent[]` | — | 🍎🤖🌐 | Up to 3 snap heights, sorted smallest → largest. Values: `'auto'` or `0`–`1` |
+| `detents` | `SheetDetent[]` | `[0.5, 1]` | 🍎🤖🌐 | Up to 3 snap heights, sorted smallest → largest. Values: `'auto'`, `'peek'`, or `0`–`1` |
 | `maxContentHeight` | `number` | — | 🍎🤖🌐 | Absolute max height in dp |
-| `maxContentWidth` | `number` | 640 | 🤖🌐 | Max width. On Android/Web defaults to 640dp |
+| `maxContentWidth` | `number` | — | 🍎🤖🌐 | Max width. Android/Web default to 640dp; iOS uses the system width. Ignored on phones in portrait |
+
+**`SheetDetent` values:**
+
+| Value | Platforms | Description |
+|-------|-----------|-------------|
+| `'auto'` | 🍎 16+ 🤖🌐 | Size to the content's natural height. With a plugged scrollable, sizes to the scroll content and resizes as it grows/shrinks |
+| `'peek'` | 🍎 16+ 🤖🌐 | Collapsed height from the measured `header` + absolute `footer` + content through the bottom edge of a `TrueSheetPeek` component. Falls back to `150` when none provided |
+| `number` | 🍎🤖🌐 | Fraction (0–1) of the screen height |
 
 ## Appearance
 
 | Prop | Type | Default | Platforms | Description |
 |------|------|---------|-----------|-------------|
-| `backgroundColor` | `ColorValue` | System default | 🍎🤖🌐 | Sheet background. On iOS 26+, setting this disables Liquid Glass |
-| `cornerRadius` | `number` | System default | 🍎🤖🌐 | Corner radius of the sheet |
+| `backgroundColor` | `ColorValue` | System default | 🍎🤖🌐 | Sheet background. On iOS 26.1+, setting this overrides Liquid Glass. Android default is Material 3 `colorSurfaceContainerLow` (adapts to light/dark) |
+| `cornerRadius` | `number` | System default | 🍎🤖🌐 | Corner radius. iOS uses the device's native radius; Android defaults to `16` (Material 3) |
 | `elevation` | `number` | 4 | 🤖🌐 | Shadow depth |
-| `style` | `ViewStyle` | — | 🍎🤖🌐 | Container style override |
+| `style` | `ViewStyle` | — | 🍎🤖🌐 | Content style override. Content wraps its children's height by default — pass `flex: 1` to fill the sheet's visible height per detent |
 
 ## Blur
 
 | Prop | Type | Default | Platforms | Description |
 |------|------|---------|-----------|-------------|
-| `backgroundBlur` | `BackgroundBlur` | — | 🍎 | iOS blur effect applied to the sheet background |
+| `backgroundBlur` | `BackgroundBlur` | — | 🍎 | iOS blur effect applied over `backgroundColor`. On iOS 26.1+, setting this overrides Liquid Glass |
 | `blurOptions` | `BlurOptions` | — | 🍎 | Fine-tune blur intensity and interaction |
 
 **`BackgroundBlur` values:** `'light'`, `'dark'`, `'default'`, `'extra-light'`, `'regular'`, `'prominent'`, `'system-ultra-thin-material'`, `'system-thin-material'`, `'system-material'`, `'system-thick-material'`, `'system-chrome-material'`, plus `-light` and `-dark` variants of each system material.
@@ -57,8 +66,8 @@ Every TrueSheet prop with type, default value, and platform support.
 **`BlurOptions`:**
 ```tsx
 {
-  intensity?: number   // 0–100 (default: system)
-  interaction?: boolean // allow touches through blur (default: true)
+  intensity?: number    // 0–100 (default: system)
+  interaction?: boolean // allow touches through blur (default: true). Disabling can help with visual artifacts on iOS 18+
 }
 ```
 
@@ -66,8 +75,8 @@ Every TrueSheet prop with type, default value, and platform support.
 
 | Prop | Type | Default | Platforms | Description |
 |------|------|---------|-----------|-------------|
-| `grabber` | `boolean` | `true` | 🍎🤖🌐 | Show the native drag handle |
-| `grabberOptions` | `GrabberOptions` | — | 🍎🤖🌐 | Customize grabber appearance |
+| `grabber` | `boolean` | `true` | 🍎🤖🌐 | Show the native drag handle. Auto-hidden when `draggable` is `false` |
+| `grabberOptions` | `GrabberOptions` | — | 🍎🤖 | Customize grabber appearance. On iOS, providing any option replaces the system grabber with a custom vibrancy view |
 
 **`GrabberOptions`:**
 ```tsx
@@ -77,16 +86,38 @@ Every TrueSheet prop with type, default value, and platform support.
   topMargin?: number    // iOS: 5, Android: 16
   cornerRadius?: number // default: height / 2
   color?: ColorValue
-  adaptive?: boolean    // auto-contrast against background (default: true)
+  adaptive?: boolean    // auto-contrast against light/dark mode (default: true)
 }
 ```
+
+## Accessibility
+
+| Prop | Type | Default | Platforms | Description |
+|------|------|---------|-----------|-------------|
+| `accessibilityOptions` | `AccessibilityOptions` | — | 🍎🤖🌐 | Customize/localize screen-reader strings |
+
+**`AccessibilityOptions`:**
+```tsx
+{
+  grabberLabel?: string        // iOS: 'Sheet Grabber', Android: 'Drag handle'
+  grabberHint?: string         // iOS only
+  expandedValue?: string       // announced at the last detent (default: 'Expanded')
+  collapsedValue?: string      // announced at the first detent (default: 'Collapsed')
+  detentValue?: string         // intermediate detents; supports {index} and {count} (default: 'Detent {index} of {count}')
+  expandActionLabel?: string   // Android only (default: 'Expand')
+  collapseActionLabel?: string // Android only (default: 'Collapse')
+  paneTitle?: string           // Android pane title / Web hidden dialog title
+}
+```
+
+On iOS, grabber strings only apply when `grabberOptions` is provided (the system grabber is already localized).
 
 ## Interaction
 
 | Prop | Type | Default | Platforms | Description |
 |------|------|---------|-----------|-------------|
-| `dismissible` | `boolean` | `true` | 🍎🤖🌐 | Whether the user can swipe to dismiss |
-| `draggable` | `boolean` | `true` | 🍎🤖🌐 | Whether the user can drag to resize |
+| `dismissible` | `boolean` | `true` | 🍎🤖🌐 | Whether the user can swipe to dismiss or tap outside |
+| `draggable` | `boolean` | `true` | 🍎🤖🌐 | Whether the user can drag to resize. When `false`, the grabber is hidden |
 
 ## Dimming
 
@@ -99,31 +130,57 @@ Every TrueSheet prop with type, default value, and platform support.
 
 | Prop | Type | Default | Platforms | Description |
 |------|------|---------|-----------|-------------|
-| `header` | `ReactElement` | — | 🍎🤖🌐 | Fixed header rendered above content in a native container. Height is auto-deducted from available space |
+| `header` | `ReactElement \| ComponentType` | — | 🍎🤖🌐 | Fixed header rendered in a native container. Prefer passing an element over a component for perf |
 | `headerStyle` | `ViewStyle` | — | 🍎🤖🌐 | Style for header container |
-| `footer` | `ReactElement \| ComponentType` | — | 🍎🤖🌐 | Fixed footer below content. Prefer passing an element over a component for perf |
-| `footerStyle` | `ViewStyle` | — | 🍎🤖🌐 | Style for footer container |
+| `headerOptions` | `HeaderOptions` | — | 🍎🤖🌐 | Header layout behavior |
+| `footer` | `ReactElement \| ComponentType` | — | 🍎🤖🌐 | Fixed footer pinned to the sheet's bottom edge. Prefer passing an element over a component for perf |
+| `footerStyle` | `ViewStyle` | — | 🍎🤖🌐 | Style for footer container. Set the background here so it fills the safe-area inset |
+| `footerOptions` | `FooterOptions` | — | 🍎🤖🌐 | Footer layout and keyboard behavior |
+
+**`HeaderOptions`:**
+```tsx
+{
+  position?: 'relative' | 'absolute' // default: 'relative'
+}
+```
+- `'relative'`: takes space above the content, included in the `'auto'` detent height.
+- `'absolute'`: floats over the content, pinned to the top edge, excluded from `'auto'`. Add top padding to your content so it starts below the header.
+
+**`FooterOptions`:**
+```tsx
+{
+  position?: 'relative' | 'absolute' // default: 'relative'
+  keyboardOffset?: number            // default: 0 — absolute footers only
+}
+```
+- `'relative'`: takes space below the content, included in `'auto'` but **excluded from `'peek'`** (pushed off-screen at peek). Stays in the layout flow behind the keyboard. If content is taller than the sheet (fixed detents), bound it with `flex: 1` on the sheet `style` so the footer stays visible.
+- `'absolute'`: floats over the content, excluded from `'auto'` but **included in `'peek'`**, and rises above the keyboard. Add bottom padding to your content so it ends above the footer.
+- `keyboardOffset` adjusts how far an absolute footer rises with the keyboard. Negative values tuck the footer's own bottom padding behind the keyboard.
+
+**Safe area:** the footer absorbs the bottom safe-area inset as padding when `insetAdjustment` is `'automatic'` — don't add manual `paddingBottom: insets.bottom` or it doubles up. While the keyboard is open, an absolute footer skips the inset (no gap above the keyboard).
 
 ## Scrolling
 
 | Prop | Type | Default | Platforms | Description |
 |------|------|---------|-----------|-------------|
-| `scrollable` | `boolean` | — | 🍎🤖 | Auto-pins ScrollView/FlatList to fit available space. Cannot be used with `'auto'` detent |
-| `scrollableOptions` | `ScrollableOptions` | — | 🍎🤖 | Fine-tune scroll behavior |
+| `scrollableRef` | `RefObject<Component>` | — | 🍎🤖🌐 | Ref to the ScrollView/FlatList inside the content. Wires nested scrolling, keyboard insets, and `'auto'` detent sizing. Replaces the v3 `scrollable` prop |
+| `scrollableOptions` | `ScrollableOptions` | — | 🍎🤖🌐 | Fine-tune scrollable behavior |
 
 **`ScrollableOptions`:**
 ```tsx
 {
-  scrollingExpandsSheet?: boolean       // Scrolling to top expands sheet (default: true)
-  keyboardScrollOffset?: number         // Extra spacing above keyboard (default: 0)
-  topScrollEdgeEffect?: ScrollEdgeEffect   // iOS 26+
-  bottomScrollEdgeEffect?: ScrollEdgeEffect // iOS 26+
+  contentInsetAdjustmentBehavior?: boolean  // apply bottom safe-area inset to scroll content while it can scroll (default: true)
+  scrollingExpandsSheet?: boolean           // scrolling to top expands the sheet (default: true)
+  keyboardScrollOffset?: number             // extra spacing above keyboard when scrolling to a focused input (default: 0)
+  keyboardOffset?: number                   // adjust the keyboard bottom inset; pass -insets.bottom to cancel manual padding (default: 0)
+  topScrollEdgeEffect?: ScrollEdgeEffect    // iOS 26+, applies to header + scroll top edge
+  bottomScrollEdgeEffect?: ScrollEdgeEffect // iOS 26+, applies to footer + scroll bottom edge
 }
 ```
 
-**`ScrollEdgeEffect`:** `'automatic'` | `'hard'` | `'soft'` | `'hidden'` (default: `'hidden'`)
+**`ScrollEdgeEffect`:** `'automatic'` | `'hard'` | `'soft'` | `'hidden'` (default: `'hidden'`). iOS 26+ only.
 
-**Web scrolling:** The `scrollable` prop is currently native-only. On web, wrap content in a standard scrollable container.
+Like any scroll view, a plugged scrollable needs a bounded height for fixed detents — pass `flex: 1` via the sheet's `style`. With an `'auto'` detent no flex is needed. On Android, nested scrolling is managed internally (`nestedScrollEnabled` is ignored) and `RefreshControl` is supported.
 
 ## Layout and positioning
 
@@ -132,7 +189,7 @@ Every TrueSheet prop with type, default value, and platform support.
 | `anchor` | `'left' \| 'center' \| 'right'` | `'center'` | 🍎🤖🌐 | Horizontal positioning. Ignored on phones in portrait |
 | `anchorOffset` | `number` | `16` | 🤖🌐 | Edge margin when anchored left/right |
 | `presentation` | `'page' \| 'form'` | `'page'` | 🍎🌐 | iPad/web (landscape/tablet) presentation. `'form'` is absolute and ignores `maxContentWidth`. iOS 17+ |
-| `insetAdjustment` | `'automatic' \| 'never'` | `'automatic'` | 🍎🤖🌐 | Bottom safe area handling |
+| `insetAdjustment` | `'automatic' \| 'never'` | `'automatic'` | 🍎🤖 | Bottom safe-area handling. `'never'` keeps the layout as-is for precise sizing |
 
 ## Initial presentation
 
@@ -145,5 +202,5 @@ Every TrueSheet prop with type, default value, and platform support.
 
 | Prop | Type | Default | Platforms | Description |
 |------|------|---------|-----------|-------------|
-| `detached` | `boolean` | — | 🌐 | Render as a floating card instead of bottom-attached |
+| `detached` | `boolean` | `false` | 🌐 | Render as a floating card instead of bottom-attached |
 | `detachedOffset` | `number` | `16` | 🌐 | Gap from bottom edge for detached sheets |

--- a/skills/truesheet-usage/references/troubleshooting.md
+++ b/skills/truesheet-usage/references/troubleshooting.md
@@ -4,23 +4,43 @@ Common issues and fixes when using TrueSheet, organized by symptom.
 
 ## Table of Contents
 
+- [Content renders with zero height or gets clipped](#content-renders-with-zero-height-or-gets-clipped)
 - [Blank screen after modal dismiss (iOS)](#blank-screen-after-modal-dismiss-ios)
+- [Sheet snaps without animation on keyboard dismiss (iOS, RN 0.83–0.85)](#sheet-snaps-without-animation-on-keyboard-dismiss-ios-rn-083085)
 - [Gesture handler not working (Android)](#gesture-handler-not-working-android)
 - [initialDetentIndex not working from deep link (iOS)](#initialdetentindex-not-working-from-deep-link-ios)
-- [Weird layout or render glitches](#weird-layout-or-render-glitches)
-- [FlatList scrollToEnd not working](#flatlist-scrolltoend-not-working)
+- [Gap above the keyboard](#gap-above-the-keyboard)
+- [Doubled bottom padding in footer or scroll content](#doubled-bottom-padding-in-footer-or-scroll-content)
 - [Overlays render behind the sheet (Android)](#overlays-render-behind-the-sheet-android)
 - [Keyboard hides input](#keyboard-hides-input)
 - [Sheet doesn't build (Xcode version)](#sheet-doesnt-build-xcode-version)
 - [EAS Build fails](#eas-build-fails)
+- [Patched react-native-screens not applied on EAS](#patched-react-native-screens-not-applied-on-eas)
 
 ---
+
+## Content renders with zero height or gets clipped
+
+**Symptom:** `flex: 1` children render with zero height, or content taller than the sheet gets clipped.
+
+**Cause:** In v4, the sheet's content lays out naturally — it wraps its children's height like a regular view, instead of filling the sheet.
+
+**Fixes:**
+
+1. **`flex: 1` children collapse** — pass `flex: 1` via the sheet's `style` prop so the content fills the sheet's visible height:
+   ```tsx
+   <TrueSheet style={{ flex: 1 }} detents={[0.5, 1]}>
+     <View style={{ flex: 1 }}>{/* now fills */}</View>
+   </TrueSheet>
+   ```
+2. **Content taller than the sheet gets clipped** — use a ScrollView plugged via `scrollableRef` with `flex: 1` on the sheet's `style`, or size your layout with `flexGrow`, `flexBasis`, or fixed heights.
+3. **Still misbehaving?** Move the sheet higher in the component tree — a container may interfere with the sheet's content rendering.
 
 ## Blank screen after modal dismiss (iOS)
 
 **Symptom:** Screen goes blank after dismissing a React Native `Modal` when a sheet is also visible.
 
-**Cause:** React Native bug — dismissing a Modal while a sheet is on top can blank the underlying view.
+**Cause:** React Native bug — dismissing a Modal with another view controller presented on top only dismisses the topmost one, leaving the Modal inconsistent. A fix is pending upstream ([PR #55005](https://github.com/facebook/react-native/pull/55005)).
 
 **Fix:** Dismiss the sheet first, then dismiss the Modal:
 
@@ -29,11 +49,19 @@ await sheet.current?.dismiss()
 setModalVisible(false)
 ```
 
+## Sheet snaps without animation on keyboard dismiss (iOS, RN 0.83–0.85)
+
+**Symptom:** On React Native 0.83–0.85, the sheet snaps back to its detent without animation when the keyboard is dismissed.
+
+**Cause:** RN 0.83 made `canBecomeFirstResponder` return `YES` on every `RCTViewComponentView`, disrupting `UISheetPresentationController`'s keyboard avoidance animation. Fixed upstream in RN 0.86.
+
+**Fix:** Apply the [react-native patch](https://github.com/lodev09/react-native-true-sheet/blob/main/.yarn/patches/react-native-npm-0.85.3.patch) that gates it behind the `enableImperativeFocus` feature flag. Remove the patch once on 0.86+.
+
 ## Gesture handler not working (Android)
 
 **Symptom:** Gestures (swipe, tap) from `react-native-gesture-handler` don't fire inside the sheet.
 
-**Fix:** Wrap sheet content in `GestureHandlerRootView` with `flexGrow: 1` (not `flex: 1`):
+**Fix:** Wrap sheet content in `GestureHandlerRootView` with `flexGrow: 1`:
 
 ```tsx
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
@@ -45,47 +73,50 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler'
 </TrueSheet>
 ```
 
-The Android sheet renders in its own `CoordinatorLayout`, which needs a fresh gesture root.
+Use `flexGrow: 1` instead of `flex: 1` — the sheet's content wraps its natural height by default, so a `flex: 1` child collapses to zero height. Alternatively, pass `flex: 1` via the sheet's `style` prop to fill the sheet.
 
 ## initialDetentIndex not working from deep link (iOS)
 
-**Symptom:** `initialDetentIndex` has no effect when the app is opened via a deep link from a cold start.
+**Symptom:** `initialDetentIndex` has no effect when the app is opened via a deep link to a modal screen from a cold start.
 
-**Cause:** On iOS, the sheet component may mount before the navigation tree is ready. `initialDetentIndex` fires too early.
+**Cause:** The view wasn't attached to the correct window during the initial render.
 
-**Fix:** Use `useFocusEffect` to present the sheet when the screen actually gains focus:
+**Fix:** Use `useFocusEffect` to present when the screen gains focus, conditioned on whether the initial present succeeded:
 
 ```tsx
 import { useFocusEffect } from '@react-navigation/native'
 
+const [didPresent, setDidPresent] = useState(false)
+
 useFocusEffect(
   useCallback(() => {
-    sheet.current?.present(1)
-  }, [])
+    if (!didPresent) {
+      sheet.current?.present()
+    }
+  }, [didPresent])
 )
+
+<TrueSheet ref={sheet} initialDetentIndex={0} onDidPresent={() => setDidPresent(true)}>
 ```
 
-## Weird layout or render glitches
+## Gap above the keyboard
 
-**Symptom:** Content appears squished, overlapping, or sized incorrectly inside the sheet.
+**Symptom:** A gap appears between the keyboard and the scroll content or footer.
+
+**Cause:** Your content or footer renders its own bottom padding, which stacks on top of the sheet's keyboard inset.
 
 **Fixes:**
 
-1. **Minimize `flex: 1`** — Sheets have a defined height from detents. `flex: 1` inside a sheet can cause unexpected stretching. Use `flexGrow` or fixed `height` instead.
-2. **Move the sheet higher in the component tree** — If the sheet is deeply nested, it may inherit layout constraints that interfere with its sizing.
-3. **Use `header` and `footer` props** — Don't manually position fixed elements with `position: 'absolute'`. The native header/footer system handles layout math correctly.
+- Scroll content: pass a negative `keyboardOffset` in `scrollableOptions` to cancel the padding, e.g. `scrollableOptions={{ keyboardOffset: -insets.bottom }}`.
+- Absolute footer: pass a negative `keyboardOffset` in `footerOptions` to tuck the padding behind the keyboard, e.g. `footerOptions={{ position: 'absolute', keyboardOffset: -16 }}`.
 
-## FlatList scrollToEnd not working
+## Doubled bottom padding in footer or scroll content
 
-**Symptom:** `scrollToEnd()` on a FlatList inside a `scrollable` TrueSheet doesn't scroll to the true end.
+**Symptom:** Extra spacing at the bottom of the footer or the last scroll item.
 
-**Cause:** The native scroll container modifies the frame, and `scrollToEnd()` uses JS-side content metrics that don't account for this.
+**Cause:** v4 handles the bottom safe-area inset natively — the footer absorbs it as padding, and a plugged scrollable gets it while the content can scroll. Manual `useSafeAreaInsets()` padding gets applied twice.
 
-**Fix:** Use `scrollToOffset` with a large value:
-
-```tsx
-flatListRef.current?.scrollToOffset({ offset: 99999, animated: true })
-```
+**Fix:** Remove manual safe-area padding from the footer and scroll content. To manage it yourself instead, opt out with `scrollableOptions={{ contentInsetAdjustmentBehavior: false }}` (scrollable) or `insetAdjustment="never"` (whole sheet).
 
 ## Overlays render behind the sheet (Android)
 
@@ -102,11 +133,11 @@ flatListRef.current?.scrollToOffset({ offset: 99999, animated: true })
 TrueSheet has built-in keyboard avoidance — this usually means something else is wrong:
 
 1. **Don't use `autoFocus`** on TextInputs. Focus the input in `onDidPresent` instead.
-2. **For scrollable sheets**, add `keyboardScrollOffset` for extra padding:
+2. **Plug the scroll view via `scrollableRef`** — the sheet auto-scrolls to keep the focused input visible. Add `keyboardScrollOffset` for extra spacing:
    ```tsx
-   <TrueSheet scrollable scrollableOptions={{ keyboardScrollOffset: 16 }}>
+   <TrueSheet scrollableRef={scrollableRef} scrollableOptions={{ keyboardScrollOffset: 16 }}>
    ```
-3. **Footer repositions automatically** above the keyboard — no extra work needed.
+3. **Footer behavior**: an **absolute** footer (`footerOptions={{ position: 'absolute' }}`) rises above the keyboard automatically; a **relative** footer (default) stays in the layout flow and is covered by the keyboard until it hides.
 
 ## Sheet doesn't build (Xcode version)
 
@@ -116,7 +147,7 @@ Check your Xcode version: `xcodebuild -version`
 
 ## EAS Build fails
 
-For Expo EAS builds, ensure you're using a recent enough build image:
+For Expo EAS builds, ensure you're using a build image with Xcode 26.1+:
 
 ```json
 // eas.json
@@ -131,4 +162,33 @@ For Expo EAS builds, ensure you're using a recent enough build image:
 }
 ```
 
-This ensures Xcode 26.1+ is available during the build.
+## Patched react-native-screens not applied on EAS
+
+**Symptom:** On Expo SDK 56+ EAS builds, the sheet dismisses when navigating (or a full-screen modal fails to present over it), even though it works locally with the [react-native-screens patch](./advanced-patterns.md#navigating-from-sheets) applied.
+
+**Cause:** Expo SDK 56+ ships `react-native-screens` as a precompiled XCFramework on EAS — patches applied via `patch-package`/`pnpm patch`/Yarn `patches` are silently ignored, while local builds compile from source.
+
+**Fix:** Build from source. Either disable precompiled modules per profile in `eas.json`:
+
+```json
+{
+  "build": {
+    "development": { "env": { "EXPO_USE_PRECOMPILED_MODULES": "0" } },
+    "production": { "env": { "EXPO_USE_PRECOMPILED_MODULES": "0" } }
+  }
+}
+```
+
+Or opt out only `react-native-screens` in `package.json` (keeps everything else precompiled):
+
+```json
+{
+  "expo": {
+    "autolinking": {
+      "ios": { "buildFromSource": ["react-native-screens"] }
+    }
+  }
+}
+```
+
+Avoid `ios.buildReactNativeFromSource: true` — it rebuilds RN core and is much slower.


### PR DESCRIPTION
## Summary

Updates the `truesheet-usage` skill to reflect the v4 API, based on the v4 docs:

- `scrollable` → `scrollableRef` (works with `auto` detent and on web); removed the obsolete "never `auto` + `scrollable`" rule
- Content lays out naturally — documents `style={{ flex: 1 }}` to fill the sheet
- Relative header/footer by default, `headerOptions`/`footerOptions` with `position: 'absolute'`, native safe-area absorption
- New `peek` detent + `TrueSheetPeek`, `accessibilityOptions`, expanded `ScrollableOptions`, detents default `[0.5, 1]`
- Navigation: `standard-navigation` requirements, static API (`createTrueSheetScreen`), Expo Router `/navigation/expo-router` entry point
- Web: radix peer deps; Jest: expo-router mock + new mock exports (also fixed `setupFilesAfterEnv` key)
- Migration section rewritten for v3 → v4; troubleshooting synced with v4 docs (natural layout, keyboard-dismiss snap patch, EAS precompiled `react-native-screens`)

## Type of Change

- [x] Documentation update

## Test Plan

Content cross-checked against `docs/docs` (v4 reference and guides).

## Checklist

- [x] I updated the documentation (if needed)