### PR TITLE
fix(ios): keep a recycled host's dismissing controller from reaching the next mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: Unmounting a sheet mid-dismissal and mounting a new one no longer leaks the old sheet's `onDidDismiss` into the new mount or blocks its auto-present. ([#818](https://github.com/lodev09/react-native-true-sheet/pull/818) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fractional detents now resolve against the app's window instead of the full screen, fixing full-height sheets in windowed iPad apps (Stage Manager, iPadOS 26 windowing), and re-resolve when the window is resized or rotated. ([#815](https://github.com/lodev09/react-native-true-sheet/pull/815) by [@vilindberg](https://github.com/vilindberg) and [@lodev09](https://github.com/lodev09))
 - **Android**: A stacked parent sheet now follows its child frame-by-frame when the child resizes, and no longer gets stuck at stale detents after a half-expanded settle. ([#797](https://github.com/lodev09/react-native-true-sheet/pull/797) by [@lodev09](https://github.com/lodev09))
 - **Android**: The scrollable content now tracks the keyboard frame-by-frame — the focused input rides the keyboard up smoothly, and the scroll position eases back on dismiss instead of snapping. ([#798](https://github.com/lodev09/react-native-true-sheet/pull/798) by [@lodev09](https://github.com/lodev09))

--- a/ios/TrueSheetModule.h
+++ b/ios/TrueSheetModule.h
@@ -27,15 +27,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Register a sheet component view with its React tag
- * Called automatically by TrueSheetView during initialization
+ * Called automatically by TrueSheetView when it attaches to a window.
+ * The registry holds views weakly, so no unregistration is needed.
  */
 + (void)registerView:(TrueSheetView *)view withTag:(NSNumber *)tag;
-
-/**
- * Unregister a sheet component view
- * Called automatically by TrueSheetView during dealloc
- */
-+ (void)unregisterViewWithTag:(NSNumber *)tag;
 
 @end
 

--- a/ios/TrueSheetModule.mm
+++ b/ios/TrueSheetModule.mm
@@ -18,8 +18,9 @@
 
 #import <TrueSheetSpec/TrueSheetSpec.h>
 
-// Static registry to store view references by tag
-static NSMutableDictionary<NSNumber *, TrueSheetView *> *viewRegistry;
+// Static registry of live hosts by tag — weak so an unmounted host deallocates
+// (RN zeroes the tag before teardown, so hosts can't unregister themselves)
+static NSMapTable<NSNumber *, TrueSheetView *> *viewRegistry;
 
 @interface TrueSheetModule () <NativeTrueSheetModuleSpec>
 @end
@@ -30,7 +31,7 @@ RCT_EXPORT_MODULE(TrueSheetModule)
 
 + (void)initialize {
   if (self == [TrueSheetModule class]) {
-    viewRegistry = [NSMutableDictionary new];
+    viewRegistry = [NSMapTable strongToWeakObjectsMapTable];
   }
 }
 
@@ -151,7 +152,7 @@ RCT_EXPORT_MODULE(TrueSheetModule)
       // Find the root presented sheet (one without a parent TrueSheet)
       TrueSheetView *rootSheet = nil;
 
-      for (TrueSheetView *view in viewRegistry.allValues) {
+      for (TrueSheetView *view in viewRegistry.objectEnumerator) {
         if (!view.viewController.isPresented) {
           continue;
         }
@@ -191,7 +192,7 @@ RCT_EXPORT_MODULE(TrueSheetModule)
   }
 
   @synchronized(viewRegistry) {
-    return viewRegistry[reactTag];
+    return [viewRegistry objectForKey:reactTag];
   }
 }
 
@@ -201,17 +202,7 @@ RCT_EXPORT_MODULE(TrueSheetModule)
   }
 
   @synchronized(viewRegistry) {
-    viewRegistry[tag] = view;
-  }
-}
-
-+ (void)unregisterViewWithTag:(NSNumber *)tag {
-  if (!tag) {
-    return;
-  }
-
-  @synchronized(viewRegistry) {
-    [viewRegistry removeObjectForKey:tag];
+    [viewRegistry setObject:view forKey:tag];
   }
 }
 

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -125,10 +125,35 @@ using namespace facebook::react;
 
   UIViewController *vc = [self findPresentingViewController];
 
-  // Only present if the view controller is in the same window and not being dismissed
-  if (!vc || vc.view.window != self.window || _controller.isBeingDismissed) {
+  // Only present if the view controller is in the same window
+  if (!vc || vc.view.window != self.window) {
     // Animate next time when sheet finally moves to the correct window
     _initialDetentAnimated = YES;
+    return;
+  }
+
+  // A sheet still animating out of the presenter (e.g. our own controller,
+  // recycled mid-dismissal) blocks presentation — retry once its transition ends.
+  UIViewController *dismissing = vc.presentedViewController;
+  if (dismissing && dismissing.isBeingDismissed) {
+    _initialDetentAnimated = YES;
+
+    __weak __typeof(self) weakSelf = self;
+    void (^retry)(void) = ^{
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [weakSelf presentInitialIfNeeded];
+      });
+    };
+
+    id<UIViewControllerTransitionCoordinator> coordinator = dismissing.transitionCoordinator;
+    if (coordinator) {
+      [coordinator animateAlongsideTransition:nil
+                                   completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+                                     retry();
+                                   }];
+    } else {
+      retry();
+    }
     return;
   }
 
@@ -176,8 +201,6 @@ using namespace facebook::react;
 
   [_snapshotView removeFromSuperview];
   _snapshotView = nil;
-
-  [TrueSheetModule unregisterViewWithTag:@(self.tag)];
 }
 
 #pragma mark - RCTComponentViewProtocol
@@ -383,7 +406,38 @@ using namespace facebook::react;
 - (void)prepareForRecycle {
   [super prepareForRecycle];
 
-  [TrueSheetModule unregisterViewWithTag:@(self.tag)];
+  // Pooled mid-dismissal: the next mount can reuse this host — and its
+  // controller — while the previous sheet is still animating out. Detach until
+  // that transition ends so its tail (didBlur, didDismiss, position) can't reach
+  // the new mount, then hand the controller back and let auto-present retry.
+  if (_controller.isBeingDismissed) {
+    _controller.delegate = nil;
+
+    __weak __typeof(self) weakSelf = self;
+    void (^reattach)(void) = ^{
+      dispatch_async(dispatch_get_main_queue(), ^{
+        __typeof(self) strongSelf = weakSelf;
+        if (!strongSelf)
+          return;
+
+        strongSelf->_controller.delegate = strongSelf;
+        strongSelf->_controller.activeDetentIndex = -1;
+        if (strongSelf.window) {
+          [strongSelf presentInitialIfNeeded];
+        }
+      });
+    };
+
+    id<UIViewControllerTransitionCoordinator> coordinator = _controller.transitionCoordinator;
+    if (coordinator) {
+      [coordinator animateAlongsideTransition:nil
+                                   completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+                                     reattach();
+                                   }];
+    } else {
+      reattach();
+    }
+  }
 
   _lastStateSize = CGSizeZero;
   _didInitiallyPresent = NO;


### PR DESCRIPTION
## Summary

A fast dismiss → remount cycle (unmounting a `TrueSheet` while it's still animating out and mounting a new one in the same commit) reuses the pooled Fabric host — and its `UIViewController` — for the new mount. The new sheet then received the previous sheet's `onDidDismiss` (tearing down its lazy content, so it presented blank) and its `initialDetentIndex` auto-present was blocked by `isBeingDismissed` with nothing to retry it.

- `prepareForRecycle`: when the controller is mid-dismissal, detach its delegate until the transition ends so the old session's tail (`didBlur`, `didDismiss`, position ticks) can't reach the next mount, then reattach.
- `presentInitialIfNeeded`: wait on the presenter's dismissing sheet's transition coordinator and retry instead of bailing.
- `TrueSheetModule`: the view registry is now weak. RN zeroes `view.tag` before `prepareForRecycle`/`dealloc`, so hosts could never unregister themselves and were retained forever.

Narrow alternative to #800 / #793 — only the mid-dismissal recycle state changes behavior; every other lifecycle path is untouched.

Fixes #789 (the TrueSheet side — the remaining "SVG fills missing until next commit" symptom is upstream RN Fabric, per the reporter's investigation).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Ported the reporter's repro into the example (not committed) with three auto-cycle modes on a physical iPhone, RN 0.86:

- **Mid-dismiss remount** (key-swap 30–330 ms into the dismissal): before, every cycle logged a stale `didDismiss` on the new mount and the sheet presented blank. After, 40+ cycles with `open → didPresent → willDismiss → remount` and no leaked event.
- **Remount on `onDidDismiss`** and **content swap mid-dismissal**: clean before and after.
- Navigation regressions checked: Open Modal → Basic sheet → Navigate Test → back → Dismiss Modal (main sheet re-presents), Dismiss Modal with a sheet open (single combined animation), Test Stack.
- `yarn test` passes.

## Screenshots / Videos

N/A

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (not needed)
- [x] I added a changelog entry (if needed)