### PR TITLE
fix(ios): resolve a late-mounted scrollable after the mount transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 
 ### 🐛 Bug fixes
 
-- **iOS**: A scrollable that mounts after the sheet has presented is now detected — insets, keyboard handling, and edge effects apply instead of silently doing nothing. ([#810](https://github.com/lodev09/react-native-true-sheet/pull/810) by [@lodev09](https://github.com/lodev09))
 - **Android**: A stacked parent sheet now follows its child frame-by-frame when the child resizes, and no longer gets stuck at stale detents after a half-expanded settle. ([#797](https://github.com/lodev09/react-native-true-sheet/pull/797) by [@lodev09](https://github.com/lodev09))
 - **Android**: The scrollable content now tracks the keyboard frame-by-frame — the focused input rides the keyboard up smoothly, and the scroll position eases back on dismiss instead of snapping. ([#798](https://github.com/lodev09/react-native-true-sheet/pull/798) by [@lodev09](https://github.com/lodev09))
 - The keyboard-driven scroll inset now accounts for a floating footer's height. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: A scrollable that mounts after the sheet has presented is now detected — insets, keyboard handling, and edge effects apply instead of silently doing nothing. ([#810](https://github.com/lodev09/react-native-true-sheet/pull/810) by [@lodev09](https://github.com/lodev09))
 - **Android**: A stacked parent sheet now follows its child frame-by-frame when the child resizes, and no longer gets stuck at stale detents after a half-expanded settle. ([#797](https://github.com/lodev09/react-native-true-sheet/pull/797) by [@lodev09](https://github.com/lodev09))
 - **Android**: The scrollable content now tracks the keyboard frame-by-frame — the focused input rides the keyboard up smoothly, and the scroll position eases back on dismiss instead of snapping. ([#798](https://github.com/lodev09/react-native-true-sheet/pull/798) by [@lodev09](https://github.com/lodev09))
 - The keyboard-driven scroll inset now accounts for a floating footer's height. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))

--- a/example/shared/src/components/sheets/ScrollViewSheet.tsx
+++ b/example/shared/src/components/sheets/ScrollViewSheet.tsx
@@ -23,6 +23,7 @@ import {
   SPACING,
   times,
 } from '../../utils';
+import { Button } from '../Button';
 import { Footer, FooterPill } from '../Footer';
 import { Header } from '../Header';
 import { Text as ThemedText } from '../Text';
@@ -60,7 +61,7 @@ const HeavyItem = ({ index }: { index: number }) => {
 
 export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((props, ref) => {
   const scrollViewRef = useRef<ScrollView>(null);
-  const [showList, setShowList] = useState(true);
+  const [showList, setShowList] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
 
   const onRefresh = useCallback(() => {
@@ -95,22 +96,28 @@ export const ScrollViewSheet = forwardRef<TrueSheet, ScrollViewSheetProps>((prop
       onDidPresent={() => console.log(`Sheet ScrollView presented!`)}
       {...props}
     >
-      {showList ? (
-        <ScrollView
-          ref={scrollViewRef}
-          contentContainerStyle={styles.content}
-          keyboardDismissMode="on-drag"
-          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
-        >
-          {times(20, (i) => (
-            <HeavyItem key={i} index={i} />
-          ))}
-        </ScrollView>
-      ) : (
-        <View style={[styles.placeholder, styles.listPlaceholder]}>
-          <ThemedText style={styles.placeholderText}>List is hidden</ThemedText>
-        </View>
-      )}
+      <View style={styles.wrapper} collapsable={false}>
+        {showList ? (
+          <ScrollView
+            ref={scrollViewRef}
+            contentContainerStyle={styles.content}
+            keyboardDismissMode="on-drag"
+            refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+          >
+            {times(20, (i) => (
+              <HeavyItem key={i} index={i} />
+            ))}
+          </ScrollView>
+        ) : (
+          <View style={[styles.placeholder, styles.listPlaceholder]}>
+            <ThemedText style={styles.placeholderText}>
+              The ScrollView is not mounted yet — mounting it after the sheet has presented tests
+              late scrollable detection.
+            </ThemedText>
+            <Button text="Show ScrollView" onPress={() => setShowList(true)} />
+          </View>
+        )}
+      </View>
     </TrueSheet>
   );
 });
@@ -120,6 +127,9 @@ ScrollViewSheet.displayName = 'ScrollViewSheet';
 const styles = StyleSheet.create({
   sheet: {
     flex: 1,
+  },
+  wrapper: {
+    height: '100%',
   },
   content: {
     padding: SPACING,
@@ -175,11 +185,14 @@ const styles = StyleSheet.create({
   },
   // Clear the absolute header so the message sits in the visible area
   listPlaceholder: {
+    flex: 1,
     paddingTop: HEADER_HEIGHT + SPACING * 2,
+    gap: SPACING,
   },
   placeholderText: {
     fontSize: 14,
     opacity: 0.5,
+    textAlign: 'center',
     // The sheet background is fixed DARK on Android; themed elsewhere
     ...Platform.select({ android: { color: LIGHT_GRAY } }),
   },

--- a/ios/TrueSheetContentView.h
+++ b/ios/TrueSheetContentView.h
@@ -8,6 +8,7 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
+#import <React/RCTMountingTransactionObserving.h>
 #import <React/RCTSurfaceTouchHandler.h>
 #import <React/RCTViewComponentView.h>
 #import <UIKit/UIKit.h>
@@ -28,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface TrueSheetContentView : RCTViewComponentView <TrueSheetKeyboardObserverDelegate>
+@interface TrueSheetContentView : RCTViewComponentView <TrueSheetKeyboardObserverDelegate, RCTMountingTransactionObserving>
 
 @property (nonatomic, weak, nullable) id<TrueSheetContentViewDelegate> delegate;
 @property (nonatomic, assign) CGFloat keyboardScrollOffset;

--- a/ios/TrueSheetContentView.mm
+++ b/ios/TrueSheetContentView.mm
@@ -159,6 +159,17 @@ using namespace facebook::react;
   }
 }
 
+// A handle that commits in the same transaction as the ScrollView's insertion
+// resolves to nothing — prop updates process before mount instructions, and a
+// deep insertion doesn't pass through this view's mount hooks. Retry once the
+// whole transaction has mounted.
+- (void)mountingTransactionDidMount:(const MountingTransaction &)transaction
+               withSurfaceTelemetry:(const SurfaceTelemetry &)surfaceTelemetry {
+  if (_scrollableHandle > 0 && !_detectedScrollView) {
+    [self.delegate contentViewScrollViewDidChange];
+  }
+}
+
 #pragma mark - Scrollable
 
 // The scroll indicator follows automatically — UIKit derives its insets from


### PR DESCRIPTION
## Summary

Fixes #808.

A scrollable that mounts after the sheet has presented was never adopted on iOS — no bottom safe-area inset, no keyboard handling, no scroll edge effects. The list still scrolled (it's a plain RN scrollable), but nothing TrueSheet layers on top applied.

**Root cause:** the `scrollableHandle` prop can commit in the same Fabric transaction as the ScrollView's insertion, and prop updates process before mount instructions. Every resolve attempt on the handle commit (`updateProps`, `finalizeUpdates`) runs before the view exists. A deep-mounted scrollable (behind a non-flattened wrapper) also bypasses the content view's `mountChildComponentView` hooks, so nothing ever retries.

**Fix:** `TrueSheetContentView` now conforms to `RCTMountingTransactionObserving` and retries resolution in `mountingTransactionDidMount:` — after all of a transaction's mutations are applied. The guard is two ivar reads (`_scrollableHandle > 0 && !_detectedScrollView`), so the per-transaction cost is negligible, and the retry goes through the existing `contentViewScrollViewDidChange` delegate chain so options, edge effects, and footer insets all apply.

Android and Web are unaffected: Android receives the insertion before the handle commit so the existing setter path resolves it, and Web's subtree `MutationObserver` already re-resolves on any mount.

## Type of Change

- [x] Bug fix

## Test Plan

Repro included: the example's ScrollView sheet now mounts its ScrollView lazily behind a non-flattened wrapper — present, then tap "Show ScrollView".

- Before: handle committed, resolution attempts found nothing, never retried — `adjustedContentInset.bottom` stayed `0`, no edge effects.
- After: adoption fires at the end of the mounting transaction — `adjustedContentInset.bottom=34`, soft edge effects active, keyboard insets work.
- Verified the regular FlatList/ScrollView sheets (scrollable mounted before present) still adopt via the present lifecycle.

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I added a changelog entry (if needed)