### PR TITLE
feat: add TrueSheetOverlay for rendering content above sheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🎉 New features
 
+- New `TrueSheetOverlay` component renders its children above every presented sheet — for toasts, dialogs, and other overlays. Replaces the `FullWindowOverlay`/`Modal` workaround. ([#817](https://github.com/lodev09/react-native-true-sheet/pull/817) by [@lodev09](https://github.com/lodev09))
 - Added a JS-only `lazy` prop — set to `false` to mount sheet content before presentation, allowing `auto` detents to measure settled content before the sheet opens. ([#792](https://github.com/lodev09/react-native-true-sheet/pull/792) by [@maxlapides](https://github.com/maxlapides))
 - **iOS**: Smoother `onPositionChange`, and `onWillDismiss` now fires only when a drag-to-dismiss is committed. ([#744](https://github.com/lodev09/react-native-true-sheet/pull/744), [#756](https://github.com/lodev09/react-native-true-sheet/pull/756) by [@lodev09](https://github.com/lodev09))
 - The `auto` detent now works with plugged scrollables — the sheet sizes to the scrollable's content height. ([#743](https://github.com/lodev09/react-native-true-sheet/pull/743) by [@lodev09](https://github.com/lodev09))

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetOverlayView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetOverlayView.kt
@@ -1,0 +1,106 @@
+package com.lodev09.truesheet
+
+import android.annotation.SuppressLint
+import android.view.View
+import android.view.ViewGroup
+import android.view.accessibility.AccessibilityEvent
+import com.facebook.react.uimanager.StateWrapper
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.events.EventDispatcher
+import com.facebook.react.views.view.ReactViewGroup
+import com.lodev09.truesheet.core.TrueSheetOverlayRootView
+import com.lodev09.truesheet.core.TrueSheetOverlayRootViewDelegate
+import com.lodev09.truesheet.utils.findRootContainerView
+
+/**
+ * Hidden host that renders its children in a root view attached to the
+ * activity's content view, above every presented sheet.
+ */
+@SuppressLint("ViewConstructor")
+class TrueSheetOverlayView(private val reactContext: ThemedReactContext) :
+  ReactViewGroup(reactContext),
+  TrueSheetOverlayRootViewDelegate {
+
+  private val rootView = TrueSheetOverlayRootView(reactContext).apply {
+    delegate = this@TrueSheetOverlayView
+  }
+
+  private var rootContainerView: ViewGroup? = null
+
+  override var eventDispatcher: EventDispatcher? = null
+
+  private var lastWidth = 0
+  private var lastHeight = 0
+
+  var stateWrapper: StateWrapper? = null
+    set(value) {
+      field = value
+      pushState()
+    }
+
+  init {
+    // The host stays in the React tree for layout only — children render in the root view
+    visibility = GONE
+  }
+
+  // ==================== View Hierarchy Management ====================
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    attachRootView()
+  }
+
+  override fun onDetachedFromWindow() {
+    detachRootView()
+    super.onDetachedFromWindow()
+  }
+
+  private fun attachRootView() {
+    if (rootView.parent != null) return
+
+    val container = findRootContainerView(reactContext) ?: return
+    container.addView(rootView)
+    rootContainerView = container
+  }
+
+  private fun detachRootView() {
+    rootContainerView?.removeView(rootView)
+    rootContainerView = null
+  }
+
+  fun onDropInstance() {
+    detachRootView()
+    rootView.delegate = null
+  }
+
+  override fun addView(child: View?, index: Int) {
+    rootView.addView(child, index)
+  }
+
+  override fun getChildCount(): Int = rootView.childCount
+
+  override fun getChildAt(index: Int): View? = rootView.getChildAt(index)
+
+  override fun removeViewAt(index: Int) {
+    rootView.removeViewAt(index)
+  }
+
+  // Accessibility: children live in the root view since this view is hidden
+  override fun addChildrenForAccessibility(outChildren: ArrayList<View>) {}
+  override fun dispatchPopulateAccessibilityEvent(event: AccessibilityEvent): Boolean = false
+
+  // ==================== State ====================
+
+  override fun overlayRootViewDidChangeSize(width: Int, height: Int) {
+    if (width == lastWidth && height == lastHeight) return
+
+    lastWidth = width
+    lastHeight = height
+    pushState()
+  }
+
+  private fun pushState() {
+    if (lastWidth == 0 && lastHeight == 0) return
+    stateWrapper?.let { TrueSheetStateUpdater.updateContainerSize(it, lastWidth, lastHeight) }
+  }
+}

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetOverlayViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetOverlayViewManager.kt
@@ -1,0 +1,45 @@
+package com.lodev09.truesheet
+
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.PointerEvents
+import com.facebook.react.uimanager.ReactStylesDiffMap
+import com.facebook.react.uimanager.StateWrapper
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.ViewGroupManager
+import com.facebook.react.uimanager.annotations.ReactProp
+
+/**
+ * ViewManager for TrueSheetOverlayView
+ * Renders content above every presented sheet
+ */
+@ReactModule(name = TrueSheetOverlayViewManager.REACT_CLASS)
+class TrueSheetOverlayViewManager : ViewGroupManager<TrueSheetOverlayView>() {
+
+  override fun getName(): String = REACT_CLASS
+
+  override fun createViewInstance(reactContext: ThemedReactContext): TrueSheetOverlayView = TrueSheetOverlayView(reactContext)
+
+  override fun onDropViewInstance(view: TrueSheetOverlayView) {
+    super.onDropViewInstance(view)
+    view.onDropInstance()
+  }
+
+  override fun addEventEmitters(reactContext: ThemedReactContext, view: TrueSheetOverlayView) {
+    view.eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, view.id)
+  }
+
+  override fun updateState(view: TrueSheetOverlayView, props: ReactStylesDiffMap?, stateWrapper: StateWrapper?): Any? {
+    view.stateWrapper = stateWrapper
+    return null
+  }
+
+  @ReactProp(name = "pointerEvents")
+  fun setPointerEvents(view: TrueSheetOverlayView, pointerEventsStr: String?) {
+    view.pointerEvents = PointerEvents.parsePointerEvents(pointerEventsStr)
+  }
+
+  companion object {
+    const val REACT_CLASS = "TrueSheetOverlayView"
+  }
+}

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetPackage.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetPackage.kt
@@ -40,6 +40,7 @@ class TrueSheetPackage : BaseReactPackage() {
       TrueSheetContentViewManager(),
       TrueSheetHeaderViewManager(),
       TrueSheetFooterViewManager(),
-      TrueSheetPeekViewManager()
+      TrueSheetPeekViewManager(),
+      TrueSheetOverlayViewManager()
     )
 }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetStateUpdater.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetStateUpdater.kt
@@ -1,5 +1,7 @@
 package com.lodev09.truesheet
 
+import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.StateWrapper
 
 /**
@@ -21,6 +23,22 @@ object TrueSheetStateUpdater {
   /** Returns false when unavailable — caller should fall back to async updateState. */
   fun updateState(stateWrapper: StateWrapper, widthDp: Float, heightDp: Float): Boolean =
     isAvailable && nativeUpdateState(stateWrapper, widthDp, heightDp)
+
+  /**
+   * Pushes the container size (px) into the Fabric state — synchronously when
+   * the bridge is available, async otherwise.
+   */
+  fun updateContainerSize(stateWrapper: StateWrapper, widthPx: Int, heightPx: Int) {
+    val widthDp = widthPx.toFloat().pxToDp()
+    val heightDp = heightPx.toFloat().pxToDp()
+
+    if (updateState(stateWrapper, widthDp, heightDp)) return
+
+    val newStateData = WritableNativeMap()
+    newStateData.putDouble("containerWidth", widthDp.toDouble())
+    newStateData.putDouble("containerHeight", heightDp.toDouble())
+    stateWrapper.updateState(newStateData)
+  }
 
   /** Returns false when unavailable — caller should fall back to async updateState. */
   fun updateFooterState(stateWrapper: StateWrapper, bottomInsetDp: Float): Boolean =

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import android.view.accessibility.AccessibilityEvent
 import androidx.annotation.UiThread
 import com.facebook.react.bridge.LifecycleEventListener
-import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.StateWrapper
@@ -22,6 +21,7 @@ import com.lodev09.truesheet.core.RNScreensEventObserverDelegate
 import com.lodev09.truesheet.core.TrueSheetStackManager
 import com.lodev09.truesheet.events.*
 import com.lodev09.truesheet.utils.KeyboardUtils
+import com.lodev09.truesheet.utils.findRootContainerView
 
 /**
  * Main TrueSheet host view that manages the sheet and dispatches events to JavaScript.
@@ -376,18 +376,7 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     lastContainerWidth = width
     lastContainerHeight = height
 
-    val sw = stateWrapper ?: return
-    val widthDp = width.toFloat().pxToDp()
-    val heightDp = height.toFloat().pxToDp()
-
-    // Synchronous update — commits and mounts within the same UI-thread frame
-    if (TrueSheetStateUpdater.updateState(sw, widthDp, heightDp)) return
-
-    // Fallback: async state update
-    val newStateData = WritableNativeMap()
-    newStateData.putDouble("containerWidth", widthDp.toDouble())
-    newStateData.putDouble("containerHeight", heightDp.toDouble())
-    sw.updateState(newStateData)
+    stateWrapper?.let { TrueSheetStateUpdater.updateContainerSize(it, width, height) }
   }
 
   // ==================== Sheet Actions ====================
@@ -731,16 +720,5 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
    * of whichever window this view is in - whether that's the activity's window or a
    * Modal's dialog window.
    */
-  override fun findRootContainerView(): ViewGroup? {
-    var current: android.view.ViewParent? = parent
-
-    while (current != null) {
-      if (current is ViewGroup && current.id == android.R.id.content) {
-        return current
-      }
-      current = current.parent
-    }
-
-    return reactContext.currentActivity?.findViewById(android.R.id.content)
-  }
+  override fun findRootContainerView(): ViewGroup? = findRootContainerView(reactContext)
 }

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetOverlayRootView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetOverlayRootView.kt
@@ -48,6 +48,16 @@ class TrueSheetOverlayRootView(private val reactContext: ThemedReactContext) :
     translationZ = OVERLAY_Z
   }
 
+  // Children are positioned by Fabric — a FrameLayout pass would stretch them to match_parent
+  override fun onLayout(
+    changed: Boolean,
+    left: Int,
+    top: Int,
+    right: Int,
+    bottom: Int
+  ) {
+  }
+
   override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
     super.onSizeChanged(w, h, oldw, oldh)
     delegate?.overlayRootViewDidChangeSize(w, h)
@@ -55,7 +65,11 @@ class TrueSheetOverlayRootView(private val reactContext: ThemedReactContext) :
 
   override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
     if (ev.actionMasked == MotionEvent.ACTION_DOWN) {
-      isHandlingStream = TouchTargetHelper.findTargetTagForTouch(ev.x, ev.y, this) != id
+      // The path ends with this root, so a touch that misses every child resolves to it
+      val target = TouchTargetHelper
+        .findTargetPathAndCoordinatesForTouch(ev.x, ev.y, this, FloatArray(2))
+        .firstNotNullOfOrNull { it.getView() }
+      isHandlingStream = target != null && target !== this
     }
     if (!isHandlingStream) return false
     return super.dispatchTouchEvent(ev)

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetOverlayRootView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetOverlayRootView.kt
@@ -1,0 +1,123 @@
+package com.lodev09.truesheet.core
+
+import android.annotation.SuppressLint
+import android.view.MotionEvent
+import android.view.View
+import android.widget.FrameLayout
+import com.facebook.react.uimanager.JSPointerDispatcher
+import com.facebook.react.uimanager.JSTouchDispatcher
+import com.facebook.react.uimanager.RootView
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.TouchTargetHelper
+import com.facebook.react.uimanager.events.EventDispatcher
+import com.lodev09.truesheet.utils.TouchEventDeduper
+
+interface TrueSheetOverlayRootViewDelegate {
+  val eventDispatcher: EventDispatcher?
+  fun overlayRootViewDidChangeSize(width: Int, height: Int)
+}
+
+/**
+ * Window-level view hosting an overlay's children, attached to the activity's
+ * content view above the sheet coordinators.
+ *
+ * Implements RootView to dispatch touches to JS. Touches that miss every child
+ * fall through to the views beneath.
+ */
+@SuppressLint("ViewConstructor")
+class TrueSheetOverlayRootView(private val reactContext: ThemedReactContext) :
+  FrameLayout(reactContext),
+  RootView {
+
+  var delegate: TrueSheetOverlayRootViewDelegate? = null
+
+  private val eventDispatcher: EventDispatcher?
+    get() = delegate?.eventDispatcher
+
+  private val jsTouchDispatcher = JSTouchDispatcher(this)
+  private val jsPointerDispatcher = JSPointerDispatcher(this)
+  private val touchDeduper = TouchEventDeduper()
+
+  // Whether the current touch stream landed on a child
+  private var isHandlingStream = false
+
+  init {
+    layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+
+    // Draws and receives touches above the sheet coordinators regardless of add order
+    translationZ = OVERLAY_Z
+  }
+
+  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    delegate?.overlayRootViewDidChangeSize(w, h)
+  }
+
+  override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+    if (ev.actionMasked == MotionEvent.ACTION_DOWN) {
+      isHandlingStream = TouchTargetHelper.findTargetTagForTouch(ev.x, ev.y, this) != id
+    }
+    if (!isHandlingStream) return false
+    return super.dispatchTouchEvent(ev)
+  }
+
+  // ==================== RootView Implementation ====================
+
+  override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
+    eventDispatcher?.let { dispatcher ->
+      if (touchDeduper.shouldDispatch(event)) {
+        jsTouchDispatcher.handleTouchEvent(event, dispatcher, reactContext)
+      }
+      jsPointerDispatcher.handleMotionEvent(event, dispatcher, true)
+    }
+    return super.onInterceptTouchEvent(event)
+  }
+
+  override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+    // Mirrors ReactSurfaceView: keep receiving onInterceptTouchEvent so
+    // jsTouchDispatcher sees the gesture end, but forward the request up the tree.
+    parent?.requestDisallowInterceptTouchEvent(disallowIntercept)
+  }
+
+  @SuppressLint("ClickableViewAccessibility")
+  override fun onTouchEvent(event: MotionEvent): Boolean {
+    eventDispatcher?.let { dispatcher ->
+      if (touchDeduper.shouldDispatch(event)) {
+        jsTouchDispatcher.handleTouchEvent(event, dispatcher, reactContext)
+      }
+      jsPointerDispatcher.handleMotionEvent(event, dispatcher, false)
+    }
+    super.onTouchEvent(event)
+    return true
+  }
+
+  override fun onInterceptHoverEvent(event: MotionEvent): Boolean {
+    eventDispatcher?.let { jsPointerDispatcher.handleMotionEvent(event, it, true) }
+    return super.onHoverEvent(event)
+  }
+
+  override fun onHoverEvent(event: MotionEvent): Boolean {
+    eventDispatcher?.let { jsPointerDispatcher.handleMotionEvent(event, it, false) }
+    return super.onHoverEvent(event)
+  }
+
+  override fun onChildStartedNativeGesture(childView: View?, ev: MotionEvent) {
+    eventDispatcher?.let { dispatcher ->
+      jsTouchDispatcher.onChildStartedNativeGesture(ev, dispatcher)
+      jsPointerDispatcher.onChildStartedNativeGesture(childView, ev, dispatcher)
+    }
+  }
+
+  override fun onChildEndedNativeGesture(childView: View, ev: MotionEvent) {
+    eventDispatcher?.let { jsTouchDispatcher.onChildEndedNativeGesture(ev, it) }
+    jsPointerDispatcher.onChildEndedNativeGesture()
+  }
+
+  override fun handleException(t: Throwable) {
+    reactContext.reactApplicationContext.handleException(RuntimeException(t))
+  }
+
+  companion object {
+    private const val OVERLAY_Z = 1000f
+  }
+}

