### PR TITLE
fix(ios): retry blocked auto-present after recycled controller sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Fast dismiss/re-present cycles no longer strand an auto-presented sheet or leak the previous mount's lifecycle and detent state into its replacement. Recycled sheet hosts are also released from the native registry correctly. ([#800](https://github.com/lodev09/react-native-true-sheet/pull/800) by [@maxlapides](https://github.com/maxlapides))
 - **Android**: A stacked parent sheet now follows its child frame-by-frame when the child resizes, and no longer gets stuck at stale detents after a half-expanded settle. ([#797](https://github.com/lodev09/react-native-true-sheet/pull/797) by [@lodev09](https://github.com/lodev09))
 - **Android**: The scrollable content now tracks the keyboard frame-by-frame — the focused input rides the keyboard up smoothly, and the scroll position eases back on dismiss instead of snapping. ([#798](https://github.com/lodev09/react-native-true-sheet/pull/798) by [@lodev09](https://github.com/lodev09))
 - The keyboard-driven scroll inset now accounts for a floating footer's height. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))

--- a/ios/TrueSheetModule.mm
+++ b/ios/TrueSheetModule.mm
@@ -152,7 +152,7 @@ RCT_EXPORT_MODULE(TrueSheetModule)
       TrueSheetView *rootSheet = nil;
 
       for (TrueSheetView *view in viewRegistry.allValues) {
-        if (!view.viewController.isPresented) {
+        if (view.controllerSessionOwnedByPreviousMount || !view.viewController.isPresented) {
           continue;
         }
 

--- a/ios/TrueSheetView.h
+++ b/ios/TrueSheetView.h
@@ -24,6 +24,7 @@ typedef void (^TrueSheetCompletionBlock)(BOOL success, NSError *_Nullable error)
 @interface TrueSheetView : RCTViewComponentView
 
 @property (nonatomic, readonly) TrueSheetViewController *viewController;
+@property (nonatomic, readonly) BOOL controllerSessionOwnedByPreviousMount;
 
 // TurboModule methods
 - (void)presentAtIndex:(NSInteger)index

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -41,6 +41,8 @@ using namespace facebook::react;
 @interface TrueSheetView () <TrueSheetViewControllerDelegate,
   TrueSheetContainerViewDelegate,
   RNScreensEventObserverDelegate>
+- (facebook::react::SharedViewEventEmitter)activeEventEmitter;
+- (void)clearStaleControllerSessionOwnershipIfNeeded;
 @end
 
 @implementation TrueSheetView {
@@ -51,14 +53,18 @@ using namespace facebook::react;
   UIView *_snapshotView;
   CGSize _lastStateSize;
   NSInteger _initialDetentIndex;
+  NSUInteger _initialPresentGeneration;
+  NSUInteger _mountGeneration;
   TrueSheetViewInsetAdjustment _insetAdjustment;
   ScrollableOptions *_scrollableOptions;
   NSInteger _scrollableHandle;
   BOOL _hasAutoDetent;
   BOOL _initialDetentAnimated;
+  BOOL _forceInitialPresentAnimated;
   BOOL _isSheetUpdatePending;
   BOOL _pendingLayoutUpdate;
   BOOL _didInitiallyPresent;
+  BOOL _controllerSessionOwnedByPreviousMount;
   BOOL _dismissedByNavigation;
   BOOL _pendingNavigationRepresent;
   BOOL _pendingMountEvent;
@@ -86,8 +92,12 @@ using namespace facebook::react;
     _snapshotView = nil;
     _lastStateSize = CGSizeZero;
     _initialDetentIndex = -1;
+    _initialPresentGeneration = 0;
+    _mountGeneration = 0;
     _initialDetentAnimated = YES;
+    _forceInitialPresentAnimated = NO;
     _isSheetUpdatePending = NO;
+    _controllerSessionOwnedByPreviousMount = NO;
 
     _screensEventObserver = [[RNScreensEventObserver alloc] init];
     _screensEventObserver.delegate = self;
@@ -120,35 +130,56 @@ using namespace facebook::react;
 // Called from didMoveToWindow (re-attach) and finalizeUpdates (the prop
 // arriving after attach, which didMoveToWindow won't re-fire for).
 - (void)presentInitialIfNeeded {
+  [self clearStaleControllerSessionOwnershipIfNeeded];
+
   if (_initialDetentIndex < 0 || _didInitiallyPresent)
     return;
 
   UIViewController *vc = [self findPresentingViewController];
 
-  // Only present if the view controller is in the same window and not being dismissed
-  if (!vc || vc.view.window != self.window || _controller.isBeingDismissed) {
-    // Animate next time when sheet finally moves to the correct window
-    _initialDetentAnimated = YES;
+  // Wait for the retained controller session to finish before presenting into this window.
+  if (!vc || vc.view.window != self.window || _controllerSessionOwnedByPreviousMount || _controller.isPresented ||
+      _controller.isBeingDismissed) {
+    _forceInitialPresentAnimated = YES;
     return;
   }
 
   _didInitiallyPresent = YES;
+  NSUInteger generation = _initialPresentGeneration;
+  NSInteger initialDetentIndex = _initialDetentIndex;
+  BOOL initialDetentAnimated = _initialDetentAnimated || _forceInitialPresentAnimated;
 
   // Deferred a runloop turn so sibling mounts from the current transaction
   // (e.g. a footer committed alongside the prop) land before measuring.
   __weak __typeof(self) weakSelf = self;
   dispatch_async(dispatch_get_main_queue(), ^{
     __typeof(self) strongSelf = weakSelf;
-    if (!strongSelf || strongSelf->_controller.isPresented || strongSelf->_controller.isBeingPresented)
+    if (!strongSelf || strongSelf->_initialPresentGeneration != generation)
       return;
 
-    [strongSelf presentAtIndex:strongSelf->_initialDetentIndex
-                      animated:strongSelf->_initialDetentAnimated
+    if (strongSelf->_controller.isBeingPresented)
+      return;
+
+    if (!strongSelf.window || strongSelf->_controller.isBeingDismissed) {
+      strongSelf->_didInitiallyPresent = NO;
+      return;
+    }
+
+    if (strongSelf->_controller.isPresented) {
+      return;
+    }
+
+    [strongSelf presentAtIndex:initialDetentIndex
+                      animated:initialDetentAnimated
                     completion:^(BOOL success, NSError *_Nullable error) {
                       // Present can fail if the view detached during this turn —
                       // reset so the next attach/prop update retries.
-                      if (!success) {
-                        strongSelf->_didInitiallyPresent = NO;
+                      if (strongSelf->_initialPresentGeneration == generation) {
+                        if (success) {
+                          strongSelf->_forceInitialPresentAnimated = NO;
+                        } else {
+                          strongSelf->_didInitiallyPresent = NO;
+                        }
                       }
                     }];
   });
@@ -387,12 +418,32 @@ using namespace facebook::react;
 - (void)prepareForRecycle {
   [super prepareForRecycle];
 
+  _initialPresentGeneration += 1;
+  _mountGeneration += 1;
+
+  if (_controller.isPresented || _controller.isBeingPresented || _controller.isBeingDismissed) {
+    _controllerSessionOwnedByPreviousMount = YES;
+  }
+
+  if (_controller.isPresented && !_controller.isBeingDismissed) {
+    [self dismissAnimated:NO completion:nil];
+  }
+
   [TrueSheetModule unregisterViewWithTag:@(self.tag)];
+
+  [self cleanupContainerView];
 
   _lastStateSize = CGSizeZero;
   _didInitiallyPresent = NO;
+  _forceInitialPresentAnimated = NO;
   _dismissedByNavigation = NO;
   _pendingNavigationRepresent = NO;
+  _pendingMountEvent = NO;
+  _pendingPropsUpdate = NO;
+  _pendingLayoutUpdate = NO;
+  _isSheetUpdatePending = NO;
+  _pendingDetents = nil;
+  _pendingSizeChange = NO;
 }
 
 #pragma mark - Child Component Mounting
@@ -483,6 +534,8 @@ using namespace facebook::react;
 - (void)presentAtIndex:(NSInteger)index
               animated:(BOOL)animated
             completion:(nullable TrueSheetCompletionBlock)completion {
+  [self clearStaleControllerSessionOwnershipIfNeeded];
+
   if (_controller.isBeingPresented || _controller.isPresented) {
     RCTLogWarn(@"TrueSheet: sheet is already presented. Use resize() to change detent.");
     if (completion) {
@@ -503,6 +556,11 @@ using namespace facebook::react;
       completion(NO, error);
     }
     return;
+  }
+
+  if (_pendingDetents) {
+    _controller.detents = _pendingDetents;
+    _pendingDetents = nil;
   }
 
   [_controller setupAnchorViewInView:presentingViewController.view];
@@ -561,8 +619,12 @@ using namespace facebook::react;
   return _controller;
 }
 
+- (BOOL)controllerSessionOwnedByPreviousMount {
+  return _controllerSessionOwnedByPreviousMount;
+}
+
 - (void)emitDismissedPosition {
-  [TrueSheetStateEvents emitPositionChange:_eventEmitter
+  [TrueSheetStateEvents emitPositionChange:self.activeEventEmitter
                                      index:-1
                                   position:_controller.screenHeight
                                     detent:0
@@ -578,6 +640,9 @@ using namespace facebook::react;
     }
     return;
   }
+
+  // Keep below the no-op guard: only a real dismiss supersedes auto-present; its isBeingDismissed bail resets the latch.
+  _initialPresentGeneration += 1;
 
   // Dismiss from the presenting view controller to dismiss this sheet and all its children
   UIViewController *presenter = _controller.presentingViewController;
@@ -644,8 +709,12 @@ using namespace facebook::react;
     return;
 
   _isSheetUpdatePending = YES;
+  NSUInteger generation = _mountGeneration;
 
   dispatch_async(dispatch_get_main_queue(), ^{
+    if (self->_mountGeneration != generation)
+      return;
+
     self->_isSheetUpdatePending = NO;
     if (!self->_containerView || self->_controller.isBeingDismissed)
       return;
@@ -687,12 +756,18 @@ using namespace facebook::react;
 
 - (void)viewControllerWillPresentAtIndex:(NSInteger)index position:(CGFloat)position detent:(CGFloat)detent {
   _controller.activeDetentIndex = index;
-  [TrueSheetLifecycleEvents emitWillPresent:_eventEmitter index:index position:position detent:detent];
+  [TrueSheetLifecycleEvents emitWillPresent:self.activeEventEmitter index:index position:position detent:detent];
 }
 
 - (void)viewControllerDidPresentAtIndex:(NSInteger)index position:(CGFloat)position detent:(CGFloat)detent {
+  if (_controllerSessionOwnedByPreviousMount) {
+    [self dismissAnimated:NO completion:nil];
+    return;
+  }
+
+  _didInitiallyPresent = YES;
   [_containerView setupKeyboardObserverWithViewController:_controller];
-  [TrueSheetLifecycleEvents emitDidPresent:_eventEmitter index:index position:position detent:detent];
+  [TrueSheetLifecycleEvents emitDidPresent:self.activeEventEmitter index:index position:position detent:detent];
 
   if (_pendingPropsUpdate) {
     _pendingPropsUpdate = NO;
@@ -711,14 +786,14 @@ using namespace facebook::react;
                        detent:(CGFloat)detent {
   switch (state) {
     case UIGestureRecognizerStateBegan:
-      [TrueSheetDragEvents emitDragBegin:_eventEmitter index:index position:position detent:detent];
+      [TrueSheetDragEvents emitDragBegin:self.activeEventEmitter index:index position:position detent:detent];
       break;
     case UIGestureRecognizerStateChanged:
-      [TrueSheetDragEvents emitDragChange:_eventEmitter index:index position:position detent:detent];
+      [TrueSheetDragEvents emitDragChange:self.activeEventEmitter index:index position:position detent:detent];
       break;
     case UIGestureRecognizerStateEnded:
     case UIGestureRecognizerStateCancelled:
-      [TrueSheetDragEvents emitDragEnd:_eventEmitter index:index position:position detent:detent];
+      [TrueSheetDragEvents emitDragEnd:self.activeEventEmitter index:index position:position detent:detent];
       break;
     default:
       break;
@@ -727,18 +802,39 @@ using namespace facebook::react;
 
 - (void)viewControllerWillDismiss {
   if (!_dismissedByNavigation) {
-    [TrueSheetLifecycleEvents emitWillDismiss:_eventEmitter];
+    [TrueSheetLifecycleEvents emitWillDismiss:self.activeEventEmitter];
   }
 }
 
 - (void)viewControllerDidDismiss {
   [_containerView cleanupKeyboardObserver];
+  BOOL controllerSessionOwnedByPreviousMount = _controllerSessionOwnedByPreviousMount;
+  facebook::react::SharedViewEventEmitter eventEmitter = self.activeEventEmitter;
+  _controllerSessionOwnedByPreviousMount = NO;
+
   if (!_dismissedByNavigation) {
     _dismissedByNavigation = NO;
     _pendingNavigationRepresent = NO;
 
     _controller.activeDetentIndex = -1;
-    [TrueSheetLifecycleEvents emitDidDismiss:_eventEmitter];
+    [TrueSheetLifecycleEvents emitDidDismiss:eventEmitter];
+  }
+
+  if (controllerSessionOwnedByPreviousMount) {
+    [_snapshotView removeFromSuperview];
+    _snapshotView = nil;
+  }
+
+  if (self.window) {
+    NSUInteger generation = _initialPresentGeneration;
+    __weak __typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      __typeof(self) strongSelf = weakSelf;
+      if (!strongSelf || strongSelf->_initialPresentGeneration != generation)
+        return;
+
+      [strongSelf presentInitialIfNeeded];
+    });
   }
 }
 
@@ -746,14 +842,18 @@ using namespace facebook::react;
   if (_controller.activeDetentIndex != index) {
     _controller.activeDetentIndex = index;
   }
-  [TrueSheetStateEvents emitDetentChange:_eventEmitter index:index position:position detent:detent];
+  [TrueSheetStateEvents emitDetentChange:self.activeEventEmitter index:index position:position detent:detent];
 }
 
 - (void)viewControllerDidChangePosition:(CGFloat)index
                                position:(CGFloat)position
                                  detent:(CGFloat)detent
                                realtime:(BOOL)realtime {
-  [TrueSheetStateEvents emitPositionChange:_eventEmitter index:index position:position detent:detent realtime:realtime];
+  [TrueSheetStateEvents emitPositionChange:self.activeEventEmitter
+                                     index:index
+                                  position:position
+                                    detent:detent
+                                  realtime:realtime];
 }
 
 - (void)viewControllerDidChangeSize:(CGSize)size {
@@ -765,19 +865,19 @@ using namespace facebook::react;
 }
 
 - (void)viewControllerWillFocus {
-  [TrueSheetFocusEvents emitWillFocus:_eventEmitter];
+  [TrueSheetFocusEvents emitWillFocus:self.activeEventEmitter];
 }
 
 - (void)viewControllerDidFocus {
-  [TrueSheetFocusEvents emitDidFocus:_eventEmitter];
+  [TrueSheetFocusEvents emitDidFocus:self.activeEventEmitter];
 }
 
 - (void)viewControllerWillBlur {
-  [TrueSheetFocusEvents emitWillBlur:_eventEmitter];
+  [TrueSheetFocusEvents emitWillBlur:self.activeEventEmitter];
 }
 
 - (void)viewControllerDidBlur {
-  [TrueSheetFocusEvents emitDidBlur:_eventEmitter];
+  [TrueSheetFocusEvents emitDidBlur:self.activeEventEmitter];
 }
 
 #pragma mark - RNScreensEventObserverDelegate
@@ -816,14 +916,30 @@ using namespace facebook::react;
   }
 
   _dismissedByNavigation = YES;
+  NSUInteger generation = _mountGeneration;
   __weak __typeof(self) weakSelf = self;
   [_controller finishInteractiveDismissWithDuration:duration
                                          completion:^{
-                                           [weakSelf dismissAnimated:NO completion:nil];
+                                           __typeof(self) strongSelf = weakSelf;
+                                           if (!strongSelf || strongSelf->_mountGeneration != generation)
+                                             return;
+
+                                           [strongSelf dismissAnimated:NO completion:nil];
                                          }];
 }
 
 #pragma mark - Private Helpers
+
+- (facebook::react::SharedViewEventEmitter)activeEventEmitter {
+  return _controllerSessionOwnedByPreviousMount ? nullptr : _eventEmitter;
+}
+
+- (void)clearStaleControllerSessionOwnershipIfNeeded {
+  if (_controllerSessionOwnedByPreviousMount && !_controller.isPresented && !_controller.isBeingPresented &&
+      !_controller.isBeingDismissed) {
+    _controllerSessionOwnedByPreviousMount = NO;
+  }
+}
 
 - (void)setupScrollable {
   if (!_containerView)

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -52,6 +52,7 @@ using namespace facebook::react;
   TrueSheetViewShadowNode::ConcreteState::Shared _state;
   UIView *_snapshotView;
   CGSize _lastStateSize;
+  NSInteger _registeredTag;
   NSInteger _initialDetentIndex;
   NSUInteger _initialPresentGeneration;
   NSUInteger _mountGeneration;
@@ -91,6 +92,7 @@ using namespace facebook::react;
     _containerView = nil;
     _snapshotView = nil;
     _lastStateSize = CGSizeZero;
+    _registeredTag = 0;
     _initialDetentIndex = -1;
     _initialPresentGeneration = 0;
     _mountGeneration = 0;
@@ -112,6 +114,7 @@ using namespace facebook::react;
     return;
 
   if (self.tag > 0) {
+    _registeredTag = self.tag;
     [TrueSheetModule registerView:self withTag:@(self.tag)];
   }
 
@@ -208,7 +211,10 @@ using namespace facebook::react;
   [_snapshotView removeFromSuperview];
   _snapshotView = nil;
 
-  [TrueSheetModule unregisterViewWithTag:@(self.tag)];
+  if (_registeredTag > 0) {
+    [TrueSheetModule unregisterViewWithTag:@(_registeredTag)];
+    _registeredTag = 0;
+  }
 }
 
 #pragma mark - RCTComponentViewProtocol
@@ -429,7 +435,10 @@ using namespace facebook::react;
     [self dismissAnimated:NO completion:nil];
   }
 
-  [TrueSheetModule unregisterViewWithTag:@(self.tag)];
+  if (_registeredTag > 0) {
+    [TrueSheetModule unregisterViewWithTag:@(_registeredTag)];
+    _registeredTag = 0;
+  }
 
   [self cleanupContainerView];
 

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -69,6 +69,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   BOOL _pendingDetentsChange;
   BOOL _isDragging;
   BOOL _isWillDismissEmitted;
+  NSUInteger _presentationSessionGeneration;
 
   // Last bottom safe area observed while presented — reused as the estimate
   // for the next present (beats the float-threshold guess for re-presents).
@@ -112,6 +113,7 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     _isDragging = NO;
     _isPresented = NO;
     _isWillDismissEmitted = NO;
+    _presentationSessionGeneration = 0;
     _isTransitioning = NO;
     _pendingContentSizeChange = NO;
     _pendingDetentsChange = NO;
@@ -395,6 +397,7 @@ static BOOL TrueSheetIsPhoneIdiom(void) {
   _blurView.alpha = 1;
 
   if (!_isPresented) {
+    _presentationSessionGeneration += 1;
     UIViewController *presenter = self.presentingViewController;
     if ([presenter isKindOfClass:[TrueSheetViewController class]]) {
       _parentSheetController = (TrueSheetViewController *)presenter;
@@ -580,6 +583,7 @@ static BOOL TrueSheetIsPhoneIdiom(void) {
 
 - (void)emitDidDismissEvents {
   if (self.isBeingDismissed) {
+    _presentationSessionGeneration += 1;
     [self restoreWindowAccessibilityElements];
     _isPresented = NO;
     _isWillDismissEmitted = NO;
@@ -709,10 +713,14 @@ static BOOL TrueSheetIsPhoneIdiom(void) {
   if (_pendingDetentIndex >= 0) {
     NSInteger pendingIndex = _pendingDetentIndex;
     _pendingDetentIndex = -1;
+    NSUInteger generation = _presentationSessionGeneration;
 
     // The presentedView frame isn't final until UIKit finishes the resize
     // animation — no completion hook exists for it, hence the delay.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      if (self->_presentationSessionGeneration != generation)
+        return;
+
       CGFloat detent = [self detentValueForIndex:pendingIndex];
       [self.delegate viewControllerDidChangeDetent:pendingIndex position:self.currentPosition detent:detent];
       [self->_grabberView updateAccessibilityValueWithIndex:pendingIndex detentCount:self->_detents.count];
@@ -785,9 +793,13 @@ static BOOL TrueSheetIsPhoneIdiom(void) {
     case UIGestureRecognizerStateEnded:
     case UIGestureRecognizerStateCancelled: {
       if (!_isTransitioning) {
+        NSUInteger generation = _presentationSessionGeneration;
         // Dispatch so UIKit picks the target detent first; the settle emit is
         // non-realtime and JS animates alongside UIKit's snap spring.
         dispatch_async(dispatch_get_main_queue(), ^{
+          if (self->_presentationSessionGeneration != generation)
+            return;
+
           NSInteger endIndex = self.currentDetentIndex;
           [self->_grabberView updateAccessibilityValueWithIndex:endIndex detentCount:self->_detents.count];
           [self settleAtDetentIndex:endIndex debug:@"drag end"];
@@ -857,7 +869,11 @@ static BOOL TrueSheetIsPhoneIdiom(void) {
       // completes its layout pass after the transition animation — learning
       // here absorbs any sub-pixel drift since the earlier learns.
       if (strongSelf->_isPresented && !strongSelf.isBeingDismissed) {
+        NSUInteger generation = strongSelf->_presentationSessionGeneration;
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+          if (strongSelf->_presentationSessionGeneration != generation)
+            return;
+
           [strongSelf settleAtDetentIndex:strongSelf.currentDetentIndex debug:@"transition end"];
         });
       }
@@ -1503,7 +1519,11 @@ static BOOL TrueSheetIsPhoneIdiom(void) {
 
 - (void)sheetPresentationControllerDidChangeSelectedDetentIdentifier:
   (UISheetPresentationController *)sheetPresentationController {
+  NSUInteger generation = _presentationSessionGeneration;
   dispatch_async(dispatch_get_main_queue(), ^{
+    if (self->_presentationSessionGeneration != generation)
+      return;
+
     NSInteger index = self.currentDetentIndex;
     if (index >= 0) {
       CGFloat detent = [self detentValueForIndex:index];


### PR DESCRIPTION
## Summary

This forward-ports the iOS lifecycle fixes from #793 onto `main` (the v4 line), as offered in that PR's discussion.

A fast dismiss/re-present cycle can recycle the Fabric host while its retained controller is still finishing the previous presentation session. This fixes four concrete failure families:

- **Blocked auto-present:** a replacement mount can find the controller dismissing, skip `initialDetentIndex` auto-presentation, and remain permanently dead because nothing retries it. Initial presentation now retries after attachment, prop updates, or dismissal completion, with deferred work scoped to the current mount and captured presentation intent.
- **Previous-session event leakage:** presentation, dismissal, focus, drag, detent, and position callbacks from the previous mount can otherwise reach the replacement mount. Controller-session ownership now scopes those events and teardown to the mount that started the session.
- **Recycled-host state carryover:** the replacement can inherit the previous mount's container, pending props/detents/layout work, navigation state, or dismissal snapshot. Recycle now detaches the old container, resets per-mount transient state, preserves the snapshot only through the dismissal that needs it, and promotes the replacement's pending detents before its retry presentation.
- **Registered-tag leak:** React Native zeroes `view.tag` before `prepareForRecycle`, so unregistering `self.tag` removed key `0` while `TrueSheetModule`'s strong registry retained every recycled host. The view now stores the tag it registered and unregisters that exact value.

The v4 port also adds review-driven hardening for v4-specific asynchronous paths: the interactive-navigation dismissal completion is mount-scoped; pending detents are applied before retry presentation and active-index clamping; and delayed detent/position emissions are presentation-session-scoped, including the 0.1-second transition-end settle.

This is the v4 counterpart to #793 and fixes the TrueSheet auto-present/lifecycle half of #789. It does **not** claim to fix the remaining #789 symptom where a presented sheet's second-commit subtree is not inserted until a later unrelated commit; as documented in #793, that is an upstream React Native Fabric transaction issue.

The `CHANGELOG.md` entry will be pushed immediately after this PR number exists.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- The underlying lifecycle fixes were device red/green verified on the v3 line in #793 using a physical iPhone 11 running iOS 26 with React Native 0.86.2 Fabric:
  - Unpatched: 158/316 mid-dismissal remounts wedged; 134/134 mid-dismissal content swaps wedged.
  - Patched: 0 wedges across 325 remount cycles and 294 content-swap cycles (619 total).
- This v4 forward-port was verified by static lifecycle analysis and two independent, multi-round code reviews covering host recycle ordering, controller-session ownership, registry lifetime, and delayed callbacks.
- `yarn typecheck` passes.
- `yarn lint` passes.
- `yarn test --watchman=false` passes (65 tests).
- No device soak was run against the v4 branch.

## Screenshots / Videos

Not applicable; this changes lifecycle handling without changing the sheet's visual design.

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (not needed)
- [ ] I added a changelog entry (will be pushed immediately after this PR number exists)
