### PR TITLE
fix(ios): let TrueSheetOverlay children install their own view controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- **iOS**: `TrueSheetOverlay` children can now install their own view controllers — its container is owned by a `UIViewController`, so `-[UIView reactViewController]` resolves inside the overlay as it does elsewhere in the tree. Previously such content mounted and rendered nothing. ([#823](https://github.com/lodev09/react-native-true-sheet/pull/823) by [@SamuelBrucksch](https://github.com/SamuelBrucksch))
+- **iOS**: Content that needs a parent view controller, like React Native's `Modal`, now works inside `TrueSheetOverlay` instead of silently rendering nothing. ([#823](https://github.com/lodev09/react-native-true-sheet/pull/823) by [@SamuelBrucksch](https://github.com/SamuelBrucksch) and [@lodev09](https://github.com/lodev09))
 - **iOS**: Unmounting a sheet mid-dismissal and mounting a new one no longer leaks the old sheet's `onDidDismiss` into the new mount or blocks its auto-present. ([#818](https://github.com/lodev09/react-native-true-sheet/pull/818) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fractional detents now resolve against the app's window instead of the full screen, fixing full-height sheets in windowed iPad apps (Stage Manager, iPadOS 26 windowing), and re-resolve when the window is resized or rotated. ([#815](https://github.com/lodev09/react-native-true-sheet/pull/815) by [@vilindberg](https://github.com/vilindberg) and [@lodev09](https://github.com/lodev09))
 - **Android**: A stacked parent sheet now follows its child frame-by-frame when the child resizes, and no longer gets stuck at stale detents after a half-expanded settle. ([#797](https://github.com/lodev09/react-native-true-sheet/pull/797) by [@lodev09](https://github.com/lodev09))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- **iOS**: `TrueSheetOverlay` children can now install their own view controllers — its container is owned by a `UIViewController`, so `-[UIView reactViewController]` resolves inside the overlay as it does elsewhere in the tree. Previously such content mounted and rendered nothing. (by [@SamuelBrucksch](https://github.com/SamuelBrucksch))
 - **iOS**: Unmounting a sheet mid-dismissal and mounting a new one no longer leaks the old sheet's `onDidDismiss` into the new mount or blocks its auto-present. ([#818](https://github.com/lodev09/react-native-true-sheet/pull/818) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fractional detents now resolve against the app's window instead of the full screen, fixing full-height sheets in windowed iPad apps (Stage Manager, iPadOS 26 windowing), and re-resolve when the window is resized or rotated. ([#815](https://github.com/lodev09/react-native-true-sheet/pull/815) by [@vilindberg](https://github.com/vilindberg) and [@lodev09](https://github.com/lodev09))
 - **Android**: A stacked parent sheet now follows its child frame-by-frame when the child resizes, and no longer gets stuck at stale detents after a half-expanded settle. ([#797](https://github.com/lodev09/react-native-true-sheet/pull/797) by [@lodev09](https://github.com/lodev09))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- **iOS**: `TrueSheetOverlay` children can now install their own view controllers — its container is owned by a `UIViewController`, so `-[UIView reactViewController]` resolves inside the overlay as it does elsewhere in the tree. Previously such content mounted and rendered nothing. (by [@SamuelBrucksch](https://github.com/SamuelBrucksch))
+- **iOS**: `TrueSheetOverlay` children can now install their own view controllers — its container is owned by a `UIViewController`, so `-[UIView reactViewController]` resolves inside the overlay as it does elsewhere in the tree. Previously such content mounted and rendered nothing. ([#823](https://github.com/lodev09/react-native-true-sheet/pull/823) by [@SamuelBrucksch](https://github.com/SamuelBrucksch))
 - **iOS**: Unmounting a sheet mid-dismissal and mounting a new one no longer leaks the old sheet's `onDidDismiss` into the new mount or blocks its auto-present. ([#818](https://github.com/lodev09/react-native-true-sheet/pull/818) by [@lodev09](https://github.com/lodev09))
 - **iOS**: Fractional detents now resolve against the app's window instead of the full screen, fixing full-height sheets in windowed iPad apps (Stage Manager, iPadOS 26 windowing), and re-resolve when the window is resized or rotated. ([#815](https://github.com/lodev09/react-native-true-sheet/pull/815) by [@vilindberg](https://github.com/vilindberg) and [@lodev09](https://github.com/lodev09))
 - **Android**: A stacked parent sheet now follows its child frame-by-frame when the child resizes, and no longer gets stuck at stale detents after a half-expanded settle. ([#797](https://github.com/lodev09/react-native-true-sheet/pull/797) by [@lodev09](https://github.com/lodev09))

--- a/docs/docs/guides/overlays.mdx
+++ b/docs/docs/guides/overlays.mdx
@@ -70,6 +70,7 @@ Since it fills the window, content may sit under the status bar or the system na
 
 - Native modals presented **after** the overlay — React Native's `Modal`, native-stack modal screens — render above it.
 - The keyboard always renders above the overlay.
+- `react-native-screens` containers — native stacks, bottom tabs, drawers — are not supported inside the overlay. On Android they crash with the same error described in [Nesting Navigators in Sheets](./navigation#nesting-navigators-in-sheets).
 
 ## Platform Support
 

--- a/ios/TrueSheetOverlayView.mm
+++ b/ios/TrueSheetOverlayView.mm
@@ -28,13 +28,10 @@ static NSHashTable<TrueSheetOverlayView *> *gOverlayViews;
 
 @implementation TrueSheetOverlayView {
   TrueSheetOverlayContainerView *_containerView;
-  // Owns `_containerView` so it has a view controller in its responder chain.
-  //
-  // The container is added straight to the window, which makes it a sibling of
-  // `rootViewController.view`, and a UIWindow's responder chain skips its root view
-  // controller. Without an owner here `-[UIView reactViewController]` walks
-  // container -> window -> application and finds nothing, so content that installs a
-  // view controller cannot attach and renders nothing.
+  // Owns `_containerView` so it has a view controller in its responder chain. The
+  // container is a sibling of `rootViewController.view`, and a window's responder chain
+  // skips its root view controller — without an owner, `-[UIView reactViewController]`
+  // finds nothing and content that installs a view controller cannot attach.
   UIViewController *_containerController;
   RCTSurfaceTouchHandler *_touchHandler;
   TrueSheetOverlayViewShadowNode::ConcreteState::Shared _state;
@@ -64,8 +61,8 @@ static NSHashTable<TrueSheetOverlayView *> *gOverlayViews;
     _containerView = [[TrueSheetOverlayContainerView alloc] initWithFrame:CGRectZero];
     _containerView.delegate = self;
 
-    // Assigning it as the controller's view is what puts the controller in the
-    // container's responder chain; the containment below is for lifecycle only.
+    // Assigning the container as its view is what puts the controller in the responder
+    // chain; the containment below is for lifecycle only.
     _containerController = [UIViewController new];
     _containerController.view = _containerView;
 

--- a/ios/TrueSheetOverlayView.mm
+++ b/ios/TrueSheetOverlayView.mm
@@ -28,6 +28,14 @@ static NSHashTable<TrueSheetOverlayView *> *gOverlayViews;
 
 @implementation TrueSheetOverlayView {
   TrueSheetOverlayContainerView *_containerView;
+  // Owns `_containerView` so it has a view controller in its responder chain.
+  //
+  // The container is added straight to the window, which makes it a sibling of
+  // `rootViewController.view`, and a UIWindow's responder chain skips its root view
+  // controller. Without an owner here `-[UIView reactViewController]` walks
+  // container -> window -> application and finds nothing, so content that installs a
+  // view controller cannot attach and renders nothing.
+  UIViewController *_containerController;
   RCTSurfaceTouchHandler *_touchHandler;
   TrueSheetOverlayViewShadowNode::ConcreteState::Shared _state;
   CGSize _lastStateSize;
@@ -56,6 +64,11 @@ static NSHashTable<TrueSheetOverlayView *> *gOverlayViews;
     _containerView = [[TrueSheetOverlayContainerView alloc] initWithFrame:CGRectZero];
     _containerView.delegate = self;
 
+    // Assigning it as the controller's view is what puts the controller in the
+    // container's responder chain; the containment below is for lifecycle only.
+    _containerController = [UIViewController new];
+    _containerController.view = _containerView;
+
     _touchHandler = [[RCTSurfaceTouchHandler alloc] init];
     [_touchHandler attachToView:_containerView];
 
@@ -79,8 +92,16 @@ static NSHashTable<TrueSheetOverlayView *> *gOverlayViews;
   if (window) {
     _containerView.frame = window.bounds;
     [window addSubview:_containerView];
+
+    UIViewController *root = window.rootViewController;
+    if (root != nil && _containerController.parentViewController != root) {
+      [root addChildViewController:_containerController];
+      [_containerController didMoveToParentViewController:root];
+    }
   } else {
+    [_containerController willMoveToParentViewController:nil];
     [_containerView removeFromSuperview];
+    [_containerController removeFromParentViewController];
   }
 }
 
@@ -126,7 +147,9 @@ static NSHashTable<TrueSheetOverlayView *> *gOverlayViews;
 - (void)prepareForRecycle {
   [super prepareForRecycle];
 
+  [_containerController willMoveToParentViewController:nil];
   [_containerView removeFromSuperview];
+  [_containerController removeFromParentViewController];
   _lastStateSize = CGSizeZero;
   _state.reset();
   self.hidden = YES;


### PR DESCRIPTION
## Problem

Content that installs a `UIViewController` renders nothing inside `TrueSheetOverlay`, with no error or warning. The most common case is a React Navigation native stack (via `react-native-screens`): the navigator mounts, React renders it, and the overlay draws nothing. Plain views in the same overlay render fine.

```tsx
<TrueSheetOverlay>
  <View style={StyleSheet.absoluteFill}>
    <NativeStack.Navigator>
      <NativeStack.Screen name="A" component={A} />
    </NativeStack.Navigator>
  </View>
</TrueSheetOverlay>
```

Worth knowing when reproducing: **a hot reload hides the bug.** A controller that is already attached skips the code path below, so the overlay looks correct until the app is cold-started.

## Cause

`TrueSheetOverlayView` adds its container straight to the window:

```objc
_containerView.frame = window.bounds;
[window addSubview:_containerView];
```

That makes the container a *sibling* of `rootViewController.view`. A `UIWindow`'s responder chain does not include its root view controller — a view controller only joins the chain for views inside its own view — so `-[UIView reactViewController]`, which walks `nextResponder`, finds no view controller for anything inside the container.

`react-native-screens` adds its `UINavigationController`'s view only inside the branch guarded by that lookup:

```objc
// RNSScreenStack.mm
UIView *parentView = (UIView *)self.reactSuperview;
while (parentView) {
  if (parentView.reactViewController) {
    [parentView.reactViewController addChildViewController:controller];
    [self addSubview:controller.view];   // ← never reached in an overlay
    ...
```

With the lookup returning nil the loop ends having done nothing, so the navigation controller's view is never added. Hence: mounted, no error, nothing drawn.

Android does not have this gap — `TrueSheetOverlayRootView` implements `RootView`, so children have something to attach to. This PR is the iOS equivalent.

## Fix

Give the container a `UIViewController` owner. Assigning the container as that controller's `view` is what puts the controller in the responder chain, so `reactViewController` resolves and child view controllers attach as they do elsewhere in the tree. It is also added as a child of the window's root view controller so it takes part in the normal lifecycle.

No behaviour change for plain views, which need no parent view controller.

## Notes

Happy to reshape this — a few things are your call:

- Once a view controller owns that container, UIKit consults it for status-bar style, home-indicator behaviour and rotation. Overriding those to defer to the root view controller may be desirable.
- `addChildViewController:` affects appearance-callback ordering, and can be dropped if the responder chain alone is enough.
- If hosting view controllers is out of scope for the overlay, a documented note plus a dev-mode warning when the lookup fails would still be a big improvement over silent non-rendering. I see #822 documents this for *sheet screens*; the overlay case is separate and currently undocumented.

## Testing

Verified on the iOS 26 simulator, new architecture: a native stack inside `TrueSheetOverlay` renders and navigates correctly above a presented sheet, on a cold start. Plain overlay content (a fixed-size view) is unaffected. Not yet tested on iPad or in a windowed/Stage Manager configuration.