--- a/android/src/main/java/com/lodev09/truesheet/utils/ViewUtils.kt
+++ b/android/src/main/java/com/lodev09/truesheet/utils/ViewUtils.kt
@@ -2,8 +2,10 @@ package com.lodev09.truesheet.utils
 
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewParent
 import android.widget.ScrollView
 import androidx.core.widget.NestedScrollView
+import com.facebook.react.uimanager.ThemedReactContext
 
 fun View.isDescendantOf(ancestor: View): Boolean {
   if (!isAttachedToWindow) return false
@@ -20,4 +22,21 @@ fun ViewGroup.smoothScrollTo(x: Int, y: Int) {
     is ScrollView -> smoothScrollTo(x, y)
     is NestedScrollView -> smoothScrollTo(x, y)
   }
+}
+
+/**
+ * The content view hosting this view — the activity's, or a Modal dialog's.
+ * Window-level views (sheet coordinators, overlays) attach here.
+ */
+fun View.findRootContainerView(reactContext: ThemedReactContext): ViewGroup? {
+  var current: ViewParent? = parent
+
+  while (current != null) {
+    if (current is ViewGroup && current.id == android.R.id.content) {
+      return current
+    }
+    current = current.parent
+  }
+
+  return reactContext.currentActivity?.findViewById(android.R.id.content)
 }

