### PR TITLE
fix(android): skip explicit Kotlin plugin when AGP provides built-in Kotlin (v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- **Android**: The library now builds on Android Gradle Plugin 9, which ships built-in Kotlin — the explicit Kotlin plugin is skipped when AGP already provides it. ([#819](https://github.com/lodev09/react-native-true-sheet/pull/819) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 3.11.12
 
 ### 🐛 Bug fixes

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,28 @@ buildscript {
 
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// Android Gradle Plugin 9 ships built-in Kotlin support and applies the Kotlin
+// plugin itself. Applying it a second time fails the configuration phase with
+// "Cannot add extension with name 'kotlin'". Apply it only when AGP is not
+// providing Kotlin: AGP 8 and older, or AGP 9 with android.builtInKotlin=false.
+def shouldApplyKotlinPlugin() {
+  def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpMajor <= 8) {
+    return true
+  }
+  // AGP 10 removes the opt-out: built-in Kotlin is always active there.
+  if (agpMajor >= 10) {
+    return false
+  }
+  def propertyVal = providers.gradleProperty("android.builtInKotlin").orNull
+  def builtInKotlinEnabled = propertyVal != null ? propertyVal.toBoolean() : true
+  return !builtInKotlinEnabled
+}
+
+if (shouldApplyKotlinPlugin()) {
+  apply plugin: "kotlin-android"
+}
+
 apply plugin: "com.facebook.react"
 
 def getExtOrIntegerDefault(name) {


### PR DESCRIPTION
## Summary

Port of #819 to v3.

AGP 9 ships built-in Kotlin and applies the Kotlin plugin itself. Applying `kotlin-android` again fails configuration with `Cannot add extension with name 'kotlin'`. The explicit apply is now skipped when AGP provides Kotlin: AGP 8 and older always apply, AGP 10+ never applies, AGP 9 applies only with `android.builtInKotlin=false`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- `android/build.gradle` is byte-identical to main after #819.
- On main, the bare example passed a clean Android build (AGP 8.12, RN 0.86).
- AGP 9 path verified by the original author on RN 0.87 / Expo SDK 58 with AGP 9.2.1.

## Checklist

- [ ] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)