### PR TITLE
fix(ios): Measure sheet content before presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Auto detents now measure mounted content before presentation, preventing late-measuring native views from resizing the sheet during its opening animation. ([#804](https://github.com/lodev09/react-native-true-sheet/pull/804) by [@maxlapides](https://github.com/maxlapides))
 - **Android**: A stacked parent sheet now follows its child frame-by-frame when the child resizes, and no longer gets stuck at stale detents after a half-expanded settle. ([#797](https://github.com/lodev09/react-native-true-sheet/pull/797) by [@lodev09](https://github.com/lodev09))
 - **Android**: The scrollable content now tracks the keyboard frame-by-frame — the focused input rides the keyboard up smoothly, and the scroll position eases back on dismiss instead of snapping. ([#798](https://github.com/lodev09/react-native-true-sheet/pull/798) by [@lodev09](https://github.com/lodev09))
 - The keyboard-driven scroll inset now accounts for a floating footer's height. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -50,6 +50,7 @@ static const NSTimeInterval InitialMeasurementTimeout = 0.5;
   RNScreensEventObserverDelegate>
 
 - (void)stageContainerViewForMeasurement;
+- (BOOL)stageContainerViewInMeasurementController;
 - (void)attachContainerViewToController;
 - (void)removeMeasurementHostView;
 - (void)scheduleInitialPresentationAfterMeasurement;
@@ -80,6 +81,7 @@ static const NSTimeInterval InitialMeasurementTimeout = 0.5;
   NSUInteger _initialMeasurementGeneration;
   CFTimeInterval _initialMeasurementDeadline;
   UIView *_measurementHostView;
+  UIViewController *_measurementViewController;
   NSArray *_pendingDetents;
   RNScreensEventObserver *_screensEventObserver;
 }
@@ -432,6 +434,7 @@ static const NSTimeInterval InitialMeasurementTimeout = 0.5;
   [_containerView removeFromSuperview];
 
   _containerView = nil;
+  [self removeMeasurementHostView];
 }
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
@@ -882,6 +885,12 @@ static const NSTimeInterval InitialMeasurementTimeout = 0.5;
       return;
     }
 
+    if (!strongSelf->_measurementViewController && strongSelf->_initialMeasurementDeadline > CACurrentMediaTime() &&
+        [strongSelf stageContainerViewInMeasurementController]) {
+      [strongSelf scheduleInitialPresentationAfterMeasurement];
+      return;
+    }
+
     strongSelf->_isInitialMeasurementPending = NO;
 
     if (strongSelf->_controller.isPresented || strongSelf->_controller.isBeingPresented)
@@ -907,7 +916,7 @@ static const NSTimeInterval InitialMeasurementTimeout = 0.5;
 
 - (void)stageContainerViewForMeasurement {
   if (!_containerView || !self.window || _controller.isPresented || _controller.isBeingPresented ||
-      _controller.isBeingDismissed || _containerView.superview == _measurementHostView) {
+      _controller.isBeingDismissed || _measurementViewController || _containerView.superview == _measurementHostView) {
     return;
   }
 
@@ -932,6 +941,35 @@ static const NSTimeInterval InitialMeasurementTimeout = 0.5;
   [_containerView layoutIfNeeded];
 }
 
+- (BOOL)stageContainerViewInMeasurementController {
+  if (!_containerView || !_measurementHostView || !_measurementHostView.superview || _measurementViewController) {
+    return NO;
+  }
+
+  UIViewController *presentingViewController = [self findPresentingViewController];
+  if (!presentingViewController || presentingViewController.view.window != self.window) {
+    return NO;
+  }
+
+  // Native-backed children can derive intrinsic size from their containing
+  // view controller. Recreate that transition inside the hidden host before
+  // UIKit resolves the initial measured detent. A disposable controller keeps
+  // the real sheet controller's first containment transition reserved for its
+  // actual presentation.
+  _measurementViewController = [[UIViewController alloc] init];
+  [presentingViewController addChildViewController:_measurementViewController];
+  _measurementViewController.view.frame = _measurementHostView.bounds;
+  _measurementViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  [_measurementHostView addSubview:_measurementViewController.view];
+  [_measurementViewController didMoveToParentViewController:presentingViewController];
+
+  _containerView.frame = _measurementViewController.view.bounds;
+  [_measurementViewController.view addSubview:_containerView];
+  [_containerView setNeedsLayout];
+  [_containerView layoutIfNeeded];
+  return YES;
+}
+
 - (void)attachContainerViewToController {
   if (!_containerView || _containerView.superview == _controller.view) {
     return;
@@ -942,6 +980,13 @@ static const NSTimeInterval InitialMeasurementTimeout = 0.5;
 }
 
 - (void)removeMeasurementHostView {
+  if (_measurementViewController.parentViewController) {
+    [_measurementViewController willMoveToParentViewController:nil];
+    [_measurementViewController.view removeFromSuperview];
+    [_measurementViewController removeFromParentViewController];
+  }
+
+  _measurementViewController = nil;
   [_measurementHostView removeFromSuperview];
   _measurementHostView = nil;
 }

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -960,11 +960,15 @@ static const NSTimeInterval InitialMeasurementTimeout = 0.5;
   [presentingViewController addChildViewController:_measurementViewController];
   _measurementViewController.view.frame = _measurementHostView.bounds;
   _measurementViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  [_measurementHostView addSubview:_measurementViewController.view];
-  [_measurementViewController didMoveToParentViewController:presentingViewController];
 
+  // Move through an off-window controller view before attaching it to the
+  // hidden host. Native wrappers such as Expo's SwiftUI Host reparent their
+  // internal view controller from didMoveToWindow; a direct window-to-window
+  // move skips that lifecycle and leaves their pre-presentation size stale.
   _containerView.frame = _measurementViewController.view.bounds;
   [_measurementViewController.view addSubview:_containerView];
+  [_measurementHostView addSubview:_measurementViewController.view];
+  [_measurementViewController didMoveToParentViewController:presentingViewController];
   [_containerView setNeedsLayout];
   [_containerView layoutIfNeeded];
   return YES;

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -29,6 +29,7 @@
 #import <react/renderer/components/TrueSheetSpec/TrueSheetViewShadowNode.h>
 #import <react/renderer/components/TrueSheetSpec/TrueSheetViewState.h>
 
+#import <QuartzCore/QuartzCore.h>
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTLog.h>
@@ -38,6 +39,12 @@
 
 using namespace facebook::react;
 
+// Native-backed children such as SwiftUI views can publish their intrinsic size
+// several display frames after entering a window. Wait for a short quiet period,
+// but cap the total delay so a broken child cannot block presentation forever.
+static const NSTimeInterval InitialMeasurementSettleInterval = 0.08;
+static const NSTimeInterval InitialMeasurementTimeout = 0.5;
+
 @interface TrueSheetView () <TrueSheetViewControllerDelegate,
   TrueSheetContainerViewDelegate,
   RNScreensEventObserverDelegate>
@@ -45,6 +52,8 @@ using namespace facebook::react;
 - (void)stageContainerViewForMeasurement;
 - (void)attachContainerViewToController;
 - (void)removeMeasurementHostView;
+- (void)scheduleInitialPresentationAfterMeasurement;
+- (void)cancelPendingInitialPresentation;
 @end
 
 @implementation TrueSheetView {
@@ -67,6 +76,9 @@ using namespace facebook::react;
   BOOL _pendingMountEvent;
   BOOL _pendingSizeChange;
   BOOL _pendingPropsUpdate;
+  BOOL _isInitialMeasurementPending;
+  NSUInteger _initialMeasurementGeneration;
+  CFTimeInterval _initialMeasurementDeadline;
   UIView *_measurementHostView;
   NSArray *_pendingDetents;
   RNScreensEventObserver *_screensEventObserver;
@@ -92,6 +104,9 @@ using namespace facebook::react;
     _initialDetentIndex = -1;
     _initialDetentAnimated = YES;
     _isSheetUpdatePending = NO;
+    _isInitialMeasurementPending = NO;
+    _initialMeasurementGeneration = 0;
+    _initialMeasurementDeadline = 0;
 
     _screensEventObserver = [[RNScreensEventObserver alloc] init];
     _screensEventObserver.delegate = self;
@@ -142,35 +157,21 @@ using namespace facebook::react;
   }
 
   _didInitiallyPresent = YES;
+  _isInitialMeasurementPending = YES;
+
+  BOOL usesMeasuredDetent = NO;
+  if (_initialDetentIndex < (NSInteger)_controller.detents.count) {
+    double detent = [_controller.detents[_initialDetentIndex] doubleValue];
+    usesMeasuredDetent = detent == -1 || detent == -2;
+  }
+  _initialMeasurementDeadline = CACurrentMediaTime() + (usesMeasuredDetent ? InitialMeasurementTimeout : 0);
 
   [self stageContainerViewForMeasurement];
-
-  // Deferred a runloop turn so sibling mounts from the current transaction
-  // (e.g. a footer committed alongside the prop) land before measuring.
-  __weak __typeof(self) weakSelf = self;
-  dispatch_async(dispatch_get_main_queue(), ^{
-    // SwiftUI-backed children report their intrinsic size after entering a
-    // window. Give that measurement one more runloop turn to reach Fabric
-    // before the auto detent is captured for presentation.
-    dispatch_async(dispatch_get_main_queue(), ^{
-      __typeof(self) strongSelf = weakSelf;
-      if (!strongSelf || strongSelf->_controller.isPresented || strongSelf->_controller.isBeingPresented)
-        return;
-
-      [strongSelf presentAtIndex:strongSelf->_initialDetentIndex
-                        animated:strongSelf->_initialDetentAnimated
-                      completion:^(BOOL success, NSError *_Nullable error) {
-                        // Present can fail if the view detached during this turn —
-                        // reset so the next attach/prop update retries.
-                        if (!success) {
-                          strongSelf->_didInitiallyPresent = NO;
-                        }
-                      }];
-    });
-  });
+  [self scheduleInitialPresentationAfterMeasurement];
 }
 
 - (void)dealloc {
+  [self cancelPendingInitialPresentation];
   [self removeMeasurementHostView];
   [_screensEventObserver stopObserving];
   _screensEventObserver = nil;
@@ -402,6 +403,7 @@ using namespace facebook::react;
 - (void)prepareForRecycle {
   [super prepareForRecycle];
 
+  [self cancelPendingInitialPresentation];
   [self attachContainerViewToController];
   [self removeMeasurementHostView];
 
@@ -418,6 +420,12 @@ using namespace facebook::react;
 - (void)cleanupContainerView {
   if (_containerView == nil)
     return;
+
+  BOOL wasInitialMeasurementPending = _isInitialMeasurementPending;
+  [self cancelPendingInitialPresentation];
+  if (wasInitialMeasurementPending) {
+    _didInitiallyPresent = NO;
+  }
 
   _containerView.delegate = nil;
   [_touchHandler detachFromView:_containerView];
@@ -503,6 +511,8 @@ using namespace facebook::react;
 - (void)presentAtIndex:(NSInteger)index
               animated:(BOOL)animated
             completion:(nullable TrueSheetCompletionBlock)completion {
+  [self cancelPendingInitialPresentation];
+
   if (_controller.isBeingPresented || _controller.isPresented) {
     RCTLogWarn(@"TrueSheet: sheet is already presented. Use resize() to change detent.");
     if (completion) {
@@ -684,21 +694,25 @@ using namespace facebook::react;
 - (void)containerViewContentDidChangeSize:(CGSize)newSize {
   _controller.contentHeight = @(newSize.height);
   [self setupSheetDetentsForSizeChange];
+  [self scheduleInitialPresentationAfterMeasurement];
 }
 
 - (void)containerViewHeaderDidChangeSize:(CGSize)newSize {
   _controller.headerHeight = @(newSize.height);
   [self setupSheetDetentsForSizeChange];
+  [self scheduleInitialPresentationAfterMeasurement];
 }
 
 - (void)containerViewFooterDidChangeSize:(CGSize)newSize {
   [self syncFooterMetrics];
   [self setupSheetDetentsForSizeChange];
   [_controller setupAccessibilityContainer];
+  [self scheduleInitialPresentationAfterMeasurement];
 }
 
 - (void)containerViewPeekDidChangeSize:(CGSize)newSize {
   [self setupSheetDetentsForSizeChange];
+  [self scheduleInitialPresentationAfterMeasurement];
 }
 
 // When the ScrollView changes (e.g. conditional remount), re-detect the new ScrollView.
@@ -851,6 +865,45 @@ using namespace facebook::react;
 }
 
 #pragma mark - Private Helpers
+
+- (void)scheduleInitialPresentationAfterMeasurement {
+  if (!_isInitialMeasurementPending)
+    return;
+
+  NSUInteger generation = ++_initialMeasurementGeneration;
+  CFTimeInterval remaining = MAX(0.0, _initialMeasurementDeadline - CACurrentMediaTime());
+  NSTimeInterval delay = MIN(InitialMeasurementSettleInterval, remaining);
+
+  __weak __typeof(self) weakSelf = self;
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    __typeof(self) strongSelf = weakSelf;
+    if (!strongSelf || !strongSelf->_isInitialMeasurementPending ||
+        generation != strongSelf->_initialMeasurementGeneration) {
+      return;
+    }
+
+    strongSelf->_isInitialMeasurementPending = NO;
+
+    if (strongSelf->_controller.isPresented || strongSelf->_controller.isBeingPresented)
+      return;
+
+    [strongSelf presentAtIndex:strongSelf->_initialDetentIndex
+                      animated:strongSelf->_initialDetentAnimated
+                    completion:^(BOOL success, NSError *_Nullable error) {
+                      // Present can fail if the view detached while waiting —
+                      // reset so the next attach/prop update retries.
+                      if (!success) {
+                        strongSelf->_didInitiallyPresent = NO;
+                      }
+                    }];
+  });
+}
+
+- (void)cancelPendingInitialPresentation {
+  _isInitialMeasurementPending = NO;
+  _initialMeasurementDeadline = 0;
+  _initialMeasurementGeneration++;
+}
 
 - (void)stageContainerViewForMeasurement {
   if (!_containerView || !self.window || _controller.isPresented || _controller.isBeingPresented ||

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -41,6 +41,10 @@ using namespace facebook::react;
 @interface TrueSheetView () <TrueSheetViewControllerDelegate,
   TrueSheetContainerViewDelegate,
   RNScreensEventObserverDelegate>
+
+- (void)stageContainerViewForMeasurement;
+- (void)attachContainerViewToController;
+- (void)removeMeasurementHostView;
 @end
 
 @implementation TrueSheetView {
@@ -63,6 +67,7 @@ using namespace facebook::react;
   BOOL _pendingMountEvent;
   BOOL _pendingSizeChange;
   BOOL _pendingPropsUpdate;
+  UIView *_measurementHostView;
   NSArray *_pendingDetents;
   RNScreensEventObserver *_screensEventObserver;
 }
@@ -97,12 +102,17 @@ using namespace facebook::react;
 - (void)didMoveToWindow {
   [super didMoveToWindow];
 
-  if (!self.window)
+  if (!self.window) {
+    [self attachContainerViewToController];
+    [self removeMeasurementHostView];
     return;
+  }
 
   if (self.tag > 0) {
     [TrueSheetModule registerView:self withTag:@(self.tag)];
   }
+
+  [self stageContainerViewForMeasurement];
 
   if (_pendingNavigationRepresent && !_controller.isPresented) {
     _pendingNavigationRepresent = NO;
@@ -133,27 +143,35 @@ using namespace facebook::react;
 
   _didInitiallyPresent = YES;
 
+  [self stageContainerViewForMeasurement];
+
   // Deferred a runloop turn so sibling mounts from the current transaction
   // (e.g. a footer committed alongside the prop) land before measuring.
   __weak __typeof(self) weakSelf = self;
   dispatch_async(dispatch_get_main_queue(), ^{
-    __typeof(self) strongSelf = weakSelf;
-    if (!strongSelf || strongSelf->_controller.isPresented || strongSelf->_controller.isBeingPresented)
-      return;
+    // SwiftUI-backed children report their intrinsic size after entering a
+    // window. Give that measurement one more runloop turn to reach Fabric
+    // before the auto detent is captured for presentation.
+    dispatch_async(dispatch_get_main_queue(), ^{
+      __typeof(self) strongSelf = weakSelf;
+      if (!strongSelf || strongSelf->_controller.isPresented || strongSelf->_controller.isBeingPresented)
+        return;
 
-    [strongSelf presentAtIndex:strongSelf->_initialDetentIndex
-                      animated:strongSelf->_initialDetentAnimated
-                    completion:^(BOOL success, NSError *_Nullable error) {
-                      // Present can fail if the view detached during this turn —
-                      // reset so the next attach/prop update retries.
-                      if (!success) {
-                        strongSelf->_didInitiallyPresent = NO;
-                      }
-                    }];
+      [strongSelf presentAtIndex:strongSelf->_initialDetentIndex
+                        animated:strongSelf->_initialDetentAnimated
+                      completion:^(BOOL success, NSError *_Nullable error) {
+                        // Present can fail if the view detached during this turn —
+                        // reset so the next attach/prop update retries.
+                        if (!success) {
+                          strongSelf->_didInitiallyPresent = NO;
+                        }
+                      }];
+    });
   });
 }
 
 - (void)dealloc {
+  [self removeMeasurementHostView];
   [_screensEventObserver stopObserving];
   _screensEventObserver = nil;
 
@@ -362,6 +380,8 @@ using namespace facebook::react;
     [TrueSheetLifecycleEvents emitMount:_eventEmitter];
   }
 
+  [self stageContainerViewForMeasurement];
+
   if (!(updateMask & RNComponentViewUpdateMaskProps) || !_controller)
     return;
 
@@ -381,6 +401,9 @@ using namespace facebook::react;
 
 - (void)prepareForRecycle {
   [super prepareForRecycle];
+
+  [self attachContainerViewToController];
+  [self removeMeasurementHostView];
 
   [TrueSheetModule unregisterViewWithTag:@(self.tag)];
 
@@ -451,6 +474,8 @@ using namespace facebook::react;
   } else {
     _pendingMountEvent = YES;
   }
+
+  [self stageContainerViewForMeasurement];
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
@@ -499,6 +524,9 @@ using namespace facebook::react;
     }
     return;
   }
+
+  [self attachContainerViewToController];
+  [self removeMeasurementHostView];
 
   [_controller setupAnchorViewInView:presentingViewController.view];
   [_controller setupSheetSizing];
@@ -735,6 +763,10 @@ using namespace facebook::react;
     _controller.activeDetentIndex = -1;
     [TrueSheetLifecycleEvents emitDidDismiss:_eventEmitter];
   }
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self stageContainerViewForMeasurement];
+  });
 }
 
 - (void)viewControllerDidChangeDetent:(NSInteger)index position:(CGFloat)position detent:(CGFloat)detent {
@@ -819,6 +851,47 @@ using namespace facebook::react;
 }
 
 #pragma mark - Private Helpers
+
+- (void)stageContainerViewForMeasurement {
+  if (!_containerView || !self.window || _controller.isPresented || _controller.isBeingPresented ||
+      _controller.isBeingDismissed || _containerView.superview == _measurementHostView) {
+    return;
+  }
+
+  UIViewController *presentingViewController = [self findPresentingViewController];
+  UIView *presenterView = presentingViewController.view;
+  if (!presentingViewController || presenterView.window != self.window) {
+    return;
+  }
+
+  if (!_measurementHostView) {
+    _measurementHostView = [[UIView alloc] initWithFrame:presenterView.bounds];
+    _measurementHostView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    _measurementHostView.alpha = 0;
+    _measurementHostView.userInteractionEnabled = NO;
+    _measurementHostView.accessibilityElementsHidden = YES;
+    [presenterView insertSubview:_measurementHostView atIndex:0];
+  }
+
+  _containerView.frame = _measurementHostView.bounds;
+  [_measurementHostView addSubview:_containerView];
+  [_containerView setNeedsLayout];
+  [_containerView layoutIfNeeded];
+}
+
+- (void)attachContainerViewToController {
+  if (!_containerView || _containerView.superview == _controller.view) {
+    return;
+  }
+
+  [_controller.view addSubview:_containerView];
+  [_controller.view bringSubviewToFront:_containerView];
+}
+
+- (void)removeMeasurementHostView {
+  [_measurementHostView removeFromSuperview];
+  _measurementHostView = nil;
+}
 
 - (void)setupScrollable {
   if (!_containerView)


### PR DESCRIPTION
## Summary

Stage mounted sheet content in an invisible on-window host before presentation, then premeasure it inside a disposable child view controller before UIKit resolves the initial `auto` or `peek` detent.

Some native-backed children, including SwiftUI controls, change intrinsic size when they first acquire a containing view controller. Expo's SwiftUI host performs that reparenting from `didMoveToWindow`. Moving sheet content directly between two views that are already in the same window skips that callback, leaving the pre-presentation measurement stale. This change first moves content into the disposable controller while it is off-window, then attaches that controller to the hidden host. Nested hosting controllers therefore settle their intrinsic size before the opening animation captures its target detent.

Fixed detents keep their existing next-turn timing. Pending measurement work is still bounded by the existing 500 ms deadline and invalidated when presentation is superseded, content unmounts, or the component is recycled or deallocated.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Run `yarn test` (69 tests).
- Run `yarn typecheck`.
- Run `yarn prepare`.
- Run `xcrun clang-format --dry-run --Werror ios/TrueSheetView.mm`.
- Run `git diff --check`.
- Compile, install, and launch the patched package through an Expo SDK 57 / React Native 0.86 iOS app.
- On an iPhone 17 Pro simulator running iOS 26.5, verify both affected paths:
  - A lazy auto-height graphical SwiftUI date picker presents the complete six-week calendar in one continuous opening.
  - The biometric enrollment sheet reached through `/security-enroll-prompt` presents its complete content in one continuous opening.
- Compare the recordings with a deterministic frame analyzer. The reported date-sheet capture rises only 10 px over six frames with 69 px still remaining, then rises another 64 px. Two independent clean-build date-sheet presentations and the biometric enrollment presentation show no slow near-target interval followed by a second rise.

## Screenshots / Videos

The affected presentation paths were validated frame-by-frame. The consuming app is private, so its recordings are omitted here.

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)
