### PR TITLE
refactor: remove scrollableBounded state

### DIFF
--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContainerView.kt
@@ -95,12 +95,6 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
       contentView?.bottomInset = value
     }
 
-  var hasAutoDetent = false
-    set(value) {
-      field = value
-      contentView?.hasAutoDetent = value
-    }
-
   override val eventDispatcher: EventDispatcher?
     get() = delegate?.eventDispatcher
 
@@ -131,7 +125,6 @@ class TrueSheetContainerView(reactContext: ThemedReactContext) :
         child.scrollableOptions = scrollableOptions
         child.scrollableHandle = scrollableHandle
         child.bottomInset = scrollableBottomInset
-        child.hasAutoDetent = hasAutoDetent
         contentView = child
 
         // State lands before the view is attached, so pull the current value

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentView.kt
@@ -8,9 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.uimanager.PixelUtil.dpToPx
-import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.lodev09.truesheet.core.TrueSheetKeyboardObserver
@@ -57,11 +55,9 @@ interface TrueSheetContentViewDelegate {
 @SuppressLint("ViewConstructor")
 class TrueSheetContentView(private val reactContext: ThemedReactContext) : ReactViewGroup(reactContext) {
   var delegate: TrueSheetContentViewDelegate? = null
-  var stateWrapper: StateWrapper? = null
 
   private var detectedScrollView: ViewGroup? = null
   private var originalScrollViewPaddingBottom: Int = 0
-  private var scrollableBounded = false
 
   /**
    * Content height measured unconstrained by the shadow node — the height the
@@ -141,20 +137,6 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
       clearScrollable()
     }
 
-  /**
-   * Whether the sheet has an `auto` detent. Deriving the sheet height from the
-   * scroll content is circular with natural layout, so the detected ScrollView's
-   * viewport is force-bounded to the container only in this case.
-   */
-  var hasAutoDetent = false
-    set(value) {
-      if (field == value) return
-      field = value
-      if (detectedScrollView != null) {
-        setScrollableBounded(value)
-      }
-    }
-
   override fun addView(child: View?, index: Int) {
     super.addView(child, index)
     checkScrollViewChanged()
@@ -168,22 +150,6 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
   private fun checkScrollViewChanged() {
     if (detectedScrollView == null || detectedScrollView?.isDescendantOf(this) == false) {
       delegate?.contentViewScrollViewDidChange()
-    }
-  }
-
-  /**
-   * Tells the shadow node to fill the container (flexGrow/flexShrink) so the
-   * detected ScrollView's viewport is bounded to the visible space. Only applied
-   * for auto detents — otherwise content lays out naturally like a regular view.
-   */
-  private fun setScrollableBounded(bounded: Boolean) {
-    if (scrollableBounded == bounded) return
-    scrollableBounded = bounded
-
-    stateWrapper?.let {
-      val newState = WritableNativeMap()
-      newState.putBoolean("scrollableBounded", bounded)
-      it.updateState(newState)
     }
   }
 
@@ -216,7 +182,6 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     scrollView.addOnLayoutChangeListener(scrollableLayoutListener)
     scrollView.getChildAt(0)?.addOnLayoutChangeListener(scrollableLayoutListener)
 
-    setScrollableBounded(hasAutoDetent)
     updateContentInset()
 
     // If keyboard is currently showing, re-apply the keyboard inset to the new ScrollView
@@ -274,7 +239,6 @@ class TrueSheetContentView(private val reactContext: ThemedReactContext) : React
     detectedScrollView?.isNestedScrollingEnabled = false
     (detectedScrollView?.parent as? SwipeRefreshLayout)?.isNestedScrollingEnabled = true
     setScrollViewPaddingBottom(originalScrollViewPaddingBottom)
-    setScrollableBounded(false)
     detectedScrollView = null
     originalScrollViewPaddingBottom = 0
     baseBottomInset = 0

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetContentViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetContentViewManager.kt
@@ -20,7 +20,6 @@ class TrueSheetContentViewManager : ViewGroupManager<TrueSheetContentView>() {
   override fun createViewInstance(reactContext: ThemedReactContext): TrueSheetContentView = TrueSheetContentView(reactContext)
 
   override fun updateState(view: TrueSheetContentView, props: ReactStylesDiffMap?, stateWrapper: StateWrapper?): Any? {
-    view.stateWrapper = stateWrapper
     stateWrapper?.stateData?.let { data ->
       if (data.hasKey("naturalHeight")) {
         view.updateNaturalHeight(data.getDouble("naturalHeight"))

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -328,7 +328,6 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
       it.scrollableOptions = viewController.scrollableOptions
       it.scrollableHandle = viewController.scrollableHandle
       it.scrollableBottomInset = viewController.contentBottomInset
-      it.hasAutoDetent = viewController.detents.contains(-1.0)
       it.footerBottomInset = viewController.contentBottomInset
       it.absoluteFooter = viewController.absoluteFooter
       it.setupScrollable()

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewComponentDescriptor.h
@@ -11,14 +11,6 @@ namespace facebook::react {
 class TrueSheetContentViewComponentDescriptor final
     : public ConcreteComponentDescriptor<TrueSheetContentViewShadowNode> {
   using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
-
-  void adopt(ShadowNode &shadowNode) const override {
-    auto &concreteShadowNode =
-        static_cast<TrueSheetContentViewShadowNode &>(shadowNode);
-    concreteShadowNode.adjustLayoutWithState();
-
-    ConcreteComponentDescriptor::adopt(shadowNode);
-  }
 };
 
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.cpp
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.cpp
@@ -16,38 +16,6 @@ extern const char TrueSheetContentViewComponentName[] = "TrueSheetContentView";
 // clone — guard so the measurement pass doesn't measure again recursively.
 static thread_local bool gIsMeasuringNaturalHeight = false;
 
-void TrueSheetContentViewShadowNode::adjustLayoutWithState() {
-  ensureUnsealed();
-
-  auto state = std::static_pointer_cast<
-      const TrueSheetContentViewShadowNode::ConcreteState>(getState());
-  auto stateData = state->getData();
-
-  auto &props = getConcreteProps();
-
-  // When a ScrollView is detected under an auto detent, fill the container so
-  // descendant flex layouts (flex:1 wrappers, the ScrollView itself) resolve
-  // against a definite height and the viewport is bounded — natural layout is
-  // circular there since the sheet height derives from the content's natural
-  // height instead (see updateNaturalHeightIfNeeded). For fixed detents,
-  // content lays out naturally like a regular view.
-  auto flexGrow = stateData.scrollableBounded
-      ? FloatOptional{1.0f}
-      : props.yogaStyle.flexGrow();
-  auto flexShrink = stateData.scrollableBounded
-      ? FloatOptional{1.0f}
-      : props.yogaStyle.flexShrink();
-
-  if (yogaNode_.style().flexGrow() != flexGrow ||
-      yogaNode_.style().flexShrink() != flexShrink) {
-    yoga::Style adjustedStyle = props.yogaStyle;
-    adjustedStyle.setFlexGrow(flexGrow);
-    adjustedStyle.setFlexShrink(flexShrink);
-    yogaNode_.setStyle(adjustedStyle);
-    yogaNode_.setDirty(true);
-  }
-}
-
 void TrueSheetContentViewShadowNode::layout(LayoutContext layoutContext) {
   ConcreteViewShadowNode::layout(layoutContext);
   updateNaturalHeightIfNeeded(layoutContext);
@@ -65,12 +33,11 @@ static bool isHeightContainerDerived(const yoga::Style &style) {
 }
 
 // The natural height is the height the content wants when unbounded — the
-// source for the auto detent. Whenever the committed layout doesn't reflect
-// it — the container bounds the content (scrollableBounded) or the content's
-// height derives from the container — lay out a clone of the subtree with an
-// unconstrained height. Yoga respects the user's styles: an explicit-height
-// ScrollView keeps its height while a flexible one expands to its content —
-// no ScrollView discovery involved.
+// source for the auto detent. When the content's height derives from the
+// container, the committed layout doesn't reflect it — lay out a clone of the
+// subtree with an unconstrained height instead. Yoga respects the user's
+// styles: an explicit-height ScrollView keeps its height while a flexible one
+// expands to its content — no ScrollView discovery involved.
 void TrueSheetContentViewShadowNode::updateNaturalHeightIfNeeded(
     const LayoutContext &layoutContext) {
   if (gIsMeasuringNaturalHeight) {
@@ -81,8 +48,7 @@ void TrueSheetContentViewShadowNode::updateNaturalHeightIfNeeded(
   auto size = getLayoutMetrics().frame.size;
 
   Float naturalHeight = size.height;
-  if (stateData.scrollableBounded ||
-      isHeightContainerDerived(getConcreteProps().yogaStyle)) {
+  if (isHeightContainerDerived(getConcreteProps().yogaStyle)) {
     auto constraints = LayoutConstraints{};
     constraints.minimumSize = {size.width, 0};
     constraints.maximumSize = {size.width, std::numeric_limits<Float>::infinity()};

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewShadowNode.h
@@ -22,8 +22,6 @@ class JSI_EXPORT TrueSheetContentViewShadowNode final
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 
  public:
-  void adjustLayoutWithState();
-
 #pragma mark - LayoutableShadowNode
 
   void layout(LayoutContext layoutContext) override;

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.cpp
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.cpp
@@ -4,8 +4,7 @@ namespace facebook::react {
 
 #ifdef ANDROID
 folly::dynamic TrueSheetContentViewState::getDynamic() const {
-  return folly::dynamic::object("scrollableBounded", scrollableBounded)(
-      "naturalHeight", naturalHeight);
+  return folly::dynamic::object("naturalHeight", naturalHeight);
 }
 #endif
 

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetContentViewState.h
@@ -12,8 +12,6 @@ namespace facebook::react {
 
 /*
  * State for <TrueSheetContentView> component.
- * `scrollableBounded` is set from native when a ScrollView is detected so the
- * shadow node bounds the content to the container via flexShrink.
  * `naturalHeight` is measured by the shadow node during layout — the height
  * the content wants when unbounded (see TrueSheetContentViewShadowNode).
  */
@@ -25,13 +23,9 @@ class TrueSheetContentViewState final {
   TrueSheetContentViewState(
       TrueSheetContentViewState const &previousState,
       folly::dynamic data)
-      : scrollableBounded(
-            data.getDefault("scrollableBounded", previousState.scrollableBounded)
-                .getBool()),
-        naturalHeight(previousState.naturalHeight) {}
+      : naturalHeight(previousState.naturalHeight) {}
 #endif
 
-  bool scrollableBounded{false};
   Float naturalHeight{0};
 
 #ifdef ANDROID

--- a/ios/TrueSheetContainerView.h
+++ b/ios/TrueSheetContainerView.h
@@ -64,12 +64,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL contentInsetAdjustment;
 
 /**
- * Whether the sheet has an `auto` detent — bounds the detected scrollable's
- * viewport to the container so the sheet height can derive from its content size
- */
-@property (nonatomic, assign) BOOL hasAutoDetent;
-
-/**
  * Bottom safe-area inset the footer absorbs as padding — the footer
  * owns the sheet's bottom edge, so its background fills the inset
  */

--- a/ios/TrueSheetContainerView.mm
+++ b/ios/TrueSheetContainerView.mm
@@ -157,7 +157,6 @@ using namespace facebook::react;
   if (_contentView) {
     _contentView.scrollableHandle = _scrollableHandle;
     _contentView.contentInsetAdjustment = _contentInsetAdjustment;
-    _contentView.hasAutoDetent = _hasAutoDetent;
     [_contentView setupScrollable];
     [_contentView applyScrollEdgeEffects:_scrollableOptions];
     if (@available(iOS 26.0, *)) {

--- a/ios/TrueSheetContentView.h
+++ b/ios/TrueSheetContentView.h
@@ -49,13 +49,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, nullable) TrueSheetFooterView *footerView;
 
 /**
- * Whether the sheet has an `auto` detent. Deriving the sheet height from the
- * scroll content is circular with natural layout, so the detected ScrollView's
- * viewport is force-bounded to the container only in this case.
- */
-@property (nonatomic, assign) BOOL hasAutoDetent;
-
-/**
  * Content height measured unconstrained by the shadow node — the height the
  * content wants regardless of container bounds (see
  * TrueSheetContentViewShadowNode). Falls back to the frame height before the

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -29,7 +29,6 @@ using namespace facebook::react;
   CGFloat _lastReportedNaturalHeight;
   CGFloat _appliedKeyboardOffset;
   BOOL _observingTextChanges;
-  BOOL _scrollableBounded;
   UIScrollViewContentInsetAdjustmentBehavior _originalInsetAdjustmentBehavior;
   BOOL _appliedContentInsetAdjustment;
 }
@@ -57,22 +56,6 @@ using namespace facebook::react;
   if (naturalHeight != _lastReportedNaturalHeight) {
     _lastReportedNaturalHeight = naturalHeight;
     [self.delegate contentViewDidChangeSize:CGSizeMake(self.frame.size.width, naturalHeight)];
-  }
-}
-
-// Tells the shadow node to fill the container (flexGrow/flexShrink) so the
-// detected ScrollView's viewport is bounded to the visible space. Only applied
-// for auto detents — otherwise content lays out naturally like a regular view.
-- (void)setScrollableBounded:(BOOL)bounded {
-  if (_scrollableBounded == bounded) {
-    return;
-  }
-  _scrollableBounded = bounded;
-
-  if (_state) {
-    auto newState = _state->getData();
-    newState.scrollableBounded = bounded;
-    _state->updateState(std::move(newState));
   }
 }
 
@@ -109,17 +92,6 @@ using namespace facebook::react;
   } else if (!_contentInsetAdjustment && _appliedContentInsetAdjustment) {
     scrollView.contentInsetAdjustmentBehavior = _originalInsetAdjustmentBehavior;
     _appliedContentInsetAdjustment = NO;
-  }
-}
-
-- (void)setHasAutoDetent:(BOOL)hasAutoDetent {
-  if (_hasAutoDetent == hasAutoDetent) {
-    return;
-  }
-  _hasAutoDetent = hasAutoDetent;
-
-  if (_detectedScrollView) {
-    [self setScrollableBounded:hasAutoDetent];
   }
 }
 
@@ -207,7 +179,6 @@ using namespace facebook::react;
     _detectedScrollView.scrollView.contentInsetAdjustmentBehavior = _originalInsetAdjustmentBehavior;
     _appliedContentInsetAdjustment = NO;
   }
-  [self setScrollableBounded:NO];
   _detectedScrollView = nil;
 }
 
@@ -229,7 +200,6 @@ using namespace facebook::react;
   _detectedScrollView = scrollView;
 
   [self applyContentInsetAdjustment];
-  [self setScrollableBounded:_hasAutoDetent];
 
   // If keyboard is currently showing, re-apply the keyboard inset to the new ScrollView
   CGFloat keyboardHeight = _keyboardObserver ? _keyboardObserver.currentHeight : 0;
@@ -443,10 +413,8 @@ using namespace facebook::react;
   [self stopObservingTextChanges];
   [self clearScrollable];
   _state.reset();
-  _scrollableBounded = NO;
   _scrollableHandle = 0;
   _contentInsetAdjustment = NO;
-  _hasAutoDetent = NO;
   _lastReportedNaturalHeight = 0;
 }
 

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -54,7 +54,6 @@ using namespace facebook::react;
   TrueSheetViewInsetAdjustment _insetAdjustment;
   ScrollableOptions *_scrollableOptions;
   NSInteger _scrollableHandle;
-  BOOL _hasAutoDetent;
   BOOL _initialDetentAnimated;
   BOOL _isSheetUpdatePending;
   BOOL _pendingLayoutUpdate;
@@ -193,12 +192,8 @@ using namespace facebook::react;
 
   // Detents (-1 represents "auto")
   NSMutableArray *detents = [NSMutableArray new];
-  _hasAutoDetent = NO;
   for (const auto &detent : newProps.detents) {
     [detents addObject:@(detent)];
-    if (detent == -1) {
-      _hasAutoDetent = YES;
-    }
   }
 
   if (oldProps) {
@@ -833,7 +828,6 @@ using namespace facebook::react;
   _containerView.scrollableHandle = _scrollableHandle;
   _containerView.contentInsetAdjustment = (_scrollableOptions ? _scrollableOptions.contentInsetAdjustment : YES) &&
                                           _insetAdjustment == TrueSheetViewInsetAdjustment::Automatic;
-  _containerView.hasAutoDetent = _hasAutoDetent;
   [self refreshFooterBottomInset];
   [_containerView setupScrollable];
 }

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -1268,7 +1268,8 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
                 {/* Content lays out naturally like native — fill only for auto
                     detents with a plugged scrollable, where natural layout is
                     circular (sheet height derives from the scroll content size).
-                    Mirrors the native shadow node's scrollableBounded behavior. */}
+                    Unlike native, CSS won't cap the content to the container
+                    (no fit-content flex basis), so the fill is still needed here. */}
                 <View
                   ref={contentRef}
                   style={hasAutoDetent && hasBoundedScrollable ? [contentFillStyle, style] : style}


### PR DESCRIPTION
## Summary

Removes the `scrollableBounded` state flag and its entire plumbing chain. Yoga already bounds a flexible ScrollView to the container naturally — content is measured with an at-most constraint inside the definite-height container, and RN's ScrollView default `flexGrow: 1` / `flexShrink: 1` fits content capped at the available space. The forced fill and the native→shadow-node state roundtrip were redundant.

- Deletes `adjustLayoutWithState()` (forced `flexGrow`/`flexShrink`), the content descriptor's `adopt` override, and the `scrollableBounded` state field from the shared C++.
- The unconstrained natural-height measure is now gated purely on container-derived content styles (`flexGrow`/`flexShrink`/percent height from props).
- Removes the dead `hasAutoDetent` chain (`TrueSheetView` → `ContainerView` → `ContentView`) on both iOS and Android — the flag was its only consumer.
- `scrollableRef` is now purely keyboard insets, caret reveal, and scroll edge effects.
- Web keeps its ref-driven content fill — CSS flex has no fit-content capping equivalent, so it's still needed there. Comment updated.

Stacked on #801 (depends on `isHeightContainerDerived`).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor (internal change, no user-facing behavior change)

## Test Plan

- FlatListSheet demo (`auto` detent + FlatList) with and without `scrollableRef`: viewport bounded to the sheet, scrolling works, sheet grows/shrinks with Add/Remove Item.
- Fixed-detent scrollable sheets: unchanged (bounding comes from Yoga either way).
- Keyboard insets and scroll edge effects still driven by `scrollableRef`.

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)