### PR TITLE
feat: support the element inspector inside the sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - New `headerOptions` prop with a `position` option — set to `'absolute'` to float the header over the content and exclude it from the `auto` detent height. ([#747](https://github.com/lodev09/react-native-true-sheet/pull/747) by [@lodev09](https://github.com/lodev09))
 - The footer now absorbs the bottom safe-area inset as padding when `insetAdjustment` is `automatic`, except while the keyboard is open. ([#749](https://github.com/lodev09/react-native-true-sheet/pull/749), [#750](https://github.com/lodev09/react-native-true-sheet/pull/750) by [@lodev09](https://github.com/lodev09))
 - New `scrollableOptions.keyboardOffset` option to adjust the scrollable's keyboard bottom inset. ([#785](https://github.com/lodev09/react-native-true-sheet/pull/785) by [@lodev09](https://github.com/lodev09))
+- The dev menu's element inspector now works inside a presented sheet — header, content, and footer are all inspectable. ([#832](https://github.com/lodev09/react-native-true-sheet/pull/832) by [@lodev09](https://github.com/lodev09))
 
 ### 🐛 Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The true native bottom sheet experience for your React Native Apps. 💩
 * 🦶 **Relative footers** - Footers take up space below the content by default
 * 🧭 **Expo Router** - First-class support via the `Sheet` layout from `/navigation/expo-router`
 * 🍞 **`TrueSheetOverlay`** - Render toasts, dialogs, and other [overlays above your sheets](https://sheet.lodev09.com/guides/overlays) — no more `FullWindowOverlay`/`Modal` workarounds
+* 🔍 **Element inspector** - React Native's dev menu inspector now works inside a presented sheet
 
 ```sh
 npx expo install @lodev09/react-native-true-sheet@beta

--- a/docs/content/docs/next/migration.mdx
+++ b/docs/content/docs/next/migration.mdx
@@ -248,6 +248,10 @@ const Sheet = createTrueSheetNavigator({
 });
 ```
 
+### 6. Element Inspector Support
+
+React Native's element inspector now works inside a presented sheet. Open the dev menu, toggle the inspector, and tap any element in the sheet's header, content, or footer — the overlay and panel render inside the sheet, the same way they do inside a `Modal`. Dev builds only, no configuration needed.
+
 ## Step-by-Step Migration
 
 1. **Update React Native** to 0.82 or newer.

--- a/skills/truesheet-usage/references/advanced-patterns.md
+++ b/skills/truesheet-usage/references/advanced-patterns.md
@@ -507,3 +507,4 @@ The footer now takes space below the content (still pinned to the bottom edge) a
 - `TrueSheetOverlay` — toasts/dialogs above sheets, replaces the `FullWindowOverlay`/`Modal` workaround
 - `lazy={false}` — mount content before presenting so `'auto'` measures settled content
 - Synchronous per-detent layout — flex layouts track the sheet edge frame-by-frame while dragging
+- Element inspector works inside a presented sheet (dev builds, no setup) — header, content, and footer are inspectable

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -4,6 +4,7 @@ import {
   createRef,
   type ReactNode,
   type ComponentRef,
+  type ComponentType,
   isValidElement,
   createElement,
   useEffect,
@@ -40,11 +41,30 @@ import {
   Platform,
   StyleSheet,
   BackHandler,
+  RootTagContext,
   findNodeHandle,
   processColor,
   type NativeEventSubscription,
   type GestureResponderEvent,
+  type RootTag,
+  type StyleProp,
+  type ViewStyle,
 } from 'react-native';
+
+interface AppContainerProps {
+  rootTag: RootTag;
+  rootViewStyle?: StyleProp<ViewStyle>;
+  internal_excludeLogBox?: boolean;
+  children?: ReactNode;
+}
+
+// RN has no public API for hosting the element inspector inside a presented view;
+// this is the internal RN's Modal uses. Dev-only so prod bundles never resolve it.
+// The template literal keeps the RN babel preset's deep-import warning off while
+// Metro still resolves the module statically.
+const AppContainer: ComponentType<AppContainerProps> | null = __DEV__
+  ? require(`react-native/Libraries/ReactNative/AppContainer`).default
+  : null;
 
 const LINKING_ERROR =
   `The package '@lodev09/react-native-true-sheet' doesn't seem to be linked. Make sure: \n\n` +
@@ -99,6 +119,8 @@ export class TrueSheet
   implements TrueSheetMethods
 {
   displayName = 'TrueSheet';
+
+  static contextType = RootTagContext;
 
   private readonly nativeRef: RefObject<NativeRef | null>;
 
@@ -580,6 +602,42 @@ export class TrueSheet
       };
     }
 
+    const sheetContent = (
+      <>
+        {header && (
+          <TrueSheetHeaderViewNativeComponent
+            style={[
+              styles.header,
+              headerOptions?.position === 'absolute' && styles.absoluteHeader,
+              headerStyle,
+            ]}
+          >
+            {isValidElement(header) ? header : createElement(header)}
+          </TrueSheetHeaderViewNativeComponent>
+        )}
+        <TrueSheetContentViewNativeComponent style={style}>
+          {children}
+        </TrueSheetContentViewNativeComponent>
+        {footer && (
+          <TrueSheetFooterViewNativeComponent
+            autoBottomInset={insetAdjustment === 'automatic'}
+            style={[
+              styles.footer,
+              footerOptions?.position === 'absolute'
+                ? styles.absoluteFooter
+                : styles.relativeFooter,
+              footerStyle,
+            ]}
+          >
+            {isValidElement(footer) ? footer : createElement(footer)}
+          </TrueSheetFooterViewNativeComponent>
+        )}
+        {autoPresent && !this.state.initialPresentReady && (
+          <InitialPresentGate onReady={this.onInitialPresentReady} />
+        )}
+      </>
+    );
+
     return (
       <TrueSheetViewNativeComponent
         {...rest}
@@ -641,36 +699,22 @@ export class TrueSheet
       >
         {this.state.shouldRenderNativeView && (
           <TrueSheetContainerViewNativeComponent style={styles.container}>
-            {header && (
-              <TrueSheetHeaderViewNativeComponent
-                style={[
-                  styles.header,
-                  headerOptions?.position === 'absolute' && styles.absoluteHeader,
-                  headerStyle,
-                ]}
+            {AppContainer ? (
+              // Hosts the element inspector inside the sheet, like RN's Modal does —
+              // the app-level one sits behind the presented sheet.
+              // `display: contents` keeps AppContainer's wrapper views out of both
+              // Yoga layout and the native tree, so header/content/footer remain the
+              // container's direct native children, while the inspector overlay
+              // anchors to the container and lines up with measured frames.
+              <AppContainer
+                rootTag={this.context as RootTag}
+                rootViewStyle={styles.inspectorHost}
+                internal_excludeLogBox
               >
-                {isValidElement(header) ? header : createElement(header)}
-              </TrueSheetHeaderViewNativeComponent>
-            )}
-            <TrueSheetContentViewNativeComponent style={style}>
-              {children}
-            </TrueSheetContentViewNativeComponent>
-            {footer && (
-              <TrueSheetFooterViewNativeComponent
-                autoBottomInset={insetAdjustment === 'automatic'}
-                style={[
-                  styles.footer,
-                  footerOptions?.position === 'absolute'
-                    ? styles.absoluteFooter
-                    : styles.relativeFooter,
-                  footerStyle,
-                ]}
-              >
-                {isValidElement(footer) ? footer : createElement(footer)}
-              </TrueSheetFooterViewNativeComponent>
-            )}
-            {autoPresent && !this.state.initialPresentReady && (
-              <InitialPresentGate onReady={this.onInitialPresentReady} />
+                {sheetContent}
+              </AppContainer>
+            ) : (
+              sheetContent
             )}
           </TrueSheetContainerViewNativeComponent>
         )}
@@ -691,6 +735,9 @@ const styles = StyleSheet.create({
   // Fill the sheet so flex layouts track the sheet's size per detent
   container: {
     ...StyleSheet.absoluteFill,
+  },
+  inspectorHost: {
+    display: 'contents',
   },
   header: {
     pointerEvents: 'box-none',


### PR DESCRIPTION
## Summary

Toggling the element inspector from the dev menu now works while a sheet is presented. Sheet content, header, and footer are all inspectable, with highlight boxes lining up correctly.

Same mechanism RN's \`Modal\` uses: in \`__DEV__\`, the sheet's header/content/footer are wrapped in RN's \`AppContainer\`, which hosts the inspector overlay and listens to \`toggleElementInspector\`. The wrappers use \`display: 'contents'\`, so Yoga skips them and Fabric never mounts them — header/content/footer stay the container's direct native children and layout is untouched, while the overlay anchors to the container and matches measured frames.

\`AppContainer\` has no public export, so it is loaded with a \`__DEV__\`-gated template-literal \`require\` — Metro still resolves it statically, the RN babel preset's deep-import warning stays off, and prod bundles never reference the path. LogBox toasts are excluded so they don't cover the footer.

Resolves #339

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Present a sheet, open the dev menu, toggle the element inspector — overlay and panel render inside the sheet; tap header, content, and footer elements
- Toggle the inspector before presenting; present — overlay is there
- \`yarn typecheck\`, \`yarn lint\`, \`yarn test\`
- Ran the RN babel preset in dev mode over \`TrueSheet.tsx\` — no deep-import warning injected; Metro's \`collectDependencies\` resolves the template-literal require

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [ ] I tested on Web
- [ ] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)