--- a/android/src/main/jni/TrueSheetSpec.h
+++ b/android/src/main/jni/TrueSheetSpec.h
@@ -5,6 +5,7 @@
 #include <jsi/jsi.h>
 #include <react/renderer/components/TrueSheetSpec/TrueSheetContentViewComponentDescriptor.h>
 #include <react/renderer/components/TrueSheetSpec/TrueSheetFooterViewComponentDescriptor.h>
+#include <react/renderer/components/TrueSheetSpec/TrueSheetOverlayViewComponentDescriptor.h>
 #include <react/renderer/components/TrueSheetSpec/TrueSheetViewComponentDescriptor.h>
 
 namespace facebook {

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetLayoutUtils.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetLayoutUtils.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <react/renderer/components/view/conversions.h>
+#include <yoga/node/Node.h>
+#include <yoga/style/Style.h>
+
+namespace facebook::react {
+
+/*
+ * Overrides a node's Yoga dimensions with the container size reported from
+ * native. A zero dimension leaves that axis to Yoga.
+ */
+inline void applyContainerSizeToYogaNode(
+    yoga::Node &node,
+    const yoga::Style &baseStyle,
+    float containerWidth,
+    float containerHeight) {
+  if (containerWidth <= 0 && containerHeight <= 0) {
+    return;
+  }
+
+  yoga::Style adjustedStyle = baseStyle;
+  const auto &currentStyle = node.style();
+  bool needsUpdate = false;
+
+  if (containerWidth > 0) {
+    adjustedStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(containerWidth));
+    if (adjustedStyle.dimension(yoga::Dimension::Width) != currentStyle.dimension(yoga::Dimension::Width)) {
+      needsUpdate = true;
+    }
+  }
+
+  if (containerHeight > 0) {
+    adjustedStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(containerHeight));
+    if (adjustedStyle.dimension(yoga::Dimension::Height) != currentStyle.dimension(yoga::Dimension::Height)) {
+      needsUpdate = true;
+    }
+  }
+
+  if (needsUpdate) {
+    node.setStyle(adjustedStyle);
+    node.setDirty(true);
+  }
+}
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetOverlayViewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetOverlayViewComponentDescriptor.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <react/renderer/components/TrueSheetSpec/TrueSheetOverlayViewShadowNode.h>
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+namespace facebook::react {
+
+/*
+ * Descriptor for <TrueSheetOverlayView> component.
+ */
+class TrueSheetOverlayViewComponentDescriptor final
+    : public ConcreteComponentDescriptor<TrueSheetOverlayViewShadowNode> {
+  using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
+
+  void adopt(ShadowNode &shadowNode) const override {
+    static_cast<TrueSheetOverlayViewShadowNode &>(shadowNode).adjustLayoutWithState();
+    ConcreteComponentDescriptor::adopt(shadowNode);
+  }
+};
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetOverlayViewShadowNode.cpp
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetOverlayViewShadowNode.cpp
@@ -1,0 +1,17 @@
+#include "TrueSheetOverlayViewShadowNode.h"
+
+#include "TrueSheetLayoutUtils.h"
+
+namespace facebook::react {
+
+extern const char TrueSheetOverlayViewComponentName[] = "TrueSheetOverlayView";
+
+void TrueSheetOverlayViewShadowNode::adjustLayoutWithState() {
+  ensureUnsealed();
+
+  const auto &stateData = getStateData();
+  applyContainerSizeToYogaNode(
+      yogaNode_, getConcreteProps().yogaStyle, stateData.containerWidth, stateData.containerHeight);
+}
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetOverlayViewShadowNode.h
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetOverlayViewShadowNode.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <jsi/jsi.h>
+#include <react/renderer/components/TrueSheetSpec/EventEmitters.h>
+#include <react/renderer/components/TrueSheetSpec/Props.h>
+#include <react/renderer/components/TrueSheetSpec/TrueSheetViewState.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+
+namespace facebook::react {
+
+JSI_EXPORT extern const char TrueSheetOverlayViewComponentName[];
+
+/*
+ * `ShadowNode` for <TrueSheetOverlayView> component.
+ * Sized to the window from native (via TrueSheetViewState) so its children
+ * lay out against the full window like the sheet's container.
+ */
+class JSI_EXPORT TrueSheetOverlayViewShadowNode final
+    : public ConcreteViewShadowNode<
+          TrueSheetOverlayViewComponentName,
+          TrueSheetOverlayViewProps,
+          TrueSheetOverlayViewEventEmitter,
+          TrueSheetViewState> {
+  using ConcreteViewShadowNode::ConcreteViewShadowNode;
+
+ public:
+  static ShadowNodeTraits BaseTraits() {
+    auto traits = ConcreteViewShadowNode::BaseTraits();
+    traits.set(ShadowNodeTraits::Trait::RootNodeKind);
+    return traits;
+  }
+
+  void adjustLayoutWithState();
+};
+
+} // namespace facebook::react

--- a/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetViewShadowNode.cpp
+++ b/common/cpp/react/renderer/components/TrueSheetSpec/TrueSheetViewShadowNode.cpp
@@ -1,48 +1,17 @@
 #include "TrueSheetViewShadowNode.h"
 
-#include <react/renderer/components/view/conversions.h>
+#include "TrueSheetLayoutUtils.h"
 
 namespace facebook::react {
-
-using namespace yoga;
 
 extern const char TrueSheetViewComponentName[] = "TrueSheetView";
 
 void TrueSheetViewShadowNode::adjustLayoutWithState() {
   ensureUnsealed();
 
-  auto state = std::static_pointer_cast<
-      const TrueSheetViewShadowNode::ConcreteState>(getState());
-  auto stateData = state->getData();
-
-  // If container dimensions are set from native, override Yoga's dimensions
-  if (stateData.containerWidth > 0 || stateData.containerHeight > 0) {
-    auto &props = getConcreteProps();
-    yoga::Style adjustedStyle = props.yogaStyle;
-    auto currentStyle = yogaNode_.style();
-    bool needsUpdate = false;
-
-    // Set width if provided
-    if (stateData.containerWidth > 0) {
-      adjustedStyle.setDimension(yoga::Dimension::Width, StyleSizeLength::points(stateData.containerWidth));
-      if (adjustedStyle.dimension(yoga::Dimension::Width) != currentStyle.dimension(yoga::Dimension::Width)) {
-        needsUpdate = true;
-      }
-    }
-
-    // Set height if provided
-    if (stateData.containerHeight > 0) {
-      adjustedStyle.setDimension(yoga::Dimension::Height, StyleSizeLength::points(stateData.containerHeight));
-      if (adjustedStyle.dimension(yoga::Dimension::Height) != currentStyle.dimension(yoga::Dimension::Height)) {
-        needsUpdate = true;
-      }
-    }
-
-    if (needsUpdate) {
-      yogaNode_.setStyle(adjustedStyle);
-      yogaNode_.setDirty(true);
-    }
-  }
+  const auto &stateData = getStateData();
+  applyContainerSizeToYogaNode(
+      yogaNode_, getConcreteProps().yogaStyle, stateData.containerWidth, stateData.containerHeight);
 }
 
 #if !defined(ANDROID)

--- a/docs/docs/guides/overlays.mdx
+++ b/docs/docs/guides/overlays.mdx
@@ -1,59 +1,76 @@
 ---
 title: Overlays on Sheets
-description: Display modals, dialogs, and other overlays on top of bottom sheets.
-keywords: [bottom sheet overlay, bottom sheet modal, bottom sheet dialog, portal, z-index]
+description: Display toasts, dialogs, and other overlays on top of bottom sheets.
+keywords: [bottom sheet overlay, bottom sheet toast, bottom sheet dialog, portal, z-index]
 ---
 
-When displaying overlays like dialogs or modals on top of a sheet, you may encounter z-index issues where the sheet appears above the overlay, particularly on Android.
+Sheets are presented natively, above the React Native view hierarchy — so a toast or dialog rendered in your app's tree (or through a JS portal) ends up **behind** the sheet.
 
-This guide explains how to properly display overlays on top of TrueSheet.
-
-Portal-based UI libraries (like `react-native-reusables`, `tamagui`, etc.) render content outside the normal component hierarchy. On Android, the sheet may appear on top of these portals due to how native views are layered.
+`TrueSheetOverlay` renders its children in a native layer above every presented sheet.
 
 ## How?
 
-Wrap your overlay content with React Native's `Modal` on Android and `FullWindowOverlay` from `react-native-screens` on iOS.
+Wrap the content with `TrueSheetOverlay` and show or hide it by conditionally rendering children — there is no `visible` prop.
 
-```tsx
-import { Platform, Modal } from 'react-native'
-import { FullWindowOverlay } from 'react-native-screens'
+```tsx {14-16}
+import { TrueSheet, TrueSheetOverlay } from '@lodev09/react-native-true-sheet'
 
-const Overlay = Platform.select({
-  ios: FullWindowOverlay,
-  default: Modal,
-})
-
-export const App = () => {
-  const [visible, setVisible] = useState(false)
+const App = () => {
+  const [toast, setToast] = useState<string | null>(null)
 
   return (
     <>
       <TrueSheet>
-        <Button title="Show Dialog" onPress={() => setVisible(true)} />
+        <Button title="Save" onPress={() => setToast('Saved!')} />
       </TrueSheet>
 
-      <Overlay visible={visible} transparent>
-        <YourDialogContent onClose={() => setVisible(false)} />
-      </Overlay>
+      <TrueSheetOverlay>
+        {toast && <Toast message={toast} onHide={() => setToast(null)} />}
+      </TrueSheetOverlay>
     </>
   )
 }
 ```
 
-## Platform Differences
+The overlay can be mounted anywhere — on a screen, or inside a sheet's content.
 
-| Platform | Recommended Approach |
-|----------|---------------------|
-| iOS | `FullWindowOverlay` from `react-native-screens` |
-| Android | React Native `Modal` with `transparent` prop |
+## Touches
+
+Touches that miss the overlay's children pass through to whatever is beneath, so the sheet stays draggable and its buttons stay tappable around a toast.
+
+To block interaction (e.g. a dialog with a backdrop), render a child that fills the overlay:
+
+```tsx
+<TrueSheetOverlay>
+  {visible && (
+    <Pressable style={StyleSheet.absoluteFill} onPress={close}>
+      <Dialog />
+    </Pressable>
+  )}
+</TrueSheetOverlay>
+```
+
+## Layout
+
+The overlay is a transparent container that fills the window. Position children absolutely, or lay them out with flex and padding through `style`:
+
+```tsx
+<TrueSheetOverlay style={{ justifyContent: 'flex-end', padding: 16 }}>
+  <Toast />
+</TrueSheetOverlay>
+```
 
 :::note
-`FullWindowOverlay` requires `react-native-screens` to be installed.
+The overlay itself never renders — visual styles like `backgroundColor` have no effect on it. Style its children instead.
 :::
 
-## Why This Works
+Since it fills the window, content may sit under the status bar or the system navigation bar. Use `useSafeAreaInsets` from `react-native-safe-area-context` to inset it.
 
-- **iOS**: `FullWindowOverlay` renders content in a separate window above all other views
-- **Android**: `Modal` creates a new native dialog that appears above the sheet's `CoordinatorLayout`
+## Limitations
 
-Both approaches ensure the overlay is rendered in a separate native container that sits above the sheet in the view hierarchy.
+- Native modals presented **after** the overlay — React Native's `Modal`, native-stack modal screens — render above it.
+- The keyboard always renders above the overlay.
+
+## Platform Support
+
+`TrueSheetOverlay` is supported on **iOS**, **Android**, and **Web**.

--- a/example/shared/src/components/sheets/BasicSheet.tsx
+++ b/example/shared/src/components/sheets/BasicSheet.tsx
@@ -53,6 +53,7 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
   const { onNavigateToModal, onNavigateToTest, ...rest } = props;
   const sheetRef = useRef<TrueSheet>(null);
   const childSheet = useRef<TrueSheet>(null);
+  const overlaySheet = useRef<TrueSheet>(null);
   const [contentCount, setContentCount] = useState(0);
   const [detentIndex, setDetentIndex] = useState(0);
   const [toast, setToast] = useState<string | null>(null);
@@ -216,10 +217,23 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
               exiting={spring(new ZoomOut())}
             >
               <Text style={styles.overlayText}>Rendered above the sheet!</Text>
+              <Button text="Open Sheet" onPress={() => overlaySheet.current?.present()} />
               <Button text="Close" onPress={() => setDialogVisible(false)} />
             </Animated.View>
           </AnimatedPressable>
         )}
+
+        {/* A sheet inside the overlay presents like any other — beneath the dialog */}
+        <TrueSheet
+          ref={overlaySheet}
+          name="basic-overlay"
+          detents={['auto']}
+          backgroundColor={DARK}
+          style={styles.childContent}
+        >
+          <DemoContent color={DARK_BLUE} />
+          <Button text="Close" onPress={() => overlaySheet.current?.dismiss()} />
+        </TrueSheet>
       </TrueSheetOverlay>
 
       <TrueSheet

--- a/example/shared/src/components/sheets/BasicSheet.tsx
+++ b/example/shared/src/components/sheets/BasicSheet.tsx
@@ -1,13 +1,24 @@
-import { forwardRef, useRef, useState, type Ref, useImperativeHandle } from 'react';
-import { StyleSheet } from 'react-native';
+import { forwardRef, useEffect, useRef, useState, type Ref, useImperativeHandle } from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+import Animated, {
+  FadeIn,
+  FadeInDown,
+  FadeOut,
+  FadeOutUp,
+  ZoomIn,
+  ZoomOut,
+  type ComplexAnimationBuilder,
+  type WithSpringConfig,
+} from 'react-native-reanimated';
 import {
   TrueSheet,
+  TrueSheetOverlay,
   TrueSheetPeek,
   useTrueSheet,
   type TrueSheetProps,
 } from '@lodev09/react-native-true-sheet';
 
-import { BLUE, DARK, DARK_BLUE, DARK_GRAY, GAP, SPACING, times } from '../../utils';
+import { BLUE, DARK, DARK_BLUE, DARK_GRAY, GAP, LIGHT_GRAY, SPACING, times } from '../../utils';
 import { DemoContent } from '../DemoContent';
 import { Footer } from '../Footer';
 import { Button } from '../Button';
@@ -15,6 +26,23 @@ import { ButtonGroup } from '../ButtonGroup';
 import { Spacer } from '../Spacer';
 import { Header } from '../Header';
 import { Input } from '../Input';
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+const SPRING_CONFIG: WithSpringConfig = {
+  damping: 500,
+  stiffness: 1000,
+  mass: 3,
+  overshootClamping: true,
+};
+
+const spring = <T extends ComplexAnimationBuilder<any>>(animation: T) =>
+  animation
+    .springify()
+    .damping(SPRING_CONFIG.damping!)
+    .stiffness(SPRING_CONFIG.stiffness!)
+    .mass(SPRING_CONFIG.mass!)
+    .overshootClamping(SPRING_CONFIG.overshootClamping ? 1 : 0);
 
 interface BasicSheetProps extends TrueSheetProps {
   onNavigateToModal?: () => void;
@@ -27,6 +55,9 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
   const childSheet = useRef<TrueSheet>(null);
   const [contentCount, setContentCount] = useState(0);
   const [detentIndex, setDetentIndex] = useState(0);
+  const [toast, setToast] = useState<string | null>(null);
+  const [dialogVisible, setDialogVisible] = useState(false);
+  const toastTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const { dismissAll, dismissStack } = useTrueSheet();
 
@@ -49,6 +80,14 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
     await sheetRef.current?.dismiss();
     await TrueSheet.present('prompt-sheet');
   };
+
+  const showToast = () => {
+    setToast('Rendered above the sheet!');
+    clearTimeout(toastTimeout.current);
+    toastTimeout.current = setTimeout(() => setToast(null), 2000);
+  };
+
+  useEffect(() => () => clearTimeout(toastTimeout.current), []);
 
   const addContent = () => {
     setContentCount((prev) => prev + 1);
@@ -127,6 +166,10 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
         <Button text="Auto" onPress={() => resize(1)} />
         <Button text="Large" onPress={() => resize(2)} />
       </ButtonGroup>
+      <ButtonGroup>
+        <Button text="Show Toast" onPress={showToast} />
+        <Button text="Show Dialog" onPress={() => setDialogVisible(true)} />
+      </ButtonGroup>
       <TrueSheetPeek />
       <Spacer />
       <Input />
@@ -144,6 +187,40 @@ export const BasicSheet = forwardRef((props: BasicSheetProps, ref: Ref<TrueSheet
       />
       <Spacer />
       <Button text="Dismiss" onPress={dismiss} />
+
+      {/* Touches outside the toast pass through — the sheet stays interactive */}
+      <TrueSheetOverlay style={styles.toastOverlay}>
+        {toast && (
+          <Animated.View
+            style={styles.toast}
+            entering={spring(new FadeInDown())}
+            exiting={spring(new FadeOutUp())}
+          >
+            <Text style={styles.overlayText}>{toast}</Text>
+          </Animated.View>
+        )}
+      </TrueSheetOverlay>
+
+      {/* A full-size backdrop blocks the sheet until the dialog is dismissed */}
+      <TrueSheetOverlay>
+        {dialogVisible && (
+          <AnimatedPressable
+            style={styles.backdrop}
+            entering={spring(new FadeIn())}
+            exiting={spring(new FadeOut())}
+            onPress={() => setDialogVisible(false)}
+          >
+            <Animated.View
+              style={styles.dialog}
+              entering={spring(new ZoomIn())}
+              exiting={spring(new ZoomOut())}
+            >
+              <Text style={styles.overlayText}>Rendered above the sheet!</Text>
+              <Button text="Close" onPress={() => setDialogVisible(false)} />
+            </Animated.View>
+          </AnimatedPressable>
+        )}
+      </TrueSheetOverlay>
 
       <TrueSheet
         ref={childSheet}
@@ -176,6 +253,32 @@ const styles = StyleSheet.create({
   childContent: {
     padding: SPACING,
     gap: GAP,
+  },
+  toastOverlay: {
+    alignItems: 'center',
+    paddingTop: SPACING * 4,
+  },
+  toast: {
+    backgroundColor: DARK,
+    borderRadius: SPACING,
+    paddingHorizontal: SPACING,
+    paddingVertical: SPACING / 2,
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    padding: SPACING,
+  },
+  dialog: {
+    backgroundColor: DARK,
+    borderRadius: SPACING,
+    padding: SPACING,
+    gap: GAP,
+  },
+  overlayText: {
+    color: LIGHT_GRAY,
+    textAlign: 'center',
   },
 });
 

--- a/ios/TrueSheetOverlayView.h
+++ b/ios/TrueSheetOverlayView.h
@@ -1,0 +1,32 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import <React/RCTViewComponentView.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Hidden host that renders its children in a container attached directly to
+ * the window, above every presented sheet.
+ */
+@interface TrueSheetOverlayView : RCTViewComponentView
+
+/**
+ * Re-stacks every overlay container above the window's other subviews.
+ * Called when a sheet presents, since presenting adds its transition view on top.
+ */
++ (void)bringOverlaysToFrontInWindow:(nullable UIWindow *)window;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/ios/TrueSheetOverlayView.mm
+++ b/ios/TrueSheetOverlayView.mm
@@ -1,0 +1,141 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import "TrueSheetOverlayView.h"
+#import "core/TrueSheetOverlayContainerView.h"
+
+#import <react/renderer/components/TrueSheetSpec/EventEmitters.h>
+#import <react/renderer/components/TrueSheetSpec/Props.h>
+#import <react/renderer/components/TrueSheetSpec/RCTComponentViewHelpers.h>
+#import <react/renderer/components/TrueSheetSpec/TrueSheetOverlayViewComponentDescriptor.h>
+#import <react/renderer/components/TrueSheetSpec/TrueSheetOverlayViewShadowNode.h>
+
+#import <React/RCTSurfaceTouchHandler.h>
+
+using namespace facebook::react;
+
+static NSHashTable<TrueSheetOverlayView *> *gOverlayViews;
+
+@interface TrueSheetOverlayView () <TrueSheetOverlayContainerViewDelegate>
+@end
+
+@implementation TrueSheetOverlayView {
+  TrueSheetOverlayContainerView *_containerView;
+  RCTSurfaceTouchHandler *_touchHandler;
+  TrueSheetOverlayViewShadowNode::ConcreteState::Shared _state;
+  CGSize _lastStateSize;
+}
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetOverlayViewComponentDescriptor>();
+}
+
++ (void)bringOverlaysToFrontInWindow:(nullable UIWindow *)window {
+  if (!window)
+    return;
+
+  for (TrueSheetOverlayView *overlay in gOverlayViews) {
+    if (overlay->_containerView.superview == window) {
+      [window bringSubviewToFront:overlay->_containerView];
+    }
+  }
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const TrueSheetOverlayViewProps>();
+    _props = defaultProps;
+
+    _containerView = [[TrueSheetOverlayContainerView alloc] initWithFrame:CGRectZero];
+    _containerView.delegate = self;
+
+    _touchHandler = [[RCTSurfaceTouchHandler alloc] init];
+    [_touchHandler attachToView:_containerView];
+
+    _lastStateSize = CGSizeZero;
+
+    // The host stays in the React tree for layout only — children render in the container
+    self.hidden = YES;
+
+    if (!gOverlayViews) {
+      gOverlayViews = [NSHashTable weakObjectsHashTable];
+    }
+    [gOverlayViews addObject:self];
+  }
+  return self;
+}
+
+- (void)didMoveToWindow {
+  [super didMoveToWindow];
+
+  UIWindow *window = self.window;
+  if (window) {
+    _containerView.frame = window.bounds;
+    [window addSubview:_containerView];
+  } else {
+    [_containerView removeFromSuperview];
+  }
+}
+
+#pragma mark - State
+
+- (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState {
+  _state = std::static_pointer_cast<TrueSheetOverlayViewShadowNode::ConcreteState const>(state);
+
+  if (self.window) {
+    [self updateStateWithSize:self.window.bounds.size];
+  }
+}
+
+- (void)overlayContainerViewDidLayout:(CGSize)size {
+  [self updateStateWithSize:size];
+}
+
+- (void)updateStateWithSize:(CGSize)size {
+  if (!_state)
+    return;
+
+  if (fabs(size.width - _lastStateSize.width) < 0.5 && fabs(size.height - _lastStateSize.height) < 0.5)
+    return;
+
+  _lastStateSize = size;
+
+  auto stateData = _state->getData();
+  stateData.containerWidth = static_cast<float>(size.width);
+  stateData.containerHeight = static_cast<float>(size.height);
+  _state->updateState(std::move(stateData), EventQueue::UpdateMode::unstable_Immediate);
+}
+
+#pragma mark - Child Component Mounting
+
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
+  [_containerView insertSubview:childComponentView atIndex:index];
+}
+
+- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
+  [childComponentView removeFromSuperview];
+}
+
+- (void)prepareForRecycle {
+  [super prepareForRecycle];
+
+  [_containerView removeFromSuperview];
+  _lastStateSize = CGSizeZero;
+  _state.reset();
+  self.hidden = YES;
+}
+
+@end
+
+Class<RCTComponentViewProtocol> TrueSheetOverlayViewCls(void) {
+  return TrueSheetOverlayView.class;
+}
+
+#endif

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -536,9 +536,19 @@ using namespace facebook::react;
                                          }
                                        }];
 
-  // Presenting adds the sheet's transition view on top of the window — keep
-  // overlays above it (again on completion in case the transition was queued)
-  [TrueSheetOverlayView bringOverlaysToFrontInWindow:window];
+  // Presenting adds the sheet's transition view on top of the window once the
+  // transition starts — re-front overlays alongside it so the first frame is
+  // already ordered (and again on completion in case the transition was queued)
+  id<UIViewControllerTransitionCoordinator> coordinator = _controller.transitionCoordinator;
+  if (coordinator) {
+    [coordinator
+      animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        [TrueSheetOverlayView bringOverlaysToFrontInWindow:window];
+      }
+                      completion:nil];
+  } else {
+    [TrueSheetOverlayView bringOverlaysToFrontInWindow:window];
+  }
 }
 
 - (void)resizeToIndex:(NSInteger)index completion:(nullable TrueSheetCompletionBlock)completion {

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -13,6 +13,7 @@
 #import "TrueSheetContentView.h"
 #import "TrueSheetFooterView.h"
 #import "TrueSheetModule.h"
+#import "TrueSheetOverlayView.h"
 #import "TrueSheetViewController.h"
 #import "core/RNScreensEventObserver.h"
 #import "events/TrueSheetDragEvents.h"
@@ -525,13 +526,19 @@ using namespace facebook::react;
   [_screensEventObserver capturePresenterScreenFromView:self];
   [_screensEventObserver startObservingWithState:_state.get()->getData()];
 
+  UIWindow *window = presentingViewController.view.window;
   [presentingViewController presentViewController:_controller
                                          animated:animated
                                        completion:^{
+                                         [TrueSheetOverlayView bringOverlaysToFrontInWindow:window];
                                          if (completion) {
                                            completion(YES, nil);
                                          }
                                        }];
+
+  // Presenting adds the sheet's transition view on top of the window — keep
+  // overlays above it (again on completion in case the transition was queued)
+  [TrueSheetOverlayView bringOverlaysToFrontInWindow:window];
 }
 
 - (void)resizeToIndex:(NSInteger)index completion:(nullable TrueSheetCompletionBlock)completion {

--- a/ios/core/TrueSheetOverlayContainerView.h
+++ b/ios/core/TrueSheetOverlayContainerView.h
@@ -1,0 +1,31 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol TrueSheetOverlayContainerViewDelegate <NSObject>
+- (void)overlayContainerViewDidLayout:(CGSize)size;
+@end
+
+/**
+ * Window-level view hosting an overlay's children.
+ * Touches that miss every child fall through to the views beneath.
+ */
+@interface TrueSheetOverlayContainerView : UIView
+
+@property (nonatomic, weak, nullable) id<TrueSheetOverlayContainerViewDelegate> delegate;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/ios/core/TrueSheetOverlayContainerView.mm
+++ b/ios/core/TrueSheetOverlayContainerView.mm
@@ -1,0 +1,35 @@
+//
+//  Created by Jovanni Lo (@lodev09)
+//  Copyright (c) 2024-present. All rights reserved.
+//
+//  This source code is licensed under the MIT license found in the
+//  LICENSE file in the root directory of this source tree.
+//
+
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import "TrueSheetOverlayContainerView.h"
+
+@implementation TrueSheetOverlayContainerView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if (self = [super initWithFrame:frame]) {
+    self.backgroundColor = UIColor.clearColor;
+    self.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  }
+  return self;
+}
+
+- (nullable UIView *)hitTest:(CGPoint)point withEvent:(nullable UIEvent *)event {
+  UIView *hit = [super hitTest:point withEvent:event];
+  return hit == self ? nil : hit;
+}
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  [self.delegate overlayContainerViewDidLayout:self.bounds.size];
+}
+
+@end
+
+#endif

--- a/ios/tvos/TrueSheetStubs.mm
+++ b/ios/tvos/TrueSheetStubs.mm
@@ -20,6 +20,7 @@
 #import <react/renderer/components/TrueSheetSpec/ComponentDescriptors.h>
 #import <react/renderer/components/TrueSheetSpec/TrueSheetContentViewComponentDescriptor.h>
 #import <react/renderer/components/TrueSheetSpec/TrueSheetFooterViewComponentDescriptor.h>
+#import <react/renderer/components/TrueSheetSpec/TrueSheetOverlayViewComponentDescriptor.h>
 #import <react/renderer/components/TrueSheetSpec/TrueSheetViewComponentDescriptor.h>
 
 #import <TrueSheetSpec/TrueSheetSpec.h>
@@ -90,6 +91,17 @@ using namespace facebook::react;
 
 + (ComponentDescriptorProvider)componentDescriptorProvider {
   return concreteComponentDescriptorProvider<TrueSheetPeekViewComponentDescriptor>();
+}
+
+@end
+
+@interface TrueSheetOverlayView : RCTViewComponentView
+@end
+
+@implementation TrueSheetOverlayView
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<TrueSheetOverlayViewComponentDescriptor>();
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@types/babel__core": "^7",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.2.14",
+    "@types/react-dom": "~19.2.0",
     "commitlint": "^19.8.1",
     "del-cli": "^6.0.0",
     "eslint": "^9.35.0",
@@ -136,6 +137,7 @@
     "@react-navigation/native": ">=7.3.0",
     "expo-router": ">=57.0.0",
     "react": "*",
+    "react-dom": "*",
     "react-native": ">=0.82.0",
     "react-native-reanimated": ">=4",
     "react-native-worklets": "*",
@@ -152,6 +154,9 @@
       "optional": true
     },
     "expo-router": {
+      "optional": true
+    },
+    "react-dom": {
       "optional": true
     },
     "react-native-reanimated": {
@@ -283,6 +288,9 @@
         },
         "TrueSheetPeekView": {
           "className": "TrueSheetPeekView"
+        },
+        "TrueSheetOverlayView": {
+          "className": "TrueSheetOverlayView"
         }
       }
     }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -7,6 +7,7 @@ module.exports = {
           'TrueSheetViewComponentDescriptor',
           'TrueSheetContentViewComponentDescriptor',
           'TrueSheetFooterViewComponentDescriptor',
+          'TrueSheetOverlayViewComponentDescriptor',
         ],
         cmakeListsPath: '../android/src/main/jni/CMakeLists.txt',
       },

--- a/skills/truesheet-usage/SKILL.md
+++ b/skills/truesheet-usage/SKILL.md
@@ -209,6 +209,18 @@ import { TrueSheet, TrueSheetPeek } from '@lodev09/react-native-true-sheet'
 
 Collapsed, the sheet shows everything from the top through the **bottom edge** of `TrueSheetPeek`; content below stays hidden until expanded. An empty `<TrueSheetPeek />` works as a fold marker between existing views. One peek component per sheet. Absolute footers count toward the peek height; relative footers don't (pushed off-screen at peek).
 
+### Toasts and dialogs above sheets
+
+```tsx
+import { TrueSheet, TrueSheetOverlay } from '@lodev09/react-native-true-sheet'
+
+<TrueSheetOverlay>
+  {toast && <Toast message={toast} />}
+</TrueSheetOverlay>
+```
+
+Renders children in a native layer above every presented sheet. Show/hide by conditionally rendering children. Fills the window; touches that miss the children pass through. Never use RN `Modal`/`FullWindowOverlay` for this anymore.
+
 ### Non-dismissible confirmation
 
 ```tsx
@@ -293,6 +305,7 @@ await sheet.current?.resize(2) // expands to full (index 2)
 |---------|-----|---------|-----|
 | `'auto'` detent | iOS 16+ | Yes | Yes |
 | `'peek'` detent / `TrueSheetPeek` | iOS 16+ | Yes | Yes |
+| `TrueSheetOverlay` | Yes | Yes | Yes |
 | `backgroundBlur` | Yes | No | No |
 | Liquid Glass | iOS 26+ | No | No |
 | Static global methods | Yes | Yes | No (use provider) |

--- a/skills/truesheet-usage/references/advanced-patterns.md
+++ b/skills/truesheet-usage/references/advanced-patterns.md
@@ -308,23 +308,22 @@ Or via Expo config: `expo.ios.infoPlist.UIDesignRequiresCompatibility: true`. Th
 
 ## Overlays on sheets
 
-Portal-based UI elements (dialogs, toasts, dropdown menus) may render behind the sheet on Android because the sheet lives in its own `CoordinatorLayout`.
+Sheets are presented natively above the React Native view hierarchy, so toasts, dialogs, and JS-portal content render behind them.
 
-**Solution:** Use `FullWindowOverlay` (iOS) or `Modal` (Android):
+**Solution:** Render the content in `TrueSheetOverlay` — a native layer above every presented sheet. Show/hide by conditionally rendering children (no `visible` prop). Mount it anywhere, including inside a sheet's content.
 
 ```tsx
-import { Platform, Modal } from 'react-native'
-import { FullWindowOverlay } from 'react-native-screens'
+import { TrueSheetOverlay } from '@lodev09/react-native-true-sheet'
 
-const Overlay = Platform.select({
-  ios: FullWindowOverlay,
-  default: Modal,
-})
-
-<Overlay visible={visible} transparent>
-  <YourDialogContent />
-</Overlay>
+<TrueSheetOverlay>
+  {toast && <Toast message={toast} />}
+</TrueSheetOverlay>
 ```
+
+- Fills the window; touches that miss its children pass through (the sheet stays draggable). For a blocking dialog, render an `absoluteFill` backdrop child.
+- Use `style` for flex/padding layout of children. The overlay itself never renders (no `backgroundColor`).
+- Native modals presented afterwards (RN `Modal`, native-stack modal screens) and the keyboard still render above it.
+- Supported on iOS, Android, and Web.
 
 ---
 

--- a/skills/truesheet-usage/references/troubleshooting.md
+++ b/skills/truesheet-usage/references/troubleshooting.md
@@ -11,7 +11,7 @@ Common issues and fixes when using TrueSheet, organized by symptom.
 - [initialDetentIndex not working from deep link (iOS)](#initialdetentindex-not-working-from-deep-link-ios)
 - [Gap above the keyboard](#gap-above-the-keyboard)
 - [Doubled bottom padding in footer or scroll content](#doubled-bottom-padding-in-footer-or-scroll-content)
-- [Overlays render behind the sheet (Android)](#overlays-render-behind-the-sheet-android)
+- [Overlays render behind the sheet](#overlays-render-behind-the-sheet)
 - [Keyboard hides input](#keyboard-hides-input)
 - [Sheet doesn't build (Xcode version)](#sheet-doesnt-build-xcode-version)
 - [EAS Build fails](#eas-build-fails)
@@ -118,13 +118,13 @@ useFocusEffect(
 
 **Fix:** Remove manual safe-area padding from the footer and scroll content. To manage it yourself instead, opt out with `scrollableOptions={{ contentInsetAdjustmentBehavior: false }}` (scrollable) or `insetAdjustment="never"` (whole sheet).
 
-## Overlays render behind the sheet (Android)
+## Overlays render behind the sheet
 
 **Symptom:** Dropdowns, toasts, or dialogs from portal-based libraries render behind the sheet.
 
-**Cause:** The sheet lives in a native `CoordinatorLayout` that sits above the normal React Native view hierarchy.
+**Cause:** Sheets are presented natively, above the React Native view hierarchy.
 
-**Fix:** Render overlays in `FullWindowOverlay` (iOS) or `Modal` (Android). See [Advanced Patterns: Overlays on sheets](./advanced-patterns.md#overlays-on-sheets).
+**Fix:** Render overlays in `TrueSheetOverlay`. See [Advanced Patterns: Overlays on sheets](./advanced-patterns.md#overlays-on-sheets).
 
 ## Keyboard hides input
 

--- a/src/TrueSheetOverlay.tsx
+++ b/src/TrueSheetOverlay.tsx
@@ -1,0 +1,21 @@
+import { StyleSheet, type ViewProps } from 'react-native';
+
+import TrueSheetOverlayViewNativeComponent from './fabric/TrueSheetOverlayViewNativeComponent';
+
+/**
+ * Renders its children in a native layer above every presented sheet — for
+ * toasts, dialogs, and other content a sheet must not cover.
+ * Fills the window; touches that miss its children pass through to the views beneath.
+ */
+export const TrueSheetOverlay = ({ style, ...rest }: ViewProps) => (
+  <TrueSheetOverlayViewNativeComponent {...rest} style={[styles.overlay, style]} />
+);
+
+const styles = StyleSheet.create({
+  // Sized to the window from native — absolute so it takes no layout space
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+  },
+});

--- a/src/TrueSheetOverlay.tsx
+++ b/src/TrueSheetOverlay.tsx
@@ -12,10 +12,13 @@ export const TrueSheetOverlay = ({ style, ...rest }: ViewProps) => (
 );
 
 const styles = StyleSheet.create({
-  // Sized to the window from native — absolute so it takes no layout space
+  // Sized to the window from native — absolute so it takes no layout space.
+  // Children render in a native container, so the host itself must never
+  // catch touches (Android forces it visible on layout).
   overlay: {
     position: 'absolute',
     top: 0,
     left: 0,
+    pointerEvents: 'none',
   },
 });

--- a/src/TrueSheetOverlay.web.tsx
+++ b/src/TrueSheetOverlay.web.tsx
@@ -1,0 +1,33 @@
+/// <reference lib="dom" />
+import { useLayoutEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { StyleSheet, View, type ViewProps } from 'react-native';
+
+/**
+ * Renders its children in a layer above every presented sheet — for
+ * toasts, dialogs, and other content a sheet must not cover.
+ * Fills the window; touches that miss its children pass through to the views beneath.
+ */
+export const TrueSheetOverlay = ({ style, ...rest }: ViewProps) => {
+  // Portal target appended to the body so it stacks above the sheets' portal
+  const [container] = useState(() =>
+    typeof document !== 'undefined' ? document.createElement('div') : null
+  );
+
+  useLayoutEffect(() => {
+    if (!container) return;
+
+    container.style.cssText = 'position:fixed;inset:0;pointer-events:none';
+    document.body.appendChild(container);
+    return () => {
+      container.remove();
+    };
+  }, [container]);
+
+  if (!container) return null;
+
+  return createPortal(
+    <View pointerEvents="box-none" {...rest} style={[StyleSheet.absoluteFill, style]} />,
+    container
+  );
+};

--- a/src/__tests__/TrueSheet.test.tsx
+++ b/src/__tests__/TrueSheet.test.tsx
@@ -2,7 +2,7 @@
 import { createRef } from 'react';
 import { Text } from 'react-native';
 import { render, act } from '@testing-library/react-native';
-import { TrueSheet, TrueSheetPeek } from '../index';
+import { TrueSheet, TrueSheetOverlay, TrueSheetPeek } from '../index';
 import TrueSheetModule from '../specs/NativeTrueSheetModule';
 import type {
   DidDismissEvent,
@@ -68,6 +68,15 @@ describe('TrueSheet', () => {
     );
     expect(getByText('Peek Content')).toBeDefined();
     expect(getByText('Content')).toBeDefined();
+  });
+
+  it('should render TrueSheetOverlay children', () => {
+    const { getByText } = render(
+      <TrueSheetOverlay>
+        <Text>Overlay Content</Text>
+      </TrueSheetOverlay>
+    );
+    expect(getByText('Overlay Content')).toBeDefined();
   });
 
   it('should render with detents prop', () => {

--- a/src/fabric/TrueSheetOverlayViewNativeComponent.ts
+++ b/src/fabric/TrueSheetOverlayViewNativeComponent.ts
@@ -1,0 +1,12 @@
+import type { ViewProps } from 'react-native';
+import { codegenNativeComponent } from 'react-native';
+
+export interface NativeProps extends ViewProps {
+  // No props needed - sized to the window from native
+}
+
+// interfaceOnly: shadow node/state/descriptor are custom (common/cpp) so the
+// overlay is sized to the window
+export default codegenNativeComponent<NativeProps>('TrueSheetOverlayView', {
+  interfaceOnly: true,
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './TrueSheet';
 export * from './TrueSheet.types';
 export { TrueSheetPeek } from './TrueSheetPeek';
+export { TrueSheetOverlay } from './TrueSheetOverlay';
 export { TrueSheetProvider, useTrueSheet } from './TrueSheetProvider';

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -67,6 +67,13 @@ export function TrueSheetPeek({ children, ...rest }: ViewProps) {
 }
 
 /**
+ * Mock TrueSheetOverlay component for testing.
+ */
+export function TrueSheetOverlay({ children, ...rest }: ViewProps) {
+  return React.createElement(View, rest, children);
+}
+
+/**
  * Mock TrueSheetProvider for testing.
  */
 export function TrueSheetProvider({ children }: { children: React.ReactNode }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6222,6 +6222,7 @@ __metadata:
     "@types/babel__core": "npm:^7"
     "@types/jest": "npm:^29.5.14"
     "@types/react": "npm:~19.2.14"
+    "@types/react-dom": "npm:~19.2.0"
     commitlint: "npm:^19.8.1"
     del-cli: "npm:^6.0.0"
     eslint: "npm:^9.35.0"
@@ -6246,6 +6247,7 @@ __metadata:
     "@react-navigation/native": ">=7.3.0"
     expo-router: ">=57.0.0"
     react: "*"
+    react-dom: "*"
     react-native: ">=0.82.0"
     react-native-reanimated: ">=4"
     react-native-worklets: "*"
@@ -6258,6 +6260,8 @@ __metadata:
     "@react-navigation/native":
       optional: true
     expo-router:
+      optional: true
+    react-dom:
       optional: true
     react-native-reanimated:
       optional: true
@@ -8398,6 +8402,15 @@ __metadata:
   peerDependencies:
     "@types/react": ^19.0.0
   checksum: 10c0/83833af502f501a372b370fdeb7cf933dfc8780903fe0e0d6e6a76b4ea3adbe5316159a62a0388d8afdd409afd76a40959e2ce82fbb788f57d32c786a63601ee
+  languageName: node
+  linkType: hard
+
+"@types/react-dom@npm:~19.2.0":
+  version: 19.2.5
+  resolution: "@types/react-dom@npm:19.2.5"
+  peerDependencies:
+    "@types/react": ^19.2.0
+  checksum: 10c0/7a59467b043debf392d109daa1ba672e791f20ce6f24ae81fb54715f890f8119d24967e61e3644b6307428603b695b7d59e69eaf531bd1963a74a6cb462f5f49
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds `TrueSheetOverlay`, a first-class component that renders its children in a native layer above every presented sheet — for toasts, dialogs, and other content a sheet must not cover. Replaces the documented `FullWindowOverlay` (iOS) / `Modal` (Android) workaround.

Closes #813

```tsx
<TrueSheetOverlay>
  {toast && <Toast message={toast} />}
</TrueSheetOverlay>
```

- Zero config: no `visible` prop, show/hide by conditionally rendering children. Mount anywhere, including inside a sheet's content.
- Fills the window (sized from native via Fabric state, like the sheet container). Touches that miss its children pass through, so the sheet stays draggable. A full-size child (backdrop) blocks.
- **iOS**: passthrough container attached directly to the window, re-fronted when a sheet presents.
- **Android**: `RootView` attached to the activity's content view with high `translationZ`; dispatches touches to JS only when a child is hit.
- **Web**: body-level portal.
- Adds `react-dom` as an optional peer dependency for the web portal.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Test Plan

Example app `BasicSheet`: **Show Toast** (passthrough, sheet remains draggable), **Show Dialog** (backdrop blocks), **Open Sheet** from the dialog (a sheet rendered inside the overlay presents beneath the dialog). Verified on iOS, Android, and Web.

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)