### PR TITLE
fix(ios): resolve fractional detents against the app window in windowed iPad apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Fractional detents now resolve against the app's window instead of the full screen, fixing full-height sheets in windowed iPad apps (Stage Manager, iPadOS 26 windowing). ([#814](https://github.com/lodev09/react-native-true-sheet/pull/814) by [@vilindberg](https://github.com/vilindberg))
 - **Android**: A stacked parent sheet now follows its child frame-by-frame when the child resizes, and no longer gets stuck at stale detents after a half-expanded settle. ([#797](https://github.com/lodev09/react-native-true-sheet/pull/797) by [@lodev09](https://github.com/lodev09))
 - **Android**: The scrollable content now tracks the keyboard frame-by-frame — the focused input rides the keyboard up smoothly, and the scroll position eases back on dismiss instead of snapping. ([#798](https://github.com/lodev09/react-native-true-sheet/pull/798) by [@lodev09](https://github.com/lodev09))
 - The keyboard-driven scroll inset now accounts for a floating footer's height. ([#752](https://github.com/lodev09/react-native-true-sheet/pull/752) by [@lodev09](https://github.com/lodev09))

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -500,6 +500,7 @@ using namespace facebook::react;
     return;
   }
 
+  _controller.presenterView = presentingViewController.view;
   [_controller setupAnchorViewInView:presentingViewController.view];
   [_controller setupSheetSizing];
   [_controller setupSheetProps];
@@ -872,6 +873,7 @@ using namespace facebook::react;
   }
 
   UIView *presenterView = _controller.presentingViewController.view;
+  _controller.presenterView = presenterView;
   [_controller setupAnchorViewInView:presenterView];
 
   [_controller setupSheetSizing];

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -53,6 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
                                        >
 
 @property (nonatomic, weak, nullable) id<TrueSheetViewControllerDelegate> delegate;
+// The presenter's view, set before the sheet is presented. Detents are built while this
+// controller's own view is still window-less, so `screenHeight` reads the window from here.
+@property (nonatomic, weak, nullable) UIView *presenterView;
 @property (nonatomic, strong) NSArray<NSNumber *> *detents;
 @property (nonatomic, strong, nullable) NSNumber *maxContentHeight;
 @property (nonatomic, strong, nullable) NSNumber *maxContentWidth;

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -207,7 +207,11 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 }
 
 - (CGFloat)screenHeight {
-  UIWindow *window = self.view.window;
+  // `setupSheetDetents` runs before `presentViewController:`, so self.view has no window yet and a
+  // fractional detent would resolve against UIScreen.mainScreen — the whole display, not the app's
+  // window. That over-sizes every fraction in a windowed iPad app whose window is shorter than the
+  // display, and the sheet clamps to full height until a resize rebuilds the detents.
+  UIWindow *window = self.view.window ?: self.presentingViewController.view.window ?: self.presenterView.window;
   return window ? window.bounds.size.height : UIScreen.mainScreen.bounds.size.height;
 }
 


### PR DESCRIPTION
## Summary

In an iPad app running in a resizable window (Stage Manager, or iPadOS 26 windowing), a fractional detent like `detents={[0.5]}` opens the sheet at full window height instead of half the window.

`TrueSheetViewController.screenHeight` reads the window from the controller's own view:

```objc
UIWindow *window = self.view.window;
return window ? window.bounds.size.height : UIScreen.mainScreen.bounds.size.height;
```

But detents are built in `presentAtIndex:` **before** `presentViewController:` runs, so `self.view.window` is still `nil` and the fallback resolves against `UIScreen.mainScreen.bounds` - the whole display. On iPhone or a full-screen iPad app the two are the same, so nothing is visibly wrong. In a window shorter than the display, the fractional detent over-sizes (e.g. `0.5 × 1210 pt` display instead of `0.5 × 486 pt` window) and the custom-detent resolver clamps it to `maximumDetentValue` - a full-height sheet. Any iPad app that supports multitasking (no `UIRequiresFullScreen`) can hit this.

The fix falls back to a window that already exists at presentation time: `presentingViewController.view.window`, or a new weak `presenterView` property that `TrueSheetView` sets right before presenting (and on prop updates), covering the moment before `presentingViewController` is wired up.

One subtlety that hides the bug during casual testing: the *first* presentation self-heals, because the sheet content's initial React layout fires `containerViewContentDidChangeSize` → a debounced detent rebuild that runs right after the presentation settles, by which point the view has a window. Every later present stays broken (nothing rebuilds), so the deterministic repro is **present → dismiss → present again**, with static sheet content.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Full standalone repro (stock RN template + this library, one tap to reproduce, dashed line drawn at 50% of the window for visual verification): https://github.com/vilindberg/true-sheet-windowed-detent-repro

- Reproduced on an iPad Pro 11-inch (M5) simulator, iPadOS 26, window resized to 577×486 pt on a 834×1210 pt display: second present clamps to full window height.
- With this patch applied, every present (first, second, ...) lands the sheet's top edge exactly at 50% of the window.
- Verified `UIScreen.mainScreen.bounds` (1210 pt) vs window bounds (486 pt) via lldb to confirm the root cause.
- iPhone / full-screen iPad behavior is unchanged: `presentingViewController.view.window` is the same window `self.view` ends up in.

## Screenshots / Videos

Window resized to 577×486 pt on a 1210 pt-tall display, `detents={[0.5]}`, second presentation:

| Before (3.11.12) | After (this fix) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/vilindberg/true-sheet-windowed-detent-repro/d1dfb65/docs/before.png" width="380" /> | <img src="https://raw.githubusercontent.com/vilindberg/true-sheet-windowed-detent-repro/d1dfb65/docs/after.png" width="380" /> |

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android (not applicable - iOS-only change)
- [ ] I tested on Web (not applicable - iOS-only change)
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)

The same three hunks apply cleanly to the `v3` branch (verified against 3.11.12) - happy to open a backport PR if useful.


