### PR TITLE
fix: source Expo Router navigation types from expo-router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **Android**: The scrollable content now tracks the keyboard frame-by-frame — the focused input rides the keyboard up smoothly, and the scroll position eases back on dismiss instead of snapping. ([#798](https://github.com/lodev09/react-native-true-sheet/pull/798) by [@lodev09](https://github.com/lodev09))
 - The keyboard-driven scroll inset now accounts for a floating footer's height. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))
 - Auto detents now correctly size explicit-height and deeply nested scrollables. ([#783](https://github.com/lodev09/react-native-true-sheet/pull/783) by [@lodev09](https://github.com/lodev09))
+- The `/navigation/expo-router` entry now sources its base types from Expo Router's vendored React Navigation, so Expo Router apps get real navigation types instead of silently resolving to `any` — which left screen options unchecked and made `screenListeners` required. ([#806](https://github.com/lodev09/react-native-true-sheet/pull/806) by [@lodev09](https://github.com/lodev09))
 
 ### 💥 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 - **Android**: The scrollable content now tracks the keyboard frame-by-frame — the focused input rides the keyboard up smoothly, and the scroll position eases back on dismiss instead of snapping. ([#798](https://github.com/lodev09/react-native-true-sheet/pull/798) by [@lodev09](https://github.com/lodev09))
 - The keyboard-driven scroll inset now accounts for a floating footer's height. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))
 - Auto detents now correctly size explicit-height and deeply nested scrollables. ([#783](https://github.com/lodev09/react-native-true-sheet/pull/783) by [@lodev09](https://github.com/lodev09))
-- The `/navigation/expo-router` entry now sources its base types from Expo Router's vendored React Navigation, so Expo Router apps get real navigation types instead of silently resolving to `any` — which left screen options unchecked and made `screenListeners` required. ([#806](https://github.com/lodev09/react-native-true-sheet/pull/806) by [@lodev09](https://github.com/lodev09))
 
 ### 💥 Breaking changes
 

--- a/src/mocks/navigationExpoRouter.ts
+++ b/src/mocks/navigationExpoRouter.ts
@@ -1,6 +1,5 @@
-import type { ParamListBase } from '@react-navigation/native';
-
-import type { TrueSheetNavigationProp } from '../navigation/types';
+import type { ParamListBase } from '../navigation/expo-router/base-types';
+import type { TrueSheetNavigationProp } from '../navigation/expo-router/types';
 import {
   TrueSheetActions,
   useTrueSheetNavigation as useTrueSheetNavigationMock,
@@ -22,8 +21,10 @@ export const Sheet = Object.assign(
  * Mock useTrueSheetNavigation hook for testing.
  */
 export const useTrueSheetNavigation = jest.fn(
+  // Double cast: the shared mock is typed against React Navigation, this entry
+  // against Expo Router's vendored copy — identical shapes, unrelated declarations
   <T extends ParamListBase = ParamListBase>(): TrueSheetNavigationProp<T> =>
-    useTrueSheetNavigationMock() as TrueSheetNavigationProp<T>
+    useTrueSheetNavigationMock() as unknown as TrueSheetNavigationProp<T>
 );
 
 export { TrueSheetActions };
@@ -37,4 +38,4 @@ export type {
   TrueSheetNavigationProp,
   TrueSheetNavigationState,
   TrueSheetScreenProps,
-} from '../navigation/types';
+} from '../navigation/expo-router/types';

--- a/src/navigation/__tests__/createTrueSheetRouter.test.ts
+++ b/src/navigation/__tests__/createTrueSheetRouter.test.ts
@@ -1,7 +1,8 @@
 import { StackRouter, type ParamListBase } from '@react-navigation/core';
 
 import { TrueSheetActions } from '../actions';
-import { createTrueSheetRouter, type StackRouterFactory } from '../createTrueSheetRouter';
+import { createTrueSheetRouter } from '../createTrueSheetRouter';
+import type { StackRouterFactory } from '../types';
 import type { TrueSheetNavigationState } from '../types';
 
 type State = TrueSheetNavigationState<ParamListBase>;

--- a/src/navigation/base-types.ts
+++ b/src/navigation/base-types.ts
@@ -1,0 +1,20 @@
+/**
+ * Base navigation types for the React Navigation entry point.
+ *
+ * The Expo Router entry has its own copy sourced from `expo-router/react-navigation`
+ * (see `./expo-router/base-types`) because Expo Router apps never install
+ * `@react-navigation/*` — importing it there would silently resolve to `any`.
+ */
+export type {
+  DefaultNavigatorOptions,
+  Descriptor,
+  NavigationAction,
+  NavigationHelpers,
+  NavigationProp,
+  NavigationState,
+  ParamListBase,
+  RouteProp,
+  Router,
+  StackActionHelpers,
+  StackRouterOptions,
+} from '@react-navigation/core';

--- a/src/navigation/createTrueSheetRouter.ts
+++ b/src/navigation/createTrueSheetRouter.ts
@@ -1,12 +1,11 @@
+import { TrueSheetActions, type TrueSheetActionType } from './actions';
 import type {
   NavigationAction,
   NavigationState,
   ParamListBase,
   Router,
   StackRouterOptions,
-} from '@react-navigation/core';
-
-import { TrueSheetActions, type TrueSheetActionType } from './actions';
+} from './base-types';
 import type { TrueSheetNavigationState } from './types';
 
 export type TrueSheetRouterOptions = StackRouterOptions;

--- a/src/navigation/createTrueSheetRouter.ts
+++ b/src/navigation/createTrueSheetRouter.ts
@@ -1,28 +1,5 @@
-import { TrueSheetActions, type TrueSheetActionType } from './actions';
-import type {
-  NavigationAction,
-  NavigationState,
-  ParamListBase,
-  Router,
-  StackRouterOptions,
-} from './base-types';
-import type { TrueSheetNavigationState } from './types';
-
-export type TrueSheetRouterOptions = StackRouterOptions;
-
-/**
- * The base `StackRouter` factory to wrap, typed generically over the state and
- * action types the wrapper threads through — `StackRouter` is structural and
- * never touches the sheet-specific fields.
- * Injected by each entry point so the shared router never imports
- * `@react-navigation/*` at runtime (Expo Router apps don't install it).
- */
-export type StackRouterFactory = <
-  State extends NavigationState<ParamListBase>,
-  Action extends NavigationAction,
->(
-  options: TrueSheetRouterOptions
-) => Router<State, Action>;
+import { TrueSheetActions } from './actions';
+import type { TrueSheetRouter, TrueSheetRouterFactory, TrueSheetRouterOptions } from './types';
 
 const uid = () => Math.random().toString(36).slice(2, 10);
 
@@ -55,13 +32,9 @@ const ensureBaseRoute = <T extends { routes: { name: string }[] }>(
 };
 
 export const createTrueSheetRouter =
-  (stackRouter: StackRouterFactory) =>
-  (
-    routerOptions: TrueSheetRouterOptions
-  ): Router<TrueSheetNavigationState<ParamListBase>, TrueSheetActionType> => {
-    const baseRouter = stackRouter<TrueSheetNavigationState<ParamListBase>, TrueSheetActionType>(
-      routerOptions
-    );
+  (stackRouter: TrueSheetRouterFactory) =>
+  (routerOptions: TrueSheetRouterOptions): TrueSheetRouter => {
+    const baseRouter = stackRouter(routerOptions);
 
     return {
       ...baseRouter,

--- a/src/navigation/expo-router/base-types.ts
+++ b/src/navigation/expo-router/base-types.ts
@@ -1,0 +1,16 @@
+/**
+ * Base navigation types for the Expo Router entry point.
+ *
+ * Sourced from Expo Router's vendored React Navigation so apps that only install
+ * `expo-router` still get real types — see `../base-types` for the React Navigation copy.
+ */
+export type {
+  DefaultNavigatorOptions,
+  NavigationHelpers,
+  NavigationProp,
+  NavigationState,
+  ParamListBase,
+  RouteProp,
+  StackActionHelpers,
+  StackRouterOptions,
+} from 'expo-router/react-navigation';

--- a/src/navigation/expo-router/base-types.ts
+++ b/src/navigation/expo-router/base-types.ts
@@ -6,11 +6,13 @@
  */
 export type {
   DefaultNavigatorOptions,
+  NavigationAction,
   NavigationHelpers,
   NavigationProp,
   NavigationState,
   ParamListBase,
   RouteProp,
+  Router,
   StackActionHelpers,
   StackRouterOptions,
 } from 'expo-router/react-navigation';

--- a/src/navigation/expo-router/index.ts
+++ b/src/navigation/expo-router/index.ts
@@ -1,17 +1,26 @@
 import { StackRouter, unstable_integrateWithRouter, useNavigation } from 'expo-router';
 
-import { createTrueSheetRouter, type StackRouterFactory } from '../createTrueSheetRouter';
+import { createTrueSheetRouter } from '../createTrueSheetRouter';
 import { trueSheetNavigator } from '../navigator';
 import type { ParamListBase } from './base-types';
 import type {
+  StackRouterFactory,
   TrueSheetNavigationOptions,
   TrueSheetNavigationProp,
   TrueSheetNavigationState,
   TrueSheetNavigatorContentExtraProps,
   TrueSheetNavigatorProps,
+  TrueSheetRouterFactory,
   TrueSheetRouterOptions,
   TrueSheetStandardEventMap,
 } from './types';
+
+// expo-router's vendored StackRouter is structurally identical to @react-navigation's.
+// Pinned to this entry's own router types: `createTrueSheetRouter` is shared and typed
+// against React Navigation, which resolves to `any` in apps that only install expo-router.
+const sheetRouter: TrueSheetRouterFactory = createTrueSheetRouter(
+  StackRouter as StackRouterFactory
+);
 
 const SheetNavigator = unstable_integrateWithRouter<
   TrueSheetNavigationOptions,
@@ -19,17 +28,12 @@ const SheetNavigator = unstable_integrateWithRouter<
   TrueSheetStandardEventMap,
   TrueSheetNavigatorContentExtraProps,
   TrueSheetRouterOptions
->(
-  trueSheetNavigator,
-  // expo-router's vendored StackRouter is structurally identical to @react-navigation's
-  createTrueSheetRouter(StackRouter as StackRouterFactory),
-  {
-    createProps: ({ state, dispatch }) => ({
-      routes: state.routes,
-      dispatch,
-    }),
-  }
-);
+>(trueSheetNavigator, sheetRouter, {
+  createProps: ({ state, dispatch }) => ({
+    routes: state.routes,
+    dispatch,
+  }),
+});
 
 // Public props: `routes`/`dispatch` are injected by `createProps` (optional here
 // so the navigator type stays comparable), and expo-router intersects the event

--- a/src/navigation/expo-router/index.ts
+++ b/src/navigation/expo-router/index.ts
@@ -1,20 +1,17 @@
-import type { ParamListBase } from '@react-navigation/core';
 import { StackRouter, unstable_integrateWithRouter, useNavigation } from 'expo-router';
 
-import {
-  createTrueSheetRouter,
-  type StackRouterFactory,
-  type TrueSheetRouterOptions,
-} from '../createTrueSheetRouter';
+import { createTrueSheetRouter, type StackRouterFactory } from '../createTrueSheetRouter';
 import { trueSheetNavigator } from '../navigator';
+import type { ParamListBase } from './base-types';
 import type {
   TrueSheetNavigationOptions,
   TrueSheetNavigationProp,
   TrueSheetNavigationState,
   TrueSheetNavigatorContentExtraProps,
   TrueSheetNavigatorProps,
+  TrueSheetRouterOptions,
   TrueSheetStandardEventMap,
-} from '../types';
+} from './types';
 
 const SheetNavigator = unstable_integrateWithRouter<
   TrueSheetNavigationOptions,
@@ -86,4 +83,4 @@ export type {
   TrueSheetNavigationProp,
   TrueSheetNavigationState,
   TrueSheetScreenProps,
-} from '../types';
+} from './types';

--- a/src/navigation/expo-router/types.ts
+++ b/src/navigation/expo-router/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Expo Router flavour of `../types`: same shapes, but bound to Expo Router's
+ * vendored React Navigation types so apps that only install `expo-router` still
+ * get real types instead of `any` — see `./base-types`.
+ */
+import type {
+  TrueSheetActionHelpersOf,
+  TrueSheetDispatch,
+  TrueSheetNavigationEventMap,
+  TrueSheetNavigationOptions,
+  TrueSheetStateOf,
+} from '../types';
+import type {
+  DefaultNavigatorOptions,
+  NavigationHelpers,
+  NavigationProp,
+  NavigationState,
+  ParamListBase,
+  RouteProp,
+  StackActionHelpers,
+  StackRouterOptions,
+} from './base-types';
+
+export type TrueSheetRouterOptions = StackRouterOptions;
+
+export type TrueSheetNavigationState<ParamList extends ParamListBase> = TrueSheetStateOf<
+  NavigationState<ParamList>
+>;
+
+export type TrueSheetRoute = TrueSheetNavigationState<ParamListBase>['routes'][number];
+
+/**
+ * Props injected into the navigator content by Expo Router's `createProps`.
+ * Raw routes carry the custom fields (`closing`, `resizeIndex`, `resizeKey`)
+ * that the standard state strips out.
+ */
+export interface TrueSheetNavigatorContentExtraProps {
+  routes: TrueSheetRoute[];
+  dispatch: TrueSheetDispatch;
+}
+
+export type TrueSheetActionHelpers<ParamList extends ParamListBase> = TrueSheetActionHelpersOf<
+  StackActionHelpers<ParamList>
+>;
+
+export type TrueSheetNavigationProp<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList = string,
+  NavigatorID extends string | undefined = undefined,
+> = NavigationProp<
+  ParamList,
+  RouteName,
+  NavigatorID,
+  TrueSheetNavigationState<ParamList>,
+  TrueSheetNavigationOptions,
+  TrueSheetNavigationEventMap
+> &
+  TrueSheetActionHelpers<ParamList>;
+
+export type TrueSheetScreenProps<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList = string,
+  NavigatorID extends string | undefined = undefined,
+> = {
+  navigation: TrueSheetNavigationProp<ParamList, RouteName, NavigatorID>;
+  route: RouteProp<ParamList, RouteName>;
+};
+
+export type TrueSheetNavigationHelpers = NavigationHelpers<
+  ParamListBase,
+  TrueSheetNavigationEventMap
+>;
+
+export type TrueSheetNavigatorProps = DefaultNavigatorOptions<
+  ParamListBase,
+  string | undefined,
+  TrueSheetNavigationState<ParamListBase>,
+  TrueSheetNavigationOptions,
+  TrueSheetNavigationEventMap,
+  unknown
+> & {
+  /**
+   * The name of the route to use as the base screen.
+   * This screen will be rendered as a regular screen, while other screens are presented as sheets.
+   * Defaults to the first screen defined in the navigator.
+   */
+  initialRouteName?: string;
+};
+
+export type {
+  PositionChangeHandler,
+  TrueSheetDispatch,
+  TrueSheetNavigationEventMap,
+  TrueSheetNavigationOptions,
+  TrueSheetNavigationSheetProps,
+  TrueSheetStandardEventMap,
+} from '../types';

--- a/src/navigation/expo-router/types.ts
+++ b/src/navigation/expo-router/types.ts
@@ -3,6 +3,7 @@
  * vendored React Navigation types so apps that only install `expo-router` still
  * get real types instead of `any` — see `./base-types`.
  */
+import type { TrueSheetActionType } from '../actions';
 import type {
   TrueSheetActionHelpersOf,
   TrueSheetDispatch,
@@ -12,11 +13,13 @@ import type {
 } from '../types';
 import type {
   DefaultNavigatorOptions,
+  NavigationAction,
   NavigationHelpers,
   NavigationProp,
   NavigationState,
   ParamListBase,
   RouteProp,
+  Router,
   StackActionHelpers,
   StackRouterOptions,
 } from './base-types';
@@ -26,6 +29,22 @@ export type TrueSheetRouterOptions = StackRouterOptions;
 export type TrueSheetNavigationState<ParamList extends ParamListBase> = TrueSheetStateOf<
   NavigationState<ParamList>
 >;
+
+export type TrueSheetRouterState = TrueSheetNavigationState<ParamListBase>;
+
+export type TrueSheetRouter = Router<TrueSheetRouterState, TrueSheetActionType>;
+
+export type TrueSheetRouterFactory = (options: TrueSheetRouterOptions) => TrueSheetRouter;
+
+/**
+ * The base `StackRouter` factory to wrap — see `../types` for the shared contract.
+ */
+export type StackRouterFactory = <
+  State extends NavigationState<ParamListBase>,
+  Action extends NavigationAction,
+>(
+  options: TrueSheetRouterOptions
+) => Router<State, Action>;
 
 export type TrueSheetRoute = TrueSheetNavigationState<ParamListBase>['routes'][number];
 

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -4,16 +4,17 @@ import {
   type StandardNavigationTypeBagBase,
 } from '@react-navigation/native';
 
-import { createTrueSheetRouter, type StackRouterFactory } from './createTrueSheetRouter';
+import { createTrueSheetRouter } from './createTrueSheetRouter';
 import { trueSheetNavigator } from './navigator';
 import type {
+  StackRouterFactory,
   TrueSheetActionHelpers,
   TrueSheetNavigationOptions,
   TrueSheetNavigationEventMap,
   TrueSheetNavigationState,
   TrueSheetNavigatorContentExtraProps,
+  TrueSheetRouterOptions,
 } from './types';
-import type { TrueSheetRouterOptions } from './createTrueSheetRouter';
 
 export interface TrueSheetNavigationTypeBag extends StandardNavigationTypeBagBase {
   State: TrueSheetNavigationState<this['ParamList']>;
@@ -62,20 +63,18 @@ export const createTrueSheetNavigator = createNavigator;
 export const createTrueSheetScreen = createScreen;
 
 export { TrueSheetActions, type TrueSheetActionType } from './actions';
-export {
-  createTrueSheetRouter,
-  type StackRouterFactory,
-  type TrueSheetRouterOptions,
-} from './createTrueSheetRouter';
+export { createTrueSheetRouter } from './createTrueSheetRouter';
 export { useTrueSheetNavigation } from './useTrueSheetNavigation';
 
 export type { DetentInfoEventPayload, PositionChangeEventPayload } from '../TrueSheet.types';
 
 export type {
+  StackRouterFactory,
   TrueSheetNavigationEventMap,
   TrueSheetNavigationHelpers,
   TrueSheetNavigationOptions,
   TrueSheetNavigationProp,
   TrueSheetNavigationState,
+  TrueSheetRouterOptions,
   TrueSheetScreenProps,
 } from './types';

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -9,12 +9,15 @@ import type { TrueSheetActionType } from './actions';
 import type {
   DefaultNavigatorOptions,
   Descriptor,
+  NavigationAction,
   NavigationHelpers,
   NavigationProp,
   NavigationState,
   ParamListBase,
   RouteProp,
+  Router,
   StackActionHelpers,
+  StackRouterOptions,
 } from './base-types';
 
 export type PositionChangeHandler = (payload: PositionChangeEventPayload) => void;
@@ -95,6 +98,32 @@ export type TrueSheetStateOf<State extends { routes: readonly unknown[] }> = Omi
 export type TrueSheetNavigationState<ParamList extends ParamListBase> = TrueSheetStateOf<
   NavigationState<ParamList>
 >;
+
+export type TrueSheetRouterState = TrueSheetNavigationState<ParamListBase>;
+
+export type TrueSheetRouterOptions = StackRouterOptions;
+
+export type TrueSheetRouter = Router<TrueSheetRouterState, TrueSheetActionType>;
+
+/**
+ * The wrapped router factory — also the shape `createTrueSheetRouter` accepts,
+ * pre-instantiated so either entry point's `StackRouterFactory` fits it.
+ */
+export type TrueSheetRouterFactory = (options: TrueSheetRouterOptions) => TrueSheetRouter;
+
+/**
+ * The base `StackRouter` factory to wrap, typed generically over the state and
+ * action types the wrapper threads through — `StackRouter` is structural and
+ * never touches the sheet-specific fields.
+ * Injected by each entry point so the shared router never imports
+ * `@react-navigation/*` at runtime (Expo Router apps don't install it).
+ */
+export type StackRouterFactory = <
+  State extends NavigationState<ParamListBase>,
+  Action extends NavigationAction,
+>(
+  options: TrueSheetRouterOptions
+) => Router<State, Action>;
 
 /**
  * `TrueSheetNavigationEventMap` in the `standard-navigation` event-map shape.

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,3 +1,11 @@
+import type { NavigatorArgs } from 'standard-navigation';
+
+import type {
+  DetentInfoEventPayload,
+  PositionChangeEventPayload,
+  TrueSheetProps,
+} from '../TrueSheet.types';
+import type { TrueSheetActionType } from './actions';
 import type {
   DefaultNavigatorOptions,
   Descriptor,
@@ -7,15 +15,7 @@ import type {
   ParamListBase,
   RouteProp,
   StackActionHelpers,
-} from '@react-navigation/core';
-import type { NavigatorArgs } from 'standard-navigation';
-
-import type {
-  DetentInfoEventPayload,
-  PositionChangeEventPayload,
-  TrueSheetProps,
-} from '../TrueSheet.types';
-import type { TrueSheetActionType } from './actions';
+} from './base-types';
 
 export type PositionChangeHandler = (payload: PositionChangeEventPayload) => void;
 
@@ -74,17 +74,27 @@ export type TrueSheetNavigationEventMap = {
   sheetDidBlur: { data: undefined };
 };
 
-export type TrueSheetNavigationState<ParamList extends ParamListBase> = Omit<
-  NavigationState<ParamList>,
+/**
+ * A navigation state tagged as `true-sheet`, with the sheet fields the router
+ * adds to each route.
+ * Generic over the base state so each entry point can bind its own
+ * `NavigationState` — see `./base-types`.
+ */
+export type TrueSheetStateOf<State extends { routes: readonly unknown[] }> = Omit<
+  State,
   'routes'
 > & {
   type: 'true-sheet';
-  routes: (NavigationState<ParamList>['routes'][number] & {
+  routes: (State['routes'][number] & {
     resizeIndex?: number;
     resizeKey?: number;
     closing?: boolean;
   })[];
 };
+
+export type TrueSheetNavigationState<ParamList extends ParamListBase> = TrueSheetStateOf<
+  NavigationState<ParamList>
+>;
 
 /**
  * `TrueSheetNavigationEventMap` in the `standard-navigation` event-map shape.
@@ -116,13 +126,20 @@ export interface TrueSheetNavigatorContentExtraProps {
   dispatch: TrueSheetDispatch;
 }
 
-export type TrueSheetActionHelpers<ParamList extends ParamListBase> =
-  StackActionHelpers<ParamList> & {
-    /**
-     * Resize the sheet to a specific detent index.
-     */
-    resize(index?: number): void;
-  };
+/**
+ * Generic over the base helpers so each entry point can bind its own
+ * `StackActionHelpers` — see `./base-types`.
+ */
+export type TrueSheetActionHelpersOf<Helpers> = Helpers & {
+  /**
+   * Resize the sheet to a specific detent index.
+   */
+  resize(index?: number): void;
+};
+
+export type TrueSheetActionHelpers<ParamList extends ParamListBase> = TrueSheetActionHelpersOf<
+  StackActionHelpers<ParamList>
+>;
 
 export type TrueSheetNavigationProp<
   ParamList extends ParamListBase,


### PR DESCRIPTION
## Summary

v4 tells Expo Router users they don't need `@react-navigation/*`. That's true at runtime, but not for types: `/navigation/expo-router` shared `navigation/types.ts`, which sources its base types from `@react-navigation/core`.

Expo Router apps never install that package (expo-router vendors React Navigation), and `skipLibCheck: true` — Expo's default — suppresses the missing-module error. The base types silently resolved to `any`, so the entry's public types were unchecked:

- `screenListeners` was **required** on `<Sheet>` (`Pick<any, 'screenListeners'>`)
- unknown navigator props were silently accepted

Fix: add a per-entry base-types indirection and bind the Expo Router entry to `expo-router/react-navigation`. All base types are reachable there, and expo-router ships no `exports` map, so the path is public. The entry already imports `expo-router` at runtime, so this adds no dependency.

- `navigation/base-types.ts` / `navigation/expo-router/base-types.ts` — the base types, per entry
- `navigation/expo-router/types.ts` — Expo Router flavour of the base-dependent aliases; base-free ones are re-exported from `../types`
- `navigation/types.ts` — factors out the two shapes that would otherwise be duplicated (`TrueSheetStateOf`, `TrueSheetActionHelpersOf`) so the Expo copy re-binds instead of re-declaring
- `createTrueSheetRouter.ts` — `TrueSheetRouterOptions` and `StackRouterFactory` move into the per-entry `types.ts` files, so the shared router module imports no base types at all and the Expo entry never has to name a React Navigation type. Its factory parameter is pre-instantiated so either entry's `StackRouterFactory` fits without a cast.

The resulting invariant: every base-dependent type has exactly one home per entry (`types.ts`), and only `base-types.ts` names the upstream package.

No public API change — `/navigation` exports the same names, just sourced from `./types`. No runtime change: every pre-existing file in `lib/module` is byte-identical to the pre-fix build apart from one hoisted local and moved comments; the only new emits are empty type-only modules.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Typecheck-only change, so verified against the **built** `lib`, not source — a passing typecheck proves nothing on its own here, since `any` passes too.

`grep -r "@react-navigation" lib/typescript/src/navigation/expo-router/` → empty (also clean for `mocks/navigationExpoRouter.d.ts`).

Isolated app with `expo-router` installed and **no** `@react-navigation/*`, `skipLibCheck: true`, consuming the built package:

- `<Sheet initialRouteName="(home)">` without `screenListeners` → compiles
- `<Sheet.Screen options={{ notARealOption: 1 }} />` → errors
- `options={{ detents: ['auto', 1], scrollableRef }}` → compiles
- unknown navigator prop → errors
- `TrueSheetNavigationOptions` and `navigation.resize()` reject wrong types (`@ts-expect-error` satisfied, so genuinely not `any`)

Against the pre-fix build in the same sandbox: `screenListeners` was required on every `<Sheet>`, and an unknown navigator prop was accepted with no error. Bug reproduced, then gone.

React Navigation entry: second sandbox (with `@react-navigation` present) typechecks `createTrueSheetNavigator`, `useTrueSheetNavigation`, `TrueSheetScreenProps`, and the public `createTrueSheetRouter` / `StackRouterFactory` / `TrueSheetRouterOptions` against the built types. Plus `yarn typecheck`, `eslint`, and `yarn test` (69/69) all pass.

## Screenshots / Videos

N/A — types only.

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)
