### PR TITLE
fix(ios): let VoiceOver dismiss the sheet and reach the grabber (v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🐛 Bug fixes
+
+- **iOS**: VoiceOver users can now dismiss the sheet with the two-finger Z gesture, and the grabber is announced as the sheet's first element so it can be resized or dismissed with swipe gestures. ([#829](https://github.com/lodev09/react-native-true-sheet/pull/829) by [@lodev09](https://github.com/lodev09))
+
 ## 3.11.13
 
 ### 🐛 Bug fixes

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -382,7 +382,6 @@ using namespace facebook::react;
   [_controller.view addSubview:_containerView];
   [LayoutUtil pinView:_containerView toParentView:_controller.view edges:UIRectEdgeAll];
   [_controller.view bringSubviewToFront:_containerView];
-  _containerView.accessibilityViewIsModal = YES;
   _controller.accessibilityContentView = _containerView;
   [_controller setupAccessibilityContainer];
 

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -43,12 +43,27 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 - (void)restoreWindowAccessibilityElements;
 - (void)setSheetAccessibilityElementsHidden:(BOOL)hidden;
 - (void)setAccessibilityContentElement:(UIView *)contentView;
+- (NSArray *)accessibilityGrabberElements;
 - (void)endInteractiveDismissState;
 - (void)emitInteractivePosition;
 - (void)animateInteractiveContainerToTransform:(CGAffineTransform)transform
                                       duration:(NSTimeInterval)duration
                           allowUserInteraction:(BOOL)allowUserInteraction
                                     completion:(void (^)(void))completion;
+
+@end
+
+// VoiceOver delivers the two-finger Z (escape) gesture by walking up the view
+// hierarchy from the focused element, so the sheet's root view handles it.
+@interface TrueSheetControllerView : UIView
+@property (nonatomic, weak) TrueSheetViewController *controller;
+@end
+
+@implementation TrueSheetControllerView
+
+- (BOOL)accessibilityPerformEscape {
+  return [self.controller accessibilityPerformEscape];
+}
 
 @end
 
@@ -214,6 +229,12 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
 
 #pragma mark - View Lifecycle
 
+- (void)loadView {
+  TrueSheetControllerView *view = [[TrueSheetControllerView alloc] init];
+  view.controller = self;
+  self.view = view;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
   self.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
@@ -321,6 +342,32 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   }
 }
 
+- (NSArray *)accessibilityGrabberElements {
+  if (_grabberView && !_grabberView.hidden) {
+    return @[ _grabberView ];
+  }
+
+  // The system grabber is an accessibility element UIKit adds to the presented view
+  // (a sibling of our root view). Expose it so VoiceOver can resize or dismiss with it.
+  // UIKit also keeps a transparent bottom grabber there, so skip invisible views.
+  NSMutableArray *elements = [NSMutableArray array];
+  for (UIView *subview in self.presentationController.presentedView.subviews) {
+    if (subview != self.view && subview.isAccessibilityElement && !subview.hidden && subview.alpha > 0) {
+      [elements addObject:subview];
+    }
+  }
+  return elements;
+}
+
+- (BOOL)accessibilityPerformEscape {
+  if (!_isPresented || !self.dismissible) {
+    return NO;
+  }
+
+  [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+  return YES;
+}
+
 - (void)setAccessibilityContentElement:(UIView *)contentView {
   BOOL hasAccessibilityFooterElements = [contentView isKindOfClass:[TrueSheetContainerView class]] &&
                                         [(TrueSheetContainerView *)contentView hasAccessibilityFooterElements];
@@ -333,12 +380,12 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
   // its accessibilityElements getter recomputes live, so a footer/content subtree
   // that remounts (e.g. swapping a footer button on a state change) stays
   // discoverable instead of leaving this snapshot pointing at destroyed views.
-  NSArray *accessibilityElements;
+  NSMutableArray *accessibilityElements = [[self accessibilityGrabberElements] mutableCopy];
   if (isAccessibilityModal) {
     NSArray *contentElements = contentView.accessibilityElements;
-    accessibilityElements = contentElements.count > 0 ? contentElements : @[ contentView ];
+    [accessibilityElements addObjectsFromArray:contentElements.count > 0 ? contentElements : @[ contentView ]];
   } else {
-    accessibilityElements = @[ contentView ];
+    [accessibilityElements addObject:contentView];
   }
 
   self.view.isAccessibilityElement = NO;
@@ -1146,6 +1193,12 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     _grabberView.onTap = nil;
     _grabberView.onIncrement = nil;
     _grabberView.onDecrement = nil;
+  }
+
+  // Only the topmost sheet may refresh, or a parent's prop update would steal the
+  // window accessibility override from the child presented over it.
+  if (_isPresented && self.isTopmostPresentedController) {
+    [self setupAccessibilityContainer];
   }
 }
 


### PR DESCRIPTION
## Summary

Backport of #828 to v3. Fixes #807.

Under VoiceOver, iOS sheets could not be dismissed: the two-finger Z (escape) gesture was ignored, the grabber was not in the accessibility tree, and the dim view was excluded from traversal.

- The sheet's root view is now a `TrueSheetControllerView` that handles `accessibilityPerformEscape`, dismissing when `dismissible` is true.
- The grabber is exposed as the first accessibility element. With `grabberOptions` that is the library grabber (swipe down at the lowest detent dismisses). Without it, UIKit's system grabber is picked up from the presented view, skipping the transparent bottom duplicate UIKit also adds.
- Removed the container's `accessibilityViewIsModal`, which filtered out the grabber sibling. The root view already carries the modal flag.
- `setupGrabber` refreshes the exposed elements for the topmost sheet only, so a parent's prop update cannot steal the window override from a child.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Clean cherry-pick of the main commit; the touched code is identical between branches. Verified on main (#828) by building the example on the iOS 26.5 simulator, inspecting the accessibility tree, and calling `accessibilityPerformEscape` via lldb across dimmed, non-dimmed, non-dismissible, custom grabber, system grabber, and stacked cases. Not rebuilt on v3.

## Screenshots / Videos

N/A

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)