### PR TITLE
fix(ios): resolve the scrollable when its handle changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **Android**: The scrollable content now tracks the keyboard frame-by-frame — the focused input rides the keyboard up smoothly, and the scroll position eases back on dismiss instead of snapping. ([#798](https://github.com/lodev09/react-native-true-sheet/pull/798) by [@lodev09](https://github.com/lodev09))
 - The keyboard-driven scroll inset now accounts for a floating footer's height. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))
 - Auto detents now correctly size explicit-height and deeply nested scrollables. ([#783](https://github.com/lodev09/react-native-true-sheet/pull/783) by [@lodev09](https://github.com/lodev09))
+- **iOS**: A scrollable that mounts after the sheet has presented is now resolved — `setScrollableHandle:` released the previous scroll view without re-resolving, so the sheet never adopted the new one. ([#809](https://github.com/lodev09/react-native-true-sheet/pull/809) by [@godza](https://github.com/godza))
 
 ### 💥 Breaking changes
 

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -65,8 +65,10 @@ using namespace facebook::react;
   }
   _scrollableHandle = scrollableHandle;
 
-  // Release the previously resolved ScrollView — setupScrollable re-resolves
+  // Release the previously resolved ScrollView, then resolve the new one. A handle that arrives after the
+  // sheet has presented reaches none of the lifecycle calls that would otherwise re-resolve it.
   [self clearScrollable];
+  [self setupScrollable];
 }
 
 - (void)setContentInsetAdjustment:(BOOL)contentInsetAdjustment {


### PR DESCRIPTION
### Summary

`setScrollableHandle:` releases the resolved scroll view and leaves the search to `setupScrollable`, as
its comment says. Nothing calls `setupScrollable` from there.

`setupScrollable` runs only from lifecycle points — present, layout, size change, and
`containerViewScrollViewDidChange`. A handle that arrives **after** the sheet has presented reaches none
of them, so `_detectedScrollView` stays nil, `applyContentInsetAdjustment` never runs, and the sheet
never adopts the list.

This one line resolves it where the handle changes.

### When it shows

Whenever the scrollable mounts after presentation. In my app the sheet holds a sliding panel and the list
lives in a step the reader opens later, so `scrollableRef` resolves well after `onDidPresent`.

The list still scrolls, because it is a normal RN list, but nothing bounds it. Fifteen rows with ten
visible reached row 13 and no further — a drag revealed the last two and releasing returned to 13.

### Measured

iPhone 17 Pro simulator, iOS 26.5, React Native 0.86.2, New Architecture, `4.0.0-beta.6`, with an
`NSLog` in `setupScrollable` read back through `simctl log stream`:

```
before   scrollH=649  contentH=821  adjustedContentInset.bottom=0
after    scrollH=676  contentH=821  adjustedContentInset.bottom=34
```

The inset is the proof: `applyContentInsetAdjustment` runs only once `_detectedScrollView` is set.

### Why it is safe

`setupScrollable` returns early when it finds nothing, so an early call costs nothing, and every existing
lifecycle call still retries.

One caveat worth stating: with this fix alone the resolve can still run before Fabric has inserted the
view, because the ref callback fires in the same commit. A consumer that reports its node a frame later
is picked up by `finalizeUpdates:` regardless. Both paths work; this makes the setter honest about what
its own comment promises.

Reported in #808.
