### PR TITLE
feat: add onDismissAttempt event for blocked dismissals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - The footer now absorbs the bottom safe-area inset as padding when `insetAdjustment` is `automatic`, except while the keyboard is open. ([#749](https://github.com/lodev09/react-native-true-sheet/pull/749), [#750](https://github.com/lodev09/react-native-true-sheet/pull/750) by [@lodev09](https://github.com/lodev09))
 - New `scrollableOptions.keyboardOffset` option to adjust the scrollable's keyboard bottom inset. ([#785](https://github.com/lodev09/react-native-true-sheet/pull/785) by [@lodev09](https://github.com/lodev09))
 - The dev menu's element inspector now works inside a presented sheet — header, content, and footer are all inspectable. ([#832](https://github.com/lodev09/react-native-true-sheet/pull/832) by [@lodev09](https://github.com/lodev09))
+- New `onDismissAttempt` event fires when the user tries to dismiss a sheet with `dismissible` set to `false` — confirm unsaved changes, then call `dismiss()`. ([#833](https://github.com/lodev09/react-native-true-sheet/pull/833) by [@lodev09](https://github.com/lodev09))
 
 ### 🐛 Bug fixes
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetView.kt
@@ -590,6 +590,11 @@ class TrueSheetView(private val reactContext: ThemedReactContext) :
     eventDispatcher?.dispatchEvent(WillDismissEvent(surfaceId, id))
   }
 
+  override fun viewControllerDidAttemptDismiss() {
+    val surfaceId = UIManagerHelper.getSurfaceId(this)
+    eventDispatcher?.dispatchEvent(DismissAttemptEvent(surfaceId, id))
+  }
+
   override fun viewControllerDidDismiss(parent: TrueSheetView?) {
     // Detach coordinator from the root container view
     viewController.coordinatorLayout?.let { rootContainerView?.removeView(it) }

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewController.kt
@@ -55,6 +55,7 @@ interface TrueSheetViewControllerDelegate {
   fun viewControllerDidPresent(index: Int, position: Float, detent: Float)
   fun viewControllerWillDismiss()
   fun viewControllerDidDismiss(parent: TrueSheetView?)
+  fun viewControllerDidAttemptDismiss()
   fun viewControllerDidChangeDetent(index: Int, position: Float, detent: Float)
   fun viewControllerDidDragBegin(index: Int, position: Float, detent: Float)
   fun viewControllerDidDragChange(index: Int, position: Float, detent: Float)
@@ -493,6 +494,14 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
   override fun findScrollView(): ViewGroup? = containerView?.contentView?.findScrollView()
   override fun findSheetView(): TrueSheetBottomSheetView? = sheetView
 
+  override fun coordinatorLayoutDidPullDown() {
+    // A pull that left the sheet in place at its lowest detent is a blocked
+    // drag-to-dismiss. Keyboard-shifted detents make the index unreliable.
+    if (isPresented && !dismissible && draggable && currentDetentIndex == 0 && keyboardInset == 0) {
+      delegate?.viewControllerDidAttemptDismiss()
+    }
+  }
+
   // =============================================================================
   // MARK: - TrueSheetDimViewDelegate
   // =============================================================================
@@ -530,8 +539,12 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
 
   override fun bottomSheetViewDidTapGrabber() {
     val nextIndex = (currentDetentIndex + 1) % detents.size
-    if (nextIndex == 0 && detents.size == 1 && dismissible) {
-      dismiss(animated = true)
+    if (nextIndex == 0 && detents.size == 1) {
+      if (dismissible) {
+        dismiss(animated = true)
+      } else {
+        delegate?.viewControllerDidAttemptDismiss()
+      }
     } else {
       setStateForDetentIndex(nextIndex)
     }
@@ -548,6 +561,8 @@ class TrueSheetViewController(private val reactContext: ThemedReactContext) :
       setStateForDetentIndex(currentDetentIndex - 1)
     } else if (dismissible) {
       dismiss(animated = true)
+    } else {
+      delegate?.viewControllerDidAttemptDismiss()
     }
   }
 

--- a/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
+++ b/android/src/main/java/com/lodev09/truesheet/TrueSheetViewManager.kt
@@ -81,6 +81,7 @@ class TrueSheetViewManager :
       DidPresentEvent.EVENT_NAME to hashMapOf("registrationName" to DidPresentEvent.REGISTRATION_NAME),
       WillDismissEvent.EVENT_NAME to hashMapOf("registrationName" to WillDismissEvent.REGISTRATION_NAME),
       DidDismissEvent.EVENT_NAME to hashMapOf("registrationName" to DidDismissEvent.REGISTRATION_NAME),
+      DismissAttemptEvent.EVENT_NAME to hashMapOf("registrationName" to DismissAttemptEvent.REGISTRATION_NAME),
       DetentChangeEvent.EVENT_NAME to hashMapOf("registrationName" to DetentChangeEvent.REGISTRATION_NAME),
       DragBeginEvent.EVENT_NAME to hashMapOf("registrationName" to DragBeginEvent.REGISTRATION_NAME),
       DragChangeEvent.EVENT_NAME to hashMapOf("registrationName" to DragChangeEvent.REGISTRATION_NAME),

--- a/android/src/main/java/com/lodev09/truesheet/core/TrueSheetCoordinatorLayout.kt
+++ b/android/src/main/java/com/lodev09/truesheet/core/TrueSheetCoordinatorLayout.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import android.widget.EditText
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ReactPointerEventsView
 import com.facebook.react.uimanager.TouchTargetHelper
@@ -20,6 +21,7 @@ interface TrueSheetCoordinatorLayoutDelegate {
   fun coordinatorLayoutDidChangeConfiguration()
   fun findScrollView(): ViewGroup?
   fun findSheetView(): TrueSheetBottomSheetView?
+  fun coordinatorLayoutDidPullDown()
 }
 
 /**
@@ -65,6 +67,16 @@ class TrueSheetCoordinatorLayout(context: Context) :
   private var streamSheetDraggable = false
   private var streamDraggableEditText = false
 
+  // Pull-down tracking. BottomSheetBehavior gives no callback when a downward drag
+  // is clamped by `isHideable = false` — the sheet stays put (or the scrollable
+  // overscrolls) and no state change fires. Track the finger ourselves and report
+  // a stationary vertical pull on release so the controller can surface a
+  // blocked dismiss attempt.
+  private var pullTracking = false
+  private var pullStartX = 0f
+  private var pullStartY = 0f
+  private var pullSheetTop = 0
+
   init {
     layoutParams = LayoutParams(
       LayoutParams.MATCH_PARENT,
@@ -93,6 +105,39 @@ class TrueSheetCoordinatorLayout(context: Context) :
 
   override val pointerEvents: PointerEvents
     get() = PointerEvents.BOX_NONE
+
+  override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+    when (ev.actionMasked) {
+      MotionEvent.ACTION_DOWN -> {
+        val sheet = delegate?.findSheetView()
+        val scrollView = delegate?.findScrollView()
+        // Only a touch on the sheet whose scrollable (if any) is already at its
+        // top can be a drag-to-dismiss; anything else is a scroll or a dim tap.
+        pullTracking = sheet != null &&
+          isTouchInside(sheet, ev) &&
+          scrollView?.canScrollVertically(-1) != true
+        pullStartX = ev.rawX
+        pullStartY = ev.rawY
+        pullSheetTop = sheet?.top ?: 0
+      }
+
+      MotionEvent.ACTION_UP -> if (pullTracking) {
+        pullTracking = false
+        val dx = kotlin.math.abs(ev.rawX - pullStartX)
+        val dy = ev.rawY - pullStartY
+        val sheet = delegate?.findSheetView()
+        // Let the behavior settle first so a moved sheet is caught by the top check.
+        val handled = super.dispatchTouchEvent(ev)
+        if (sheet != null && sheet.top == pullSheetTop && dy > dx && dy > PULL_DOWN_THRESHOLD_DP.dpToPx()) {
+          delegate?.coordinatorLayoutDidPullDown()
+        }
+        return handled
+      }
+
+      MotionEvent.ACTION_CANCEL -> pullTracking = false
+    }
+    return super.dispatchTouchEvent(ev)
+  }
 
   /**
    * Clears stale `nestedScrollingChildRef` from BottomSheetBehavior.
@@ -158,6 +203,14 @@ class TrueSheetCoordinatorLayout(context: Context) :
 
     streamSheetDraggable = true
     streamDraggableEditText = target is EditText
+  }
+
+  private fun isTouchInside(view: View, ev: MotionEvent): Boolean {
+    val loc = IntArray(2)
+    view.getLocationOnScreen(loc)
+    val x = ev.rawX.toInt()
+    val y = ev.rawY.toInt()
+    return x >= loc[0] && x <= loc[0] + view.width && y >= loc[1] && y <= loc[1] + view.height
   }
 
   private fun findDescendantViewAt(view: View, rawX: Int, rawY: Int, predicate: (View) -> Boolean): View? {
@@ -299,5 +352,6 @@ class TrueSheetCoordinatorLayout(context: Context) :
   companion object {
     private const val GESTURE_HANDLER_ROOT_VIEW_CLASS = "com.swmansion.gesturehandler.react.RNGestureHandlerRootView"
     private const val GESTURE_CLAIM_SLOP_FACTOR = 3
+    private const val PULL_DOWN_THRESHOLD_DP = 24f
   }
 }

--- a/android/src/main/java/com/lodev09/truesheet/events/TrueSheetLifecycleEvents.kt
+++ b/android/src/main/java/com/lodev09/truesheet/events/TrueSheetLifecycleEvents.kt
@@ -94,6 +94,21 @@ class DidDismissEvent(surfaceId: Int, viewId: Int) : Event<DidDismissEvent>(surf
 }
 
 /**
+ * Fired when the user tries to dismiss a non-dismissible sheet
+ */
+class DismissAttemptEvent(surfaceId: Int, viewId: Int) : Event<DismissAttemptEvent>(surfaceId, viewId) {
+
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun getEventData(): WritableMap = Arguments.createMap()
+
+  companion object {
+    const val EVENT_NAME = "topDismissAttempt"
+    const val REGISTRATION_NAME = "onDismissAttempt"
+  }
+}
+
+/**
  * Fired when the sheet visibility changes due to screen transitions
  */
 class VisibilityChangeEvent(surfaceId: Int, viewId: Int, private val visible: Boolean) : Event<VisibilityChangeEvent>(surfaceId, viewId) {

--- a/docs/content/docs/next/guides/navigation.mdx
+++ b/docs/content/docs/next/guides/navigation.mdx
@@ -322,6 +322,7 @@ function DetailsSheet() {
 | `sheetDidPresent` | Sheet finished presenting |
 | `sheetWillDismiss` | Sheet is about to dismiss |
 | `sheetDidDismiss` | Sheet finished dismissing |
+| `sheetDismissAttempt` | User tried to dismiss a non-dismissible sheet |
 | `sheetDetentChange` | Detent changed |
 | `sheetDragBegin` | User started dragging |
 | `sheetDragChange` | User is dragging |

--- a/docs/content/docs/next/reference/configuration.mdx
+++ b/docs/content/docs/next/reference/configuration.mdx
@@ -167,6 +167,10 @@ If set to `false`, the sheet will prevent interactive dismissal via dragging or 
 | - | - | - | - | - |
 | `boolean` | `true` | ✅ | ✅ | ✅ |
 
+:::tip
+Blocked attempts fire [`onDismissAttempt`](events#ondismissattempt). Use it to confirm before dismissing programmatically, e.g. when a form has unsaved changes.
+:::
+
 ## `draggable`
 
 If set to `false`, the sheet will disable dragging to resize. The sheet can only be resized programmatically using the [`resize`](methods#resize) method.

--- a/docs/content/docs/next/reference/events.mdx
+++ b/docs/content/docs/next/reference/events.mdx
@@ -70,6 +70,31 @@ This is called when the sheet is about to be dismissed.
 
 This is called when the sheet has been dismissed.
 
+## `onDismissAttempt`
+
+This is called when the user tries to dismiss the sheet while [`dismissible`](configuration#dismissible) is `false` — by dragging it down, pressing the hardware back button (Android) or escape key (Web), or using an accessibility dismiss action. Tapping the dimmed background does not count, matching iOS. The sheet stays presented.
+
+Use this to confirm destructive dismissals, then call [`dismiss`](methods#dismiss) to proceed. This follows Apple's `isModalInPresentation` + `presentationControllerDidAttemptToDismiss` pattern for unsaved changes.
+
+```tsx
+<TrueSheet
+  ref={sheet}
+  dismissible={!hasUnsavedChanges}
+  onDismissAttempt={() => {
+    Alert.alert('Discard changes?', undefined, [
+      { text: 'Keep editing', style: 'cancel' },
+      { text: 'Discard', style: 'destructive', onPress: () => sheet.current?.dismiss() },
+    ])
+  }}
+>
+  {/* form */}
+</TrueSheet>
+```
+
+:::info
+On Android, providing `onDismissAttempt` consumes the back press while `dismissible` is `false`. Return `false` from [`onBackPress`](#onbackpress) to let it propagate anyway.
+:::
+
 ## `onDetentChange`
 
 Comes with [`DetentInfoEventPayload`](types#detentinfoeventpayload).

--- a/example/shared/src/components/sheets/PromptSheet.tsx
+++ b/example/shared/src/components/sheets/PromptSheet.tsx
@@ -1,5 +1,5 @@
-import { forwardRef, useRef, type Ref, useImperativeHandle } from 'react';
-import { ScrollView, StyleSheet, TextInput } from 'react-native';
+import { forwardRef, useRef, type Ref, useImperativeHandle, useState } from 'react';
+import { Alert, Platform, ScrollView, StyleSheet, TextInput } from 'react-native';
 import { TrueSheet, type TrueSheetProps } from '@lodev09/react-native-true-sheet';
 
 import { BUTTON_HEIGHT, DARK, GAP, SPACING } from '../../utils';
@@ -28,8 +28,27 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
   const input10Ref = useRef<TextInput>(null);
   const textAreaRef = useRef<TextInput>(null);
 
+  // Unsaved changes lock the sheet; a blocked dismiss asks before discarding
+  const [isDirty, setIsDirty] = useState(false);
+  const markDirty = () => setIsDirty(true);
+
   const handleDismiss = () => {
+    setIsDirty(false);
     console.log('Sheet prompt dismissed!');
+  };
+
+  const handleDismissAttempt = () => {
+    console.log('Dismiss attempted with unsaved changes');
+    if (Platform.OS === 'web') {
+      // eslint-disable-next-line no-alert
+      if (window.confirm('Discard changes?')) sheetRef.current?.dismiss();
+      return;
+    }
+
+    Alert.alert('Discard changes?', 'Your input will be lost.', [
+      { text: 'Keep editing', style: 'cancel' },
+      { text: 'Discard', style: 'destructive', onPress: () => sheetRef.current?.dismiss() },
+    ]);
   };
 
   const handleDismissPress = async () => {
@@ -57,6 +76,8 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
       }}
       backgroundBlur="dark"
       backgroundColor={DARK}
+      dismissible={!isDirty}
+      onDismissAttempt={handleDismissAttempt}
       onDidDismiss={handleDismiss}
       onDidPresent={(e) => {
         console.log(
@@ -94,6 +115,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
         <Input
           ref={input1Ref}
           placeholder="First name"
+          onChangeText={markDirty}
           submitBehavior="submit"
           returnKeyType="next"
           onSubmitEditing={() => input2Ref.current?.focus()}
@@ -101,6 +123,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
         <Input
           ref={input2Ref}
           placeholder="Last name"
+          onChangeText={markDirty}
           submitBehavior="submit"
           returnKeyType="next"
           onSubmitEditing={() => input3Ref.current?.focus()}
@@ -109,6 +132,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
           ref={input3Ref}
           placeholder="Email"
           keyboardType="email-address"
+          onChangeText={markDirty}
           submitBehavior="submit"
           returnKeyType="next"
           onSubmitEditing={() => input4Ref.current?.focus()}
@@ -117,6 +141,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
           ref={input4Ref}
           placeholder="Phone"
           keyboardType="phone-pad"
+          onChangeText={markDirty}
           submitBehavior="submit"
           returnKeyType="next"
           onSubmitEditing={() => input5Ref.current?.focus()}
@@ -124,6 +149,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
         <Input
           ref={input5Ref}
           placeholder="Address"
+          onChangeText={markDirty}
           submitBehavior="submit"
           returnKeyType="next"
           onSubmitEditing={() => input6Ref.current?.focus()}
@@ -131,6 +157,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
         <Input
           ref={input6Ref}
           placeholder="City"
+          onChangeText={markDirty}
           submitBehavior="submit"
           returnKeyType="next"
           onSubmitEditing={() => input7Ref.current?.focus()}
@@ -138,6 +165,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
         <Input
           ref={input7Ref}
           placeholder="State"
+          onChangeText={markDirty}
           submitBehavior="submit"
           returnKeyType="next"
           onSubmitEditing={() => input8Ref.current?.focus()}
@@ -146,6 +174,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
           ref={input8Ref}
           placeholder="Zip code"
           keyboardType="number-pad"
+          onChangeText={markDirty}
           submitBehavior="submit"
           returnKeyType="next"
           onSubmitEditing={() => input9Ref.current?.focus()}
@@ -153,6 +182,7 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
         <Input
           ref={input9Ref}
           placeholder="Country"
+          onChangeText={markDirty}
           submitBehavior="submit"
           returnKeyType="next"
           onSubmitEditing={() => input10Ref.current?.focus()}
@@ -160,11 +190,12 @@ export const PromptSheet = forwardRef((props: PromptSheetProps, ref: Ref<TrueShe
         <Input
           ref={input10Ref}
           placeholder="Contact"
+          onChangeText={markDirty}
           submitBehavior="submit"
           returnKeyType="next"
           onSubmitEditing={() => textAreaRef.current?.focus()}
         />
-        <Input ref={textAreaRef} placeholder="Message..." multiline />
+        <Input ref={textAreaRef} placeholder="Message..." onChangeText={markDirty} multiline />
       </ScrollView>
     </TrueSheet>
   );

--- a/ios/TrueSheetView.mm
+++ b/ios/TrueSheetView.mm
@@ -796,6 +796,10 @@ using namespace facebook::react;
   }
 }
 
+- (void)viewControllerDidAttemptDismiss {
+  [TrueSheetLifecycleEvents emitDismissAttempt:_eventEmitter];
+}
+
 - (void)viewControllerDidDismiss {
   [_containerView cleanupKeyboardObserver];
   if (!_dismissedByNavigation) {

--- a/ios/TrueSheetViewController.h
+++ b/ios/TrueSheetViewController.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewControllerDidPresentAtIndex:(NSInteger)index position:(CGFloat)position detent:(CGFloat)detent;
 - (void)viewControllerWillDismiss;
 - (void)viewControllerDidDismiss;
+- (void)viewControllerDidAttemptDismiss;
 - (void)viewControllerDidChangeDetent:(NSInteger)index position:(CGFloat)position detent:(CGFloat)detent;
 - (void)viewControllerDidDrag:(UIGestureRecognizerState)state
                         index:(NSInteger)index

--- a/ios/TrueSheetViewController.mm
+++ b/ios/TrueSheetViewController.mm
@@ -526,7 +526,12 @@ static BOOL TrueSheetIsPhoneIdiom(void) {
 }
 
 - (BOOL)accessibilityPerformEscape {
-  if (!_isPresented || !self.dismissible) {
+  if (!_isPresented) {
+    return NO;
+  }
+
+  if (!self.dismissible) {
+    [self.delegate viewControllerDidAttemptDismiss];
     return NO;
   }
 
@@ -1463,6 +1468,8 @@ static BOOL TrueSheetIsPhoneIdiom(void) {
         }];
       } else if (strongSelf.dismissible) {
         [strongSelf.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+      } else {
+        [strongSelf.delegate viewControllerDidAttemptDismiss];
       }
     };
 
@@ -1492,8 +1499,12 @@ static BOOL TrueSheetIsPhoneIdiom(void) {
     return;
 
   NSInteger nextIndex = (currentIndex + 1) % detentCount;
-  if (nextIndex == 0 && detentCount == 1 && self.dismissible) {
-    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+  if (nextIndex == 0 && detentCount == 1) {
+    if (self.dismissible) {
+      [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+    } else {
+      [self.delegate viewControllerDidAttemptDismiss];
+    }
   } else {
     [self.sheet animateChanges:^{
       [self resizeToDetentIndex:nextIndex];
@@ -1583,6 +1594,13 @@ static BOOL TrueSheetIsPhoneIdiom(void) {
 
 - (BOOL)presentationControllerShouldDismiss:(UIPresentationController *)presentationController {
   return self.dismissible;
+}
+
+// UIKit calls this after shouldDismiss returns NO — the sheet has already
+// bounced back, so JS can confirm and dismiss programmatically (Apple's
+// unsaved-changes pattern).
+- (void)presentationControllerDidAttemptToDismiss:(UIPresentationController *)presentationController {
+  [self.delegate viewControllerDidAttemptDismiss];
 }
 
 - (void)sheetPresentationControllerDidChangeSelectedDetentIdentifier:

--- a/ios/events/TrueSheetLifecycleEvents.h
+++ b/ios/events/TrueSheetLifecycleEvents.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)emitDidDismiss:(std::shared_ptr<const facebook::react::EventEmitter>)eventEmitter;
 
++ (void)emitDismissAttempt:(std::shared_ptr<const facebook::react::EventEmitter>)eventEmitter;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/events/TrueSheetLifecycleEvents.mm
+++ b/ios/events/TrueSheetLifecycleEvents.mm
@@ -66,6 +66,14 @@
   emitter->onDidDismiss({});
 }
 
++ (void)emitDismissAttempt:(std::shared_ptr<const facebook::react::EventEmitter>)eventEmitter {
+  if (!eventEmitter)
+    return;
+
+  auto emitter = std::static_pointer_cast<TrueSheetViewEventEmitter const>(eventEmitter);
+  emitter->onDismissAttempt({});
+}
+
 @end
 
 #endif  // RCT_NEW_ARCH_ENABLED

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -6,6 +6,7 @@ jest.mock('./src/specs/NativeTrueSheetModule', () => ({
   default: {
     presentByRef: jest.fn(),
     dismissByRef: jest.fn(),
+    handleBackPress: jest.fn(),
   },
 }));
 

--- a/skills/truesheet-usage/SKILL.md
+++ b/skills/truesheet-usage/SKILL.md
@@ -240,6 +240,25 @@ Renders children in a native layer above every presented sheet. Show/hide by con
 </TrueSheet>
 ```
 
+### Confirm before dismiss (unsaved changes)
+
+```tsx
+<TrueSheet
+  ref={sheet}
+  dismissible={!isDirty}
+  onDismissAttempt={() =>
+    Alert.alert('Discard changes?', undefined, [
+      { text: 'Keep editing', style: 'cancel' },
+      { text: 'Discard', style: 'destructive', onPress: () => sheet.current?.dismiss() },
+    ])
+  }
+>
+  {/* form */}
+</TrueSheet>
+```
+
+Don't try to block dismissal from a callback — native can't wait on JS. Toggle `dismissible` from state; blocked drags and back/escape fire `onDismissAttempt` (dim taps don't), then `dismiss()` programmatically.
+
 ### iOS blur background
 
 ```tsx
@@ -340,6 +359,7 @@ The most commonly used events:
 | `onMount` | Content is mounted and ready | — |
 | `onDidPresent` | Sheet finished presenting | `{ index, position, detent }` |
 | `onDidDismiss` | Sheet finished dismissing | — |
+| `onDismissAttempt` | User tried to dismiss while `dismissible={false}` | — |
 | `onDetentChange` | User dragged or `resize()` changed the detent | `{ index, position, detent }` |
 | `onPositionChange` | Continuous position updates during drag/animation | `{ index, position, detent, realtime }` |
 

--- a/skills/truesheet-usage/references/advanced-patterns.md
+++ b/skills/truesheet-usage/references/advanced-patterns.md
@@ -156,7 +156,7 @@ navigation.addListener('sheetDidPresent', (e) => {
 })
 ```
 
-Also available as `screenListeners` on the navigator or `listeners` on a screen. Events: `sheetWillPresent`, `sheetDidPresent`, `sheetWillDismiss`, `sheetDidDismiss`, `sheetDetentChange`, `sheetDragBegin`, `sheetDragChange`, `sheetDragEnd`, `sheetPositionChange`.
+Also available as `screenListeners` on the navigator or `listeners` on a screen. Events: `sheetWillPresent`, `sheetDidPresent`, `sheetWillDismiss`, `sheetDidDismiss`, `sheetDismissAttempt`, `sheetDetentChange`, `sheetDragBegin`, `sheetDragChange`, `sheetDragEnd`, `sheetPositionChange`.
 
 ### Navigating from sheets
 

--- a/skills/truesheet-usage/references/api.md
+++ b/skills/truesheet-usage/references/api.md
@@ -72,6 +72,7 @@ These fire in pairs — "will" before the animation and "did" after.
 | `onDidPresent` | `DetentInfoEventPayload` | Finished presenting |
 | `onWillDismiss` | — | About to start dismissing |
 | `onDidDismiss` | — | Finished dismissing |
+| `onDismissAttempt` | — | User tried to dismiss while `dismissible={false}` (drag, back/escape, a11y — not dim tap). Sheet stays open — confirm, then call `dismiss()`. Consumes Android back press |
 
 ### Detent and drag events
 

--- a/skills/truesheet-usage/references/configuration.md
+++ b/skills/truesheet-usage/references/configuration.md
@@ -116,7 +116,7 @@ On iOS, grabber strings only apply when `grabberOptions` is provided (the system
 
 | Prop | Type | Default | Platforms | Description |
 |------|------|---------|-----------|-------------|
-| `dismissible` | `boolean` | `true` | 🍎🤖🌐 | Whether the user can swipe to dismiss or tap outside |
+| `dismissible` | `boolean` | `true` | 🍎🤖🌐 | Whether the user can swipe to dismiss or tap outside. Blocked attempts fire `onDismissAttempt` |
 | `draggable` | `boolean` | `true` | 🍎🤖🌐 | Whether the user can drag to resize. When `false`, the grabber is hidden |
 
 ## Dimming

--- a/src/TrueSheet.tsx
+++ b/src/TrueSheet.tsx
@@ -23,6 +23,7 @@ import type {
   PositionChangeEvent,
   DidDismissEvent,
   WillDismissEvent,
+  DismissAttemptEvent,
   MountEvent,
   WillFocusEvent,
   DidFocusEvent,
@@ -166,6 +167,7 @@ export class TrueSheet
     this.onMount = this.onMount.bind(this);
     this.onWillDismiss = this.onWillDismiss.bind(this);
     this.onDidDismiss = this.onDidDismiss.bind(this);
+    this.onDismissAttempt = this.onDismissAttempt.bind(this);
     this.onWillPresent = this.onWillPresent.bind(this);
     this.onDidPresent = this.onDidPresent.bind(this);
     this.onDetentChange = this.onDetentChange.bind(this);
@@ -367,6 +369,10 @@ export class TrueSheet
     this.props.onWillDismiss?.(event);
   }
 
+  private onDismissAttempt(event: DismissAttemptEvent): void {
+    this.props.onDismissAttempt?.(event);
+  }
+
   private onDidDismiss(event: DidDismissEvent): void {
     this.isPresented = false;
     this.isSheetVisible = true;
@@ -436,9 +442,12 @@ export class TrueSheet
     const nodeHandle = findNodeHandle(this.nativeRef.current);
     if (nodeHandle == null || nodeHandle === -1) return false;
 
-    // When not dismissible, let back propagate (e.g. navigation goes back to the previous screen)
+    // When not dismissible, report the attempt. An attempt handler consumes the back
+    // press; otherwise let it propagate (e.g. navigation goes back to the previous screen)
     if (this.props.dismissible === false) {
-      return this.props.onBackPress?.() ?? false;
+      const { onDismissAttempt, onBackPress } = this.props;
+      onDismissAttempt?.({ nativeEvent: null } as DismissAttemptEvent);
+      return onBackPress?.() ?? onDismissAttempt != null;
     }
 
     TrueSheetModule?.handleBackPress(nodeHandle);
@@ -675,6 +684,7 @@ export class TrueSheet
         onDidPresent={this.onDidPresent}
         onWillDismiss={this.onWillDismiss}
         onDidDismiss={this.onDidDismiss}
+        onDismissAttempt={this.onDismissAttempt}
         onDetentChange={this.onDetentChange}
         onDragBegin={this.onDragBegin}
         onDragChange={this.onDragChange}

--- a/src/TrueSheet.types.ts
+++ b/src/TrueSheet.types.ts
@@ -36,6 +36,7 @@ export type WillPresentEvent = NativeSyntheticEvent<DetentInfoEventPayload>;
 export type DidPresentEvent = NativeSyntheticEvent<DetentInfoEventPayload>;
 export type WillDismissEvent = NativeSyntheticEvent<null>;
 export type DidDismissEvent = NativeSyntheticEvent<null>;
+export type DismissAttemptEvent = NativeSyntheticEvent<null>;
 export type DragBeginEvent = NativeSyntheticEvent<DetentInfoEventPayload>;
 export type DragChangeEvent = NativeSyntheticEvent<DetentInfoEventPayload>;
 export type DragEndEvent = NativeSyntheticEvent<DetentInfoEventPayload>;
@@ -456,6 +457,7 @@ export interface TrueSheetProps extends ViewProps {
 
   /**
    * Prevents interactive dismissal of the Sheet.
+   * Blocked attempts fire `onDismissAttempt`, so you can confirm before dismissing programmatically.
    *
    * @default true
    */
@@ -687,6 +689,13 @@ export interface TrueSheetProps extends ViewProps {
    * Called when the Sheet has been dismissed
    */
   onDidDismiss?: (event: DidDismissEvent) => void;
+
+  /**
+   * Called when the user tries to dismiss the sheet while `dismissible` is `false`,
+   * e.g. by dragging down or pressing back/escape. Tapping the dim does not count.
+   * The sheet stays presented. Confirm with the user, then call `dismiss()` to proceed.
+   */
+  onDismissAttempt?: (event: DismissAttemptEvent) => void;
 
   /**
    * Called when the detent of the sheet has changed.

--- a/src/TrueSheet.web.tsx
+++ b/src/TrueSheet.web.tsx
@@ -31,6 +31,7 @@ import type {
   TrueSheetStaticMethods,
   WillBlurEvent,
   WillDismissEvent,
+  DismissAttemptEvent,
   WillFocusEvent,
   WillPresentEvent,
 } from './TrueSheet.types';
@@ -105,6 +106,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
     onDidPresent,
     onWillDismiss,
     onDidDismiss,
+    onDismissAttempt,
     onDetentChange,
     onDragBegin,
     onDragChange,
@@ -1025,12 +1027,17 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
   const onDidBlurRef = useRef(onDidBlur);
   const onWillFocusRef = useRef(onWillFocus);
   const onDidFocusRef = useRef(onDidFocus);
+  const onDismissAttemptRef = useRef(onDismissAttempt);
   useEffect(() => {
     onWillBlurRef.current = onWillBlur;
     onDidBlurRef.current = onDidBlur;
     onWillFocusRef.current = onWillFocus;
     onDidFocusRef.current = onDidFocus;
+    onDismissAttemptRef.current = onDismissAttempt;
   });
+  const handleDismissAttempt = useCallback(() => {
+    onDismissAttemptRef.current?.({ nativeEvent: null } as DismissAttemptEvent);
+  }, []);
 
   const prevDescendantCountRef = useRef(0);
   useEffect(() => {
@@ -1256,6 +1263,7 @@ const TrueSheetComponent = forwardRef<TrueSheetMethods, TrueSheetProps>((props, 
         onDrag={handleDrag}
         onRelease={handleRelease}
         dismissible={dismissible}
+        onDismissAttempt={handleDismissAttempt}
         draggable={draggable}
         repositionInputs={false}
         modal={dimmed}

--- a/src/__tests__/TrueSheet.test.tsx
+++ b/src/__tests__/TrueSheet.test.tsx
@@ -6,6 +6,7 @@ import { TrueSheet, TrueSheetOverlay, TrueSheetPeek } from '../index';
 import TrueSheetModule from '../specs/NativeTrueSheetModule';
 import type {
   DidDismissEvent,
+  DismissAttemptEvent,
   WillFocusEvent,
   DidFocusEvent,
   WillBlurEvent,
@@ -289,6 +290,66 @@ describe('TrueSheet', () => {
 
       // Content should now be rendered after state update
       expect(queryByText('Lifecycle Content')).not.toBeNull();
+    });
+  });
+
+  describe('Dismiss Attempt', () => {
+    it('should call onDismissAttempt when triggered', async () => {
+      const onDismissAttemptMock = jest.fn();
+      render(
+        <TrueSheet
+          name="dismiss-attempt-test"
+          initialDetentIndex={0}
+          dismissible={false}
+          onDismissAttempt={onDismissAttemptMock}
+        >
+          <Text>Content</Text>
+        </TrueSheet>
+      );
+
+      const sheetRef = TrueSheet['instances']['dismiss-attempt-test']!;
+
+      await act(async () => {
+        sheetRef['onDismissAttempt']({} as DismissAttemptEvent);
+      });
+
+      expect(onDismissAttemptMock).toHaveBeenCalled();
+    });
+
+    it('should report a back press on a non-dismissible sheet and consume it', async () => {
+      const onDismissAttemptMock = jest.fn();
+      render(
+        <TrueSheet
+          name="dismiss-attempt-back-test"
+          initialDetentIndex={0}
+          dismissible={false}
+          onDismissAttempt={onDismissAttemptMock}
+        >
+          <Text>Content</Text>
+        </TrueSheet>
+      );
+
+      const sheetRef = TrueSheet['instances']['dismiss-attempt-back-test']!;
+      sheetRef['isPresented'] = true;
+      sheetRef['isSheetVisible'] = true;
+
+      expect(sheetRef['handleBackPress']()).toBe(true);
+      expect(onDismissAttemptMock).toHaveBeenCalledTimes(1);
+      expect(TrueSheetModule?.handleBackPress).not.toHaveBeenCalled();
+    });
+
+    it('should let a back press propagate when non-dismissible without a handler', async () => {
+      render(
+        <TrueSheet name="dismiss-attempt-propagate-test" initialDetentIndex={0} dismissible={false}>
+          <Text>Content</Text>
+        </TrueSheet>
+      );
+
+      const sheetRef = TrueSheet['instances']['dismiss-attempt-propagate-test']!;
+      sheetRef['isPresented'] = true;
+      sheetRef['isSheetVisible'] = true;
+
+      expect(sheetRef['handleBackPress']()).toBe(false);
     });
   });
 

--- a/src/fabric/TrueSheetViewNativeComponent.ts
+++ b/src/fabric/TrueSheetViewNativeComponent.ts
@@ -137,6 +137,7 @@ export interface NativeProps extends ViewProps {
   onDidPresent?: DirectEventHandler<DetentInfoEventPayload>;
   onWillDismiss?: DirectEventHandler<null>;
   onDidDismiss?: DirectEventHandler<null>;
+  onDismissAttempt?: DirectEventHandler<null>;
   onDetentChange?: DirectEventHandler<DetentInfoEventPayload>;
   onDragBegin?: DirectEventHandler<DetentInfoEventPayload>;
   onDragChange?: DirectEventHandler<DetentInfoEventPayload>;

--- a/src/navigation/screen/useSheetScreenState.ts
+++ b/src/navigation/screen/useSheetScreenState.ts
@@ -14,6 +14,7 @@ import type {
   PositionChangeEventPayload,
   WillBlurEvent,
   WillDismissEvent,
+  DismissAttemptEvent,
   WillFocusEvent,
   WillPresentEvent,
 } from '../../TrueSheet.types';
@@ -78,6 +79,7 @@ export const useSheetScreenState = (props: UseSheetScreenStateProps) => {
       onDidPresent: (e: DidPresentEvent) => emitEvent('sheetDidPresent', e.nativeEvent),
       onWillDismiss: (_e: WillDismissEvent) => emitEvent('sheetWillDismiss', undefined),
       onDidDismiss,
+      onDismissAttempt: (_e: DismissAttemptEvent) => emitEvent('sheetDismissAttempt', undefined),
       onDetentChange: (e: DetentChangeEvent) => emitEvent('sheetDetentChange', e.nativeEvent),
       onDragBegin: (e: DragBeginEvent) => emitEvent('sheetDragBegin', e.nativeEvent),
       onDragChange: (e: DragChangeEvent) => emitEvent('sheetDragChange', e.nativeEvent),

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -40,6 +40,10 @@ export type TrueSheetNavigationEventMap = {
    */
   sheetDidDismiss: { data: undefined };
   /**
+   * Event fired when the user tries to dismiss a non-dismissible sheet.
+   */
+  sheetDismissAttempt: { data: undefined };
+  /**
    * Event fired when the sheet's detent changes.
    */
   sheetDetentChange: { data: DetentInfoEventPayload };

--- a/src/web/vaul/constants.ts
+++ b/src/web/vaul/constants.ts
@@ -9,6 +9,10 @@ export const DEFAULT_PEEK_HEIGHT = 150;
 
 export const CLOSE_THRESHOLD = 0.25;
 
+// Minimum downward pull (px) on a non-dismissible drawer at its first snap
+// point before the release counts as a dismiss attempt.
+export const DISMISS_ATTEMPT_THRESHOLD = 24;
+
 export const SCROLL_LOCK_TIMEOUT = 100;
 
 export const BORDER_RADIUS = 8;

--- a/src/web/vaul/context.ts
+++ b/src/web/vaul/context.ts
@@ -23,6 +23,7 @@ interface DrawerContextValue {
   onNestedOpenChange: (o: boolean) => void;
   onNestedRelease: (event: React.PointerEvent<HTMLDivElement>, open: boolean) => void;
   dismissible: boolean;
+  onDismissAttempt?: () => void;
   isOpen: boolean;
   isDragging: boolean;
   keyboardIsOpen: React.MutableRefObject<boolean>;

--- a/src/web/vaul/index.tsx
+++ b/src/web/vaul/index.tsx
@@ -12,6 +12,7 @@ import { isIOS, isMobileFirefox } from './browser';
 import {
   BORDER_RADIUS,
   CLOSE_THRESHOLD,
+  DISMISS_ATTEMPT_THRESHOLD,
   DRAG_CLASS,
   NESTED_DISPLACEMENT,
   SCROLL_LOCK_TIMEOUT,
@@ -93,6 +94,12 @@ export type DialogProps = {
    * @default true
    */
   dismissible?: boolean;
+  /**
+   * Called when the user tries to close a non-dismissible drawer — dragging down
+   * at the first snap point, pressing escape, or tapping the handle of a
+   * single-snap-point drawer. Overlay clicks don't count, mirroring iOS.
+   */
+  onDismissAttempt?: () => void;
   /**
    * When `false` the drawer can't be dragged by the user. Programmatic snap-point
    * changes still animate. Defaults to `true`.
@@ -218,6 +225,7 @@ export function Root({
   closeThreshold = CLOSE_THRESHOLD,
   scrollLockTimeout = SCROLL_LOCK_TIMEOUT,
   dismissible = true,
+  onDismissAttempt,
   draggable = true,
   handleOnly = false,
   fadeFromIndex = snapPoints && snapPoints.length - 1,
@@ -274,6 +282,7 @@ export function Root({
   const isAllowedToDrag = React.useRef<boolean>(false);
   const nestedOpenChangeTimer = React.useRef<NodeJS.Timeout | null>(null);
   const pointerStart = React.useRef(0);
+  const dismissAttempted = React.useRef(false);
   const keyboardIsOpen = React.useRef(false);
   const shouldAnimate = React.useRef(!defaultOpen);
   const previousDiffFromInitial = React.useRef(0);
@@ -517,7 +526,17 @@ export function Root({
       const noCloseSnapPointsPreCondition = snapPoints && !dismissible && !isDraggingInDirection;
 
       // Disallow dragging down to close when first snap point is the active one and dismissible prop is set to false.
-      if (noCloseSnapPointsPreCondition && activeSnapPointIndex === 0) return;
+      if (noCloseSnapPointsPreCondition && activeSnapPointIndex === 0) {
+        // The drawer stays put. Remember a deliberate pull that would otherwise
+        // have dragged it (content at its top) so release() can report it.
+        if (
+          -draggedDistance > DISMISS_ATTEMPT_THRESHOLD &&
+          (isAllowedToDrag.current || shouldDrag(event.target, isDraggingInDirection))
+        ) {
+          dismissAttempted.current = true;
+        }
+        return;
+      }
 
       // We need to capture last time when drag with scroll was triggered and have a timeout between
       const absDraggedDistance = Math.abs(draggedDistance);
@@ -779,6 +798,11 @@ export function Root({
     setIsDragging(false);
     dragEndTime.current = new Date();
 
+    if (dismissAttempted.current) {
+      dismissAttempted.current = false;
+      if (isOpen) onDismissAttempt?.();
+    }
+
     // The press that started this "drag" may have dismissed the drawer (e.g. a
     // back button acting on pointerdown). Snapping now would overwrite the
     // dismiss transform that closeDrawer just wrote and freeze the sheet in
@@ -976,6 +1000,7 @@ export function Root({
           onTouchDrag: (event, pointerEvent) => drag(event, pointerEvent),
           onTouchRelease: (event, pointerEvent) => release(event, pointerEvent),
           dismissible,
+          onDismissAttempt,
           shouldAnimate,
           handleOnly,
           isOpen,
@@ -1131,6 +1156,7 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(
       snapPoints,
       setActiveSnapPoint,
       dismissible,
+      onDismissAttempt,
       container,
       handleOnly,
       shouldAnimate,
@@ -1463,6 +1489,8 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(
               activeSnapPointIndex > 0
             ) {
               setActiveSnapPoint(snapPoints![0]!);
+            } else {
+              onDismissAttempt?.();
             }
           }
         }}
@@ -1604,6 +1632,7 @@ export const Handle = React.forwardRef<HTMLDivElement, HandleProps>(
       activeSnapPoint,
       setActiveSnapPoint,
       dismissible,
+      onDismissAttempt,
       handleOnly,
       isOpen,
       onPress,
@@ -1644,6 +1673,12 @@ export const Handle = React.forwardRef<HTMLDivElement, HandleProps>(
 
       if (isLastSnapPoint && dismissible) {
         closeDrawer();
+        return;
+      }
+
+      // Mirrors native: a single-detent sheet's handle tap is a dismiss.
+      if (isLastSnapPoint && snapPoints.length === 1) {
+        onDismissAttempt?.();
         return;
       }
 


### PR DESCRIPTION
## Summary

Adds an `onDismissAttempt` event that fires when the user tries to dismiss a sheet while `dismissible` is `false`. The sheet stays presented; the app confirms and calls `dismiss()` to proceed. This is Apple's `isModalInPresentation` + `presentationControllerDidAttemptToDismiss` unsaved-changes pattern, exposed to JS.

Triggers: drag-to-dismiss at the lowest detent, hardware back (Android), escape (Web), grabber tap / accessibility decrement on a single-detent sheet, VoiceOver escape (iOS). Dim taps do not count, matching UIKit.

- **iOS**: implements `presentationControllerDidAttemptToDismiss:` plus the custom grabber / VoiceOver paths.
- **Android**: `BottomSheetBehavior` gives no callback when `isHideable = false` clamps a drag, so the coordinator tracks a stationary vertical pull and reports it on release. Back press with a handler is consumed; `onBackPress` can still override.
- **Web**: new `onDismissAttempt` prop on the vaul `Drawer.Root` for drag, escape, and handle tap.
- Sheet navigator emits `sheetDismissAttempt`.
- Docs, skill, and the `PromptSheet` example updated (locks while dirty, confirms discard).

Closes #292

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test Plan

- Unit tests for the handler and Android back-press semantics (`yarn test`)
- `PromptSheet` example: type in any input, then drag down / back / escape → confirm dialog; Discard dismisses
- Verified dim tap does not emit on any platform

## Screenshots / Videos

N/A

## Checklist

- [x] I tested on iOS
- [x] I tested on Android
- [x] I tested on Web
- [x] I updated the documentation (if needed)
- [x] I added a changelog entry (if needed)