### PR TITLE
fix(ios): escape from the system grabber, keep custom grabber from expanding under VoiceOver (v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🐛 Bug fixes
 
-- **iOS**: VoiceOver users can now dismiss the sheet with the two-finger Z gesture, and the grabber is announced as the sheet's first element so it can be resized or dismissed with swipe gestures. ([#829](https://github.com/lodev09/react-native-true-sheet/pull/829) by [@lodev09](https://github.com/lodev09))
+- **iOS**: VoiceOver users can now dismiss the sheet with the two-finger Z gesture, and the grabber is announced as the sheet's first element so it can be resized or dismissed with swipe gestures. A sheet with a custom grabber no longer expands to the next detent on its own when presented under VoiceOver. ([#829](https://github.com/lodev09/react-native-true-sheet/pull/829), [#831](https://github.com/lodev09/react-native-true-sheet/pull/831) by [@lodev09](https://github.com/lodev09))
 
 ## 3.11.13
 

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -398,6 +398,15 @@ static char TrueSheetAccessibilityWindowPreviousElementsKey;
     presentedView.accessibilityViewIsModal = isAccessibilityModal;
     presentedView.accessibilityElements = accessibilityElements;
 
+    // The system grabber is a sibling of our root view, so an escape performed while it
+    // is focused walks presentedView → window and never reaches TrueSheetControllerView.
+    if (@available(iOS 17.0, *)) {
+      __weak __typeof(self) weakSelf = self;
+      presentedView.accessibilityPerformEscapeBlock = ^BOOL {
+        return [weakSelf accessibilityPerformEscape];
+      };
+    }
+
     UIWindow *window = self.view.window;
     UIViewController *presentingViewController = [self accessibilityPresentingViewController];
     if (window && presentingViewController.view) {

--- a/ios/core/TrueSheetGrabberView.mm
+++ b/ios/core/TrueSheetGrabberView.mm
@@ -91,6 +91,13 @@ static const CGFloat kHitPaddingVertical = 10.0;
   }
 }
 
+// Pad the pill evenly like the system grabber. The view frame itself stays inside
+// the sheet, since the reveal check reads the frame rather than this rect.
+- (CGRect)accessibilityFrame {
+  CGRect rect = CGRectInset(_vibrancyView.frame, -kHitPaddingHorizontal, -kHitPaddingVertical);
+  return UIAccessibilityConvertFrameToScreenCoordinates(rect, self);
+}
+
 - (void)accessibilityIncrement {
   if (_onIncrement) {
     _onIncrement();
@@ -144,14 +151,17 @@ static const CGFloat kHitPaddingVertical = 10.0;
   CGFloat topMargin = [self effectiveTopMargin];
   CGFloat parentWidth = self.superview ? self.superview.bounds.size.width : UIScreen.mainScreen.bounds.size.width;
 
+  // Keep the frame inside the sheet. A frame above the top edge reads as a clipped element
+  // to VoiceOver, and the sheet reveals it on focus by moving to the next detent.
   CGFloat frameWidth = pillWidth + kHitPaddingHorizontal * 2;
-  CGFloat frameHeight = pillHeight + kHitPaddingVertical * 2;
-  CGFloat frameY = topMargin - kHitPaddingVertical;
+  CGFloat frameY = MAX(0, topMargin - kHitPaddingVertical);
+  CGFloat pillY = topMargin - frameY;
+  CGFloat frameHeight = pillY + pillHeight + kHitPaddingVertical;
 
   self.frame = CGRectMake((parentWidth - frameWidth) / 2.0, frameY, frameWidth, frameHeight);
   self.backgroundColor = UIColor.clearColor;
 
-  CGRect pillRect = CGRectMake(kHitPaddingHorizontal, kHitPaddingVertical, pillWidth, pillHeight);
+  CGRect pillRect = CGRectMake(kHitPaddingHorizontal, pillY, pillWidth, pillHeight);
   _vibrancyView.frame = pillRect;
   _vibrancyView.layer.cornerRadius = [self effectiveCornerRadius];
   _vibrancyView.clipsToBounds = YES;


### PR DESCRIPTION
## Summary

Port of #830 to v3. Follow-up to #829 from device testing in #807.

- The two-finger Z escape did nothing while VoiceOver focus was on UIKit's system grabber. VoiceOver walks superviews from the focused element, and the system grabber is a sibling of our root view, so the walk went presented view → window and never reached the escape handler. The presented view now handles escape via `accessibilityPerformEscapeBlock` (iOS 17+), forwarding to the controller.
- With a custom grabber, presenting a sheet under VoiceOver expanded it to the next detent on its own. The grabber's hit-padded frame started above the sheet's top edge, and UIKit reveals a clipped focused element in a sheet by changing detent. The frame is now clamped inside the sheet.
- The custom grabber's accessibility frame is padded evenly around the pill, matching the system grabber's focus box.

Tapping the dimmed background is not a VoiceOver target, matching native UIKit sheets.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

Same changes verified on main (#830) with the bare example on a physical device with VoiceOver on:

- Z escape from the system grabber and custom grabber dismisses.
- Non-dismissible sheet: escape plays the failure sound and stays.
- Stacked: escape dismisses only the child, focus returns to the parent.
- Custom grabber sheet presents at its initial detent and stays there. Grabber double tap and swipe up/down still cycle detents, swipe down at the lowest detent dismisses.
- Focus box on the custom grabber matches the system grabber.

## Screenshots / Videos

N/A

## Checklist

- [x] I tested on iOS
- [ ] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)