### PR TITLE
docs: document scrollableRef in the sheet navigator

### DIFF
--- a/docs/content/docs/next/guides/navigation.mdx
+++ b/docs/content/docs/next/guides/navigation.mdx
@@ -1,5 +1,5 @@
 ---
-title: React Navigation
+title: Navigation
 description: Navigate to other screens from within the bottom sheet.
 keywords: [bottom sheet navigation, react-navigation, navigating from sheet, sheet navigator]
 ---
@@ -252,6 +252,39 @@ function DetailsSheet() {
 :::tip
 All [TrueSheet props](../reference/configuration) like `header`, `footer`, `grabber`, `dismissible`, etc. can be dynamically updated via `setOptions`.
 :::
+
+### Scrollable Content
+
+[`scrollableRef`](../reference/configuration#scrollableref) and [`scrollableOptions`](../reference/configuration#scrollableoptions) are screen options like any other prop. Since the ref is created inside the screen component, set it with `setOptions`:
+
+```tsx
+function DetailsSheet() {
+  const navigation = useTrueSheetNavigation();
+  const scrollableRef = useRef<ScrollView>(null);
+
+  useEffect(() => {
+    navigation.setOptions({ scrollableRef });
+  }, [navigation]);
+
+  return (
+    <ScrollView ref={scrollableRef}>
+      {/* ... */}
+    </ScrollView>
+  );
+}
+```
+
+Bound the scroll view's height with `flex: 1` via the screen's `style` option.
+
+```tsx
+<Sheet.Screen
+  name="Details"
+  component={DetailsSheet}
+  options={{ detents: [0.5, 1], style: { flex: 1 } }}
+/>
+```
+
+See the [Scrolling guide](scrolling) for more information.
 
 ### Screen Listeners
 

--- a/docs/content/docs/next/guides/resizing.mdx
+++ b/docs/content/docs/next/guides/resizing.mdx
@@ -47,6 +47,10 @@ TrueSheet.resize('resizing-sheet', 1)
 :::
 
 :::info
+The [`auto`](../reference/types#sheetdetent) detent works with scrolling content too — no `flex: 1` needed. The sheet sizes to the scroll view's content height and resizes as content grows or shrinks, while the viewport is automatically bounded to the sheet's visible height. See the [Scrolling guide](scrolling).
+:::
+
+:::info
 Use [`insetAdjustment="never"`](../reference/configuration#insetadjustment) to disable automatic bottom inset adjustment on both platforms.
 :::
 

--- a/example/bare/src/navigators/SheetNavigator.tsx
+++ b/example/bare/src/navigators/SheetNavigator.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { TrueSheet } from '@lodev09/react-native-true-sheet';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
@@ -7,12 +7,13 @@ import {
   createTrueSheetNavigator,
   useTrueSheetNavigation,
 } from '@lodev09/react-native-true-sheet/navigation';
-import { Button, DemoContent, Footer } from '@example/shared/components';
-import { BLUE, DARK, DARK_BLUE, GAP, LIGHT_GRAY, SPACING } from '@example/shared/utils';
+import { Button, DemoContent, Footer, Header } from '@example/shared/components';
+import { BLUE, DARK, DARK_BLUE, DARK_GRAY, GAP, LIGHT_GRAY, SPACING } from '@example/shared/utils';
 import type { AppStackParamList, SheetHomeStackParamList, SheetStackParamList } from '../types';
 import {
   NotificationsSheetContent,
   ProfileSheetContent,
+  ScrollableSheetContent,
   SettingsSheetContent,
   TestScreen,
 } from '@example/shared/screens';
@@ -34,6 +35,7 @@ const HomeScreen = () => {
       </View>
       <Button text="Open Details Sheet" onPress={() => navigation.navigate('Details')} />
       <Button text="Open Settings Sheet" onPress={() => navigation.navigate('Settings')} />
+      <Button text="Open Scrollable Sheet" onPress={() => navigation.navigate('Scrollable')} />
       <Button text="Open Small Footer Sheet" onPress={() => navigation.navigate('SmallFooter')} />
       <Button text="Navigate to Test" onPress={() => navigation.navigate('Test')} />
       <Button text="Go Back" onPress={() => navigation.goBack()} />
@@ -115,6 +117,25 @@ const SmallFooterSheet = () => {
       <Text style={styles.sheetTitle}>Small Footer Sheet</Text>
       <Text style={styles.sheetSubtitle}>Small auto detent with a late-mounted footer.</Text>
     </View>
+  );
+};
+
+// Scrolling content in a sheet screen — the ScrollView is created here, so it's
+// plugged into the sheet via `setOptions` instead of the static screen options.
+const ScrollableSheet = () => {
+  const navigation = useTrueSheetNavigation<AppStackParamList & SheetStackParamList>();
+  const scrollableRef = useRef<ScrollView>(null);
+
+  useEffect(() => {
+    navigation.setOptions({ scrollableRef });
+  }, [navigation]);
+
+  return (
+    <ScrollableSheetContent
+      scrollableRef={scrollableRef}
+      onResize={() => navigation.resize(1)}
+      onPop={() => navigation.pop()}
+    />
   );
 };
 
@@ -249,6 +270,25 @@ export const SheetNavigator = () => {
         }}
       />
       <SheetStack.Screen
+        name="Scrollable"
+        component={ScrollableSheet}
+        options={{
+          detents: [0.6, 1],
+          backgroundColor: DARK,
+          cornerRadius: 16,
+          style: styles.scrollableSheet,
+          header: <Header />,
+          headerOptions: { position: 'absolute' },
+          footer: <Footer />,
+          footerStyle: styles.scrollableFooter,
+          footerOptions: { position: 'absolute' },
+          scrollableOptions: {
+            topScrollEdgeEffect: 'soft',
+            bottomScrollEdgeEffect: 'soft',
+          },
+        }}
+      />
+      <SheetStack.Screen
         name="SmallFooter"
         component={SmallFooterSheet}
         options={{
@@ -299,6 +339,13 @@ const styles = StyleSheet.create({
   buttons: {
     gap: GAP,
     marginTop: SPACING,
+  },
+  scrollableSheet: {
+    flex: 1,
+  },
+  // Transparent on iOS so the scroll edge effect shows through
+  scrollableFooter: {
+    backgroundColor: Platform.select({ default: DARK_GRAY, ios: undefined }),
   },
   smallFooter: {
     justifyContent: 'center',

--- a/example/bare/src/types.ts
+++ b/example/bare/src/types.ts
@@ -18,6 +18,7 @@ export type SheetStackParamList = {
   Settings: undefined;
   Profile: undefined;
   Notifications: undefined;
+  Scrollable: undefined;
   SmallFooter: undefined;
 };
 

--- a/example/expo/app/sheet/(home)/index.tsx
+++ b/example/expo/app/sheet/(home)/index.tsx
@@ -17,6 +17,7 @@ export default function SheetHomeScreen() {
       </View>
       <Button text="Open Details Sheet" onPress={() => router.push('/sheet/details')} />
       <Button text="Open Settings Sheet" onPress={() => router.push('/sheet/settings')} />
+      <Button text="Open Scrollable Sheet" onPress={() => router.push('/sheet/scrollable')} />
       <Button text="Open Small Footer Sheet" onPress={() => router.push('/sheet/small-footer')} />
       <Button text="Navigate to Test" onPress={() => router.push('/sheet/test')} />
       <Button text="Go Back" onPress={() => router.back()} />

--- a/example/expo/app/sheet/_layout.tsx
+++ b/example/expo/app/sheet/_layout.tsx
@@ -1,6 +1,8 @@
+import { Platform, StyleSheet } from 'react-native';
 import { Sheet } from '@lodev09/react-native-true-sheet/navigation/expo-router';
 
-import { DARK } from '@example/shared/utils';
+import { Footer, Header } from '@example/shared/components';
+import { DARK, DARK_GRAY } from '@example/shared/utils';
 import { TrueSheetProvider } from '@lodev09/react-native-true-sheet';
 
 export const unstable_settings = {
@@ -84,6 +86,24 @@ export default function SheetStackLayout() {
           }}
         />
         <Sheet.Screen
+          name="scrollable"
+          options={{
+            detents: [0.6, 1],
+            backgroundColor: DARK,
+            cornerRadius: 16,
+            style: styles.scrollableSheet,
+            header: <Header />,
+            headerOptions: { position: 'absolute' },
+            footer: <Footer />,
+            footerStyle: styles.scrollableFooter,
+            footerOptions: { position: 'absolute' },
+            scrollableOptions: {
+              topScrollEdgeEffect: 'soft',
+              bottomScrollEdgeEffect: 'soft',
+            },
+          }}
+        />
+        <Sheet.Screen
           name="small-footer"
           options={{
             detents: ['auto'],
@@ -95,3 +115,13 @@ export default function SheetStackLayout() {
     </TrueSheetProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  scrollableSheet: {
+    flex: 1,
+  },
+  // Transparent on iOS so the scroll edge effect shows through
+  scrollableFooter: {
+    backgroundColor: Platform.select({ default: DARK_GRAY, ios: undefined }),
+  },
+});

--- a/example/expo/app/sheet/scrollable.tsx
+++ b/example/expo/app/sheet/scrollable.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+import { ScrollView } from 'react-native';
+import { useTrueSheetNavigation } from '@lodev09/react-native-true-sheet/navigation/expo-router';
+import { useRouter } from 'expo-router';
+
+import { ScrollableSheetContent } from '@example/shared/screens';
+
+// Scrolling content in a sheet screen — the ScrollView is created here, so it's
+// plugged into the sheet via `setOptions` instead of the static screen options.
+export default function ScrollableSheet() {
+  const navigation = useTrueSheetNavigation();
+  const router = useRouter();
+  const scrollableRef = useRef<ScrollView>(null);
+
+  useEffect(() => {
+    navigation.setOptions({ scrollableRef });
+  }, [navigation]);
+
+  return (
+    <ScrollableSheetContent
+      scrollableRef={scrollableRef}
+      onResize={() => navigation.resize(1)}
+      onPop={() => router.back()}
+    />
+  );
+}

--- a/example/shared/src/screens/ScrollableSheetContent.tsx
+++ b/example/shared/src/screens/ScrollableSheetContent.tsx
@@ -1,0 +1,68 @@
+import type { RefObject } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import type { TrueSheetProps } from '@lodev09/react-native-true-sheet';
+
+import { Button } from '../components/Button';
+import { DemoContent } from '../components/DemoContent';
+import { Input } from '../components/Input';
+import { FOOTER_HEIGHT, GAP, HEADER_HEIGHT, LIGHT_GRAY, SPACING, times } from '../utils';
+
+interface ScrollableSheetContentProps {
+  // Typed as the sheet's own prop type — the app that owns the ref hands it to
+  // both the ScrollView and the sheet.
+  scrollableRef: TrueSheetProps['scrollableRef'];
+  onResize: () => void;
+  onPop: () => void;
+}
+
+export const ScrollableSheetContent = ({
+  scrollableRef,
+  onResize,
+  onPop,
+}: ScrollableSheetContentProps) => {
+  return (
+    <ScrollView
+      ref={scrollableRef as RefObject<ScrollView | null>}
+      contentContainerStyle={styles.content}
+      keyboardDismissMode="on-drag"
+    >
+      <Text style={styles.sheetTitle}>Scrollable Sheet</Text>
+      <Text style={styles.sheetSubtitle}>
+        ScrollView plugged in via the `scrollableRef` screen option.
+      </Text>
+      <View style={styles.buttons}>
+        <Button text="Resize to 100%" onPress={onResize} />
+        <Button text="pop()" onPress={onPop} />
+      </View>
+      {times(8, (i) => (
+        <DemoContent key={i} text={`Item #${i + 1}`} />
+      ))}
+      {/* Offscreen until scrolled to — focusing it scrolls the sheet automatically */}
+      <Input />
+      <Input multiline />
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  content: {
+    padding: SPACING,
+    // Clear the absolute header and footer
+    paddingTop: HEADER_HEIGHT + SPACING,
+    paddingBottom: FOOTER_HEIGHT + SPACING,
+    gap: GAP,
+  },
+  sheetTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: 'white',
+  },
+  sheetSubtitle: {
+    fontSize: 14,
+    color: LIGHT_GRAY,
+    marginBottom: SPACING,
+  },
+  buttons: {
+    gap: GAP,
+  },
+});

--- a/example/shared/src/screens/index.ts
+++ b/example/shared/src/screens/index.ts
@@ -2,6 +2,7 @@ export * from './MapScreen';
 export * from './ModalScreen';
 export * from './NotificationsSheetContent';
 export * from './ProfileSheetContent';
+export * from './ScrollableSheetContent';
 export * from './SettingsSheetContent';
 export * from './StandardScreen';
 export * from './TestScreen';


### PR DESCRIPTION
## Summary

`scrollableRef` / `scrollableOptions` already flow through the sheet navigator's screen options, but nothing documented it and no example exercised it.

- Rename the navigation guide title from "React Navigation" to "Navigation" — it covers the sheet navigator, Expo Router, and navigating from sheets.
- Add a **Scrollable Content** section documenting `scrollableRef` as a screen option, set via `navigation.setOptions()` since the ref is created inside the screen component.
- Move the `auto` detent + scrollable note to the resizing guide (the scrolling guide already had it).
- Add a **Scrollable** sheet screen to both example apps: shared `ScrollableSheetContent` with a `ScrollView`, an absolute header/footer, soft scroll edge effects, and inputs at the bottom to show the automatic scroll-to-input when focused.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Test Plan

`yarn typecheck` and `yarn lint` pass. The new example screen has not been run on a device yet.

## Checklist

- [ ] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [x] I updated the documentation (if needed)
- [ ] I added a changelog entry (if needed